### PR TITLE
Add Debian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ comprehensive support for macOS and Windows**.
   * **macOS** Monterey, Big Sur, Catalina, Mojave & High Sierra
   * **Windows** 8.1, 10 and 11 including TPM 2.0
   * [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu flavours](https://ubuntu.com/download/flavours)**
+  * [Debian](https://www.debian.org/) (bullseye with all the official and non-free DE variants)
   * [Fedora](https://getfedora.org/) & openSUSE ([Leap](https://get.opensuse.org/leap/), [Tumbleweed](https://get.opensuse.org/tumbleweed/), [MicroOS](https://microos.opensuse.org/))
   * [Linux Mint](https://linuxmint.com/) (Cinnamon, MATE, and XFCE), [elementary OS](https://elementary.io/), [Pop!_OS](https://pop.system76.com/)
   * [Arch Linux](https://www.archlinux.org/), [Kali](https://www.kali.org/),[Garuda](https://garudalinux.org/), [ZorinOS](https://zorin.com/os/) & [NixOS](https://nixos.org/)

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ preferred flavour.
 `quickget` also supports:
 
   * `archlinux`
+  * `debian`
   * `elementary`
   * `fedora`
   * `garuda`

--- a/quickget
+++ b/quickget
@@ -151,6 +151,7 @@ function list_csv() {
 function os_support() {
     echo android \
     archlinux \
+    debian \
     elementary \
     freebsd \
     fedora \
@@ -195,6 +196,18 @@ function releases_android() {
 
 function releases_archlinux() {
     echo latest
+}
+
+# later refactor these DE variants like languages and avoid the arch ?
+function releases_debian() {
+    echo 11.1.0-amd64-cinnamon \
+    11.1.0-amd64-gnome \
+    11.1.0-amd64-kde \
+    11.1.0-amd64-lxde \
+    11.1.0-amd64-lxqt \
+    11.1.0-amd64-mate \
+    11.1.0-amd64-standard \
+    11.1.0-amd64-xfce
 }
 
 function releases_elementary() {
@@ -665,6 +678,9 @@ function make_vm_config() {
     elif [ "${OS}" == "archlinux" ]; then
         GUEST="linux"
         IMAGE_TYPE="iso"
+    elif [ "${OS}" == "debian" ]; then
+        GUEST="linux"
+        IMAGE_TYPE="iso"
     elif [ "${OS}" == "elementary" ]; then
         GUEST="linux"
         IMAGE_TYPE="iso"
@@ -805,6 +821,24 @@ function get_archlinux() {
     URL="https://mirror.rackspace.com/archlinux/iso/${VERSION}"
     ISO="archlinux-${VERSION}-x86_64.iso"
     HASH=$(wget -q -O- 'https://archlinux.org/releng/releases/json/' | jq '.releases[0].sha1_sum' | cut -d "\"" -f 2)
+    web_get "${URL}/${ISO}" "${VM_PATH}"
+    check_hash "${ISO}" "${HASH}"
+    make_vm_config "${ISO}"
+}
+
+
+function get_debian() {
+    local HASH=""
+    local ISO=""
+    local URL=""
+    local HASHLINE=""
+
+    validate_release "releases_debian"
+    URL="https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid"
+    HASHLINE=$(wget -q -O- ${URL}/SHA512SUMS |grep ${RELEASE}.iso)
+    ISO="$(echo ${HASHLINE} | awk '{print $NF}' )"
+    HASH=$(echo ${HASHLINE} | cut -d\  -f1)
+
     web_get "${URL}/${ISO}" "${VM_PATH}"
     check_hash "${ISO}" "${HASH}"
     make_vm_config "${ISO}"
@@ -1339,6 +1373,8 @@ if [ -n "${2}" ]; then
         get_android
     elif [ "${OS}" == "archlinux" ]; then
         get_archlinux
+    elif [ "${OS}" == "debian" ]; then
+        get_debian
     elif [ "${OS}" == "elementary" ]; then
         get_elementary
     elif [ "${OS}" == "macos" ]; then
@@ -1426,6 +1462,8 @@ else
         releases_android
     elif [ "${OS}" == "archlinux" ]; then
         releases_archlinux
+    elif [ "${OS}" == "debian" ]; then
+        releases_debian
     elif [ "${OS}" == "elementary" ]; then
         releases_elementary
     elif [ "${OS}" == "freebsd" ]; then

--- a/quickget
+++ b/quickget
@@ -140,6 +140,10 @@ function list_csv() {
         for OPTION in intel nvidia; do
           echo "${DISPLAY_NAME},${OS},${RELEASE},${OPTION},${DOWNLOADER},${PNG},${SVG}"
         done
+        elif [ "${OS}" == "debian" ]; then
+        for OPTION in standard nonfree; do
+          echo "${DISPLAY_NAME},${OS},${RELEASE},${OPTION},${DOWNLOADER},${PNG},${SVG}"
+        done
       else
         echo "${DISPLAY_NAME},${OS},${RELEASE},,${DOWNLOADER},${PNG},${SVG}"
       fi
@@ -199,6 +203,7 @@ function releases_archlinux() {
 }
 
 # later refactor these DE variants like languages and avoid the arch ?
+# all these are available with a "nonfree" option too
 function releases_debian() {
     echo 11.1.0-amd64-cinnamon \
     11.1.0-amd64-gnome \
@@ -832,9 +837,20 @@ function get_debian() {
     local ISO=""
     local URL=""
     local HASHLINE=""
+    local FREEDOM=""
+
 
     validate_release "releases_debian"
-    URL="https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid"
+
+    if [ "${1}" == "nonfree" ]; then
+      RELEASE="${RELEASE}+nonfree"
+    fi
+    case $RELEASE in
+      *+nonfree)  URL="http://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/current-live/amd64/iso-hybrid" ;;
+      *)          URL="https://cdimage.debian.org/debian-cd/current-live/amd64/iso-hybrid";;
+    esac
+
+
     HASHLINE=$(wget -q -O- ${URL}/SHA512SUMS |grep ${RELEASE}.iso)
     ISO="$(echo ${HASHLINE} | awk '{print $NF}' )"
     HASH=$(echo ${HASHLINE} | cut -d\  -f1)
@@ -1374,7 +1390,21 @@ if [ -n "${2}" ]; then
     elif [ "${OS}" == "archlinux" ]; then
         get_archlinux
     elif [ "${OS}" == "debian" ]; then
-        get_debian
+     if [ -n "${3}" ]; then
+            FREEDOM="${3}"
+            FREEDOMS=(standard nonfree)
+            if [[ ! ${FREEDOMS[*]} =~ ${FREEDOM} ]]; then
+                echo "ERROR! ${FREEDOM} is not a supported freedom:"
+                for DRIVER in "${FREEDOMS[@]}"; do
+                  echo "${FREEDOM}"
+                done
+                exit 1
+            fi
+        else
+            FREEDOM="standard"
+        fi
+        VM_PATH="${OS}-${RELEASE}-${FREEDOM}"
+        get_debian  "${FREEDOM}"
     elif [ "${OS}" == "elementary" ]; then
         get_elementary
     elif [ "${OS}" == "macos" ]; then


### PR DESCRIPTION
It is needed I feel.
This just finds the standard current releases (all DE options)

- [x] Will look to add the unofficial no-totally-free options as well.
  sorted similar to intel|nvidia for Pop! : standard or nonfree taken as options (or none)

nonfree not noted in the Readme as it doesn't mention intel/nvidia options either as far as I can see.
I think both need noting somewhere.

Could do with some refactoring around the DE options (like the windows languages but different, and applied here and to e.g. Garuda) but it is Friday night ....