### PR TITLE
Add extra_args option in vm conf file

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -949,6 +949,10 @@ function vm_boot() {
             -device tpm-tis,tpmdev=tpm0)
   fi
 
+  if [ -n "$extra_args" ]; then
+      args+=($extra_args)
+  fi
+
   # The OSK parameter contains parenthesis, they need to be escaped in the shell
   # scripts. The vendor name, Quickemu Project, contains a space. It needs to be
   # double-quoted.

--- a/quickemu
+++ b/quickemu
@@ -1046,6 +1046,7 @@ ram=""
 secureboot="off"
 tpm="off"
 usb_devices=()
+extra_args=""
 
 DELETE_DISK=0
 DELETE_VM=0


### PR DESCRIPTION
I added this simple piece of code for any extra arguments one wants to use.
You just add extra_args variable to your vm conf file.

ex. add host disk partition
extra_args="-drive file=/dev/sdb2,cache=none,if=virtio"

This is the easiest way to "extend" quickemu functionality.