### PR TITLE
Fix #306 - supply dir to web_get when using wget

### DIFF
--- a/quickget
+++ b/quickget
@@ -490,7 +490,7 @@ function zsync_get() {
       fi
     else
       echo "INFO: zsync not found, falling back to wget"
-      web_get "${ISO}"
+      web_get "${ISO}" "${DIR}"
     fi
 }
 


### PR DESCRIPTION
Fix for #306 - works for me on Fedora with wget but no zsync.