### PR TITLE
Add support for braille terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ Usage
   quickemu --vm ubuntu.conf
 
 You can also pass optional parameters
+  --accessible            : Select accessible facilitation. 'braille' (default - currently requires --display sdl )"
   --delete-disk           : Delete the disk image and EFI variables
   --delete-vm             : Delete the entire VM and it's configuration
   --display               : Select display backend. 'sdl' (default), 'gtk', 'none', or 'spice'

--- a/README.md
+++ b/README.md
@@ -370,6 +370,19 @@ SPICE ports the VM is connected to.
 ```bash
 cat ubuntu-focal/ubuntu-focal.ports
 ```
+# Accessibility
+
+Qemu provides support for using BrlAPI to display braille output on a real or fake device.
+
+
+```bash
+quickemu --vm ubuntu-impish.conf --accessibility braille
+```
+or even
+
+```bash
+quickemu --vm ubuntu-impish.conf --acc brl
+```
 
 # BIOS and EFI
 

--- a/README.md
+++ b/README.md
@@ -376,12 +376,12 @@ Qemu provides support for using BrlAPI to display braille output on a real or fa
 
 
 ```bash
-quickemu --vm ubuntu-impish.conf --accessibility braille
+quickemu --vm ubuntu-impish.conf --accessibility braille --display sdl
 ```
 or even
 
 ```bash
-quickemu --vm ubuntu-impish.conf --acc brl
+quickemu --vm ubuntu-impish.conf --acc brl --display sdl
 ```
 
 # BIOS and EFI

--- a/quickemu
+++ b/quickemu
@@ -1004,7 +1004,7 @@ function usage() {
   echo "  ${LAUNCHER} --vm ubuntu.conf"
   echo
   echo "You can also pass optional parameters"
-  echo "  --accessible            : Select accessible facilitation. 'braille' (default)"
+  echo "  --accessible            : Select accessible facilitation. 'braille' (default - currently requires --display sdl )"
   echo "  --delete-disk           : Delete the disk image and EFI variables"
   echo "  --delete-vm             : Delete the entire VM and it's configuration"
   echo "  --display               : Select display backend. 'sdl' (default), 'gtk', 'none', or 'spice'"

--- a/quickemu
+++ b/quickemu
@@ -868,6 +868,14 @@ function vm_boot() {
          -monitor none
          -serial mon:stdio)
 
+  if [[ "${ACCESSIBLE}" == "braille" ]] || [[ "${ACCESSIBLE}" == "brl" ]]; then
+    # shellcheck disable=SC2054
+      args+=(
+            '-chardev' 'braille,id=brltty'
+            '-device' 'usb-braille,id=usbbrl,chardev=brltty'
+      )
+  fi
+
   if [ -n "${bridge}" ]; then
     # Enable bridge mode networking
     # shellcheck disable=SC2054,SC2206
@@ -998,6 +1006,7 @@ function usage() {
   echo "  ${LAUNCHER} --vm ubuntu.conf"
   echo
   echo "You can also pass optional parameters"
+  echo "  --accessible            : Select accessible facilitation. 'braille' (default)"
   echo "  --delete-disk           : Delete the disk image and EFI variables"
   echo "  --delete-vm             : Delete the entire VM and it's configuration"
   echo "  --display               : Select display backend. 'sdl' (default), 'gtk', 'none', or 'spice'"
@@ -1014,6 +1023,14 @@ function usage() {
   exit 1
 }
 
+#
+function accessible_param_check() {
+  if [ "${ACCESSIBLE}" != "braille" ] && [ "${ACCESSIBLE}" != "brl" ] ; then
+    echo "ERROR! Requested accessiblility '${ACCESSIBLE}' is not recognised."
+    exit 1
+    # TODO can we check the device/API is available
+  fi
+}
 function display_param_check() {
   if [ "${OUTPUT}" != "gtk" ] && [ "${OUTPUT}" != "none" ] && [ "${OUTPUT}" != "sdl" ] && [ "${OUTPUT}" != "spice" ]; then
     echo "ERROR! Requested output '${OUTPUT}' is not recognised."
@@ -1104,6 +1121,11 @@ if [ $# -lt 1 ]; then
 else
     while [ $# -gt 0 ]; do
         case "${1}" in
+          -acc|--acc|-accessible|--accessible|-accessibility|--accessibility)
+            ACCESSIBLE="${2}"
+            accessible_param_check
+            shift
+            shift;;
           -delete|--delete|-delete-disk|--delete-disk)
             DELETE_DISK=1
             shift;;

--- a/quickemu
+++ b/quickemu
@@ -870,10 +870,8 @@ function vm_boot() {
 
   if [[ "${ACCESSIBLE}" == "braille" ]] || [[ "${ACCESSIBLE}" == "brl" ]]; then
     # shellcheck disable=SC2054
-      args+=(
-            '-chardev' 'braille,id=brltty'
-            '-device' 'usb-braille,id=usbbrl,chardev=brltty'
-      )
+      args+=(-chardev braille,id=brltty
+             -device usb-braille,id=usbbrl,chardev=brltty)
   fi
 
   if [ -n "${bridge}" ]; then


### PR DESCRIPTION
fixes #307

Added parameter `--acc | --accessible | --accessibility` which if given `braille` ( or `brl ` )
with add parameters to invoke `Qemu` braille terminal support.