### PR TITLE
Added openSUSE path for OVMF

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -395,6 +395,9 @@ function vm_boot() {
         elif [ -e "/usr/share/edk2-ovmf/OVMF_CODE.fd" ]; then
 	        EFI_CODE="/usr/share/edk2-ovmf/OVMF_CODE.secboot.fd"
 	        efi_vars "/usr/share/edk2-ovmf/OVMF_VARS.fd" "${EFI_VARS}"
+        elif [ -e "/usr/share/qemu/ovmf-x86_64-smm-ms-code.bin" ]; then
+          EFI_CODE="/usr/share/qemu/ovmf-x86_64-smm-ms-code.bin"
+          efi_vars "/usr/share/qemu/ovmf-x86_64-smm-ms-vars.bin" "${EFI_VARS}"
         else
           echo "ERROR! SecureBoot was requested but no SecureBoot capable firmware was found."
           echo "       Please install OVMF firmware."
@@ -417,6 +420,9 @@ function vm_boot() {
         elif [ -e "/usr/share/edk2-ovmf/OVMF_CODE.fd" ]; then
 	        EFI_CODE="/usr/share/edk2-ovmf/OVMF_CODE.fd"
 	        efi_vars "/usr/share/edk2-ovmf/OVMF_VARS.fd" "${EFI_VARS}"
+        elif [ -e "/usr/share/qemu/ovmf-x86_64-4m-code.bin" ]; then
+          EFI_CODE="/usr/share/qemu/ovmf-x86_64-4m-code.bin"
+          efi_vars "/usr/share/qemu/ovmf-x86_64-4m-vars.bin" "${EFI_VARS}"
         else
           echo "ERROR! EFI boot requested but no EFI firmware found."
           echo "       Please install OVMF firmware."


### PR DESCRIPTION
Congratulations, quickget and quickemu are very cool.

Before adding the path I get:

`./quickemu --vm ~/VMs/quickemu/archlinux-latest.conf 
Quickemu 3.11 using /usr/bin/qemu-system-x86_64 v6.1.0
 - Host:     "openSUSE Tumbleweed" running Linux 5.15 (skynet)
 - CPU:      Intel(R) Core(TM) i7-4510U CPU @ 2.00GHz
 - CPU VM:   1 Socket(s), 1 Core(s), 2 Thread(s), 4G RAM
ERROR! EFI boot requested but no EFI firmware found.
       Please install OVMF firmware.`
  
After the addition, I was able to start all VMs I've tried.