### PR TITLE
Turn off Hibernation in Windows autounattend.xml

### DIFF
--- a/quickget
+++ b/quickget
@@ -551,6 +551,11 @@ function unattended_windows() {
           <Description>Install spice-vdagent SPICE agent</Description>
           <Order>4</Order>
         </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <CommandLine>Cmd /c POWERCFG -H OFF</CommandLine>
+          <Description>Disable Hibernation</Description>
+          <Order>5</Order>
+        </SynchronousCommand>
       </FirstLogonCommands>
     </component>
   </settings>


### PR DESCRIPTION
Turn off Hibernation in Windows to correct issue #162
I've had some success correcting the "every other boot lockup problem" with Windows guests.
I was able to fix the problem on my machine by launching a cmd prompt with Admin privileges in the Windows guest and typing:
powercfg -h off 
(this turns off hibernation and thus also turns off fastboot)
This PR is an attempt to automate this fix using the autounattend.xml file.
Someone more familiar with Windows automation should test this thoroughly.
(There may be a better way to do it.)