### PR TITLE
Fix Recent openSUSE Leap ISO Location

### DIFF
--- a/quickget
+++ b/quickget
@@ -1014,8 +1014,12 @@ function get_opensuse() {
         ISO="openSUSE-MicroOS-DVD-x86_64-Current.iso"
         URL="https://download.opensuse.org/tumbleweed/iso/${ISO}"
         HASH=$(wget -q -O- "${URL}.sha256" | cut -d' ' -f1)
-    else
+    elif [ "$RELEASE" == 15.0 ] || [ "$RELEASE" == 15.1 ]; then
         ISO="openSUSE-Leap-${RELEASE}-DVD-x86_64.iso"
+        URL="https://download.opensuse.org/distribution/leap/${RELEASE}/iso/${ISO}"
+        HASH=$(wget -q -O- "${URL}.sha256" | cut -d' ' -f1)
+    else
+        ISO="openSUSE-Leap-${RELEASE}-DVD-x86_64-Current.iso"
         URL="https://download.opensuse.org/distribution/leap/${RELEASE}/iso/${ISO}"
         HASH=$(wget -q -O- "${URL}.sha256" | cut -d' ' -f1)
     fi


### PR DESCRIPTION
15.3 cannot be downloaded at all using the current code due to `openSUSE-Leap-15.3-DVD-x86_64.iso` not existing. It would appear that starting with 15.2, `openSUSE-Leap-${RELEASE}-DVD-x86_64-Current.iso` has been released with the most current revision for that version.