### PR TITLE
Increase virtual disk size to 64GB by default for Linux/FreeBSD/OpenBSD guests

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -460,7 +460,7 @@ function vm_boot() {
         MOUSE="usb-mouse"
       fi
       if [ -z "${disk_size}" ]; then
-        disk_size="16G"
+        disk_size="64G"
       fi
       ;;
     macos)


### PR DESCRIPTION
16GB is too small f.ex Rocky Linux