### PR TITLE
Add parameters to use pre-downloaded local isos

### DIFF
--- a/quickget
+++ b/quickget
@@ -436,9 +436,30 @@ function check_hash() {
     fi
 }
 
+function copy_local(){
+  if [ -n "${ISODIR}" ]; then
+    # use supplied filename or default to original distro ISO name
+      if [ -z ${LOCALISO} ]; then
+        LOCALISO=${FILE}
+      fi
+      LOCALFILE=$(find ${ISODIR} -type f -name "${LOCALISO}" -print -quit )
+      #echo got local file "${LOCALFILE}"
+      if [ -f "${DIR}/${FILE}" ]; then
+        echo "ERROR! File Exists - not copying over local file"
+        echo "Move it out of the way to replace it with a local file"
+        exit 1
+      else
+        cp -pv "${LOCALFILE}" ${DIR}/${FILE}
+      # if ! ; then echo ERROR! Failed to copy ${LOCALFILE}" to ${DIR}/${FILE}"
+      fi
+      #exit 0 # while testing
+    fi
+}
+
 function web_get() {
     local DIR="${2}"
     local FILE=""
+    local LOCALFILE=""
     local URL="${1}"
 
     if [ -n "${3}" ]; then
@@ -451,16 +472,19 @@ function web_get() {
       echo "ERROR! Unable to create directory ${DIR}"
       exit 1
     fi
+    copy_local
 
     if ! wget --quiet --continue --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
         echo "ERROR! Failed to download ${URL}. Try running 'quickget' again."
         exit 1
     fi
+
 }
 
 function zsync_get() {
     local DIR="${2}"
     local FILE=""
+    local LOCALFILE=""
     local OUT=""
     local URL="${1}"
     FILE="${URL##*/}"
@@ -479,6 +503,8 @@ function zsync_get() {
         echo "ERROR! Unable to create directory ${DIR}"
         exit 1
       fi
+
+    copy_local
 
       if ! zsync "${URL}.zsync" -i "${DIR}/${OUT}" -o "${DIR}/${OUT}" 2>/dev/null; then
           echo "ERROR! Failed to download ${URL}.zsync"
@@ -1585,18 +1611,49 @@ fi
 LANGS=()
 languages_windows
 
+# handle parameters
+
+# Take command line arguments
+#if [ $# -lt 1 ]; then
+#    usage
+#    exit 0
+#else
+    while [ $# -gt 0 ]; do
+        case "${1}" in
+          -delete|--delete|-delete-disk|--delete-disk)
+          # This appears unused: function is present in quickemu
+          # if this was supposed to also work it needs finishing
+            DELETE_DISK=1
+            shift;;
+          -isodir|--isodir)
+            ISODIR="${2}"
+            shift
+            shift;;
+          -localiso|--localiso)
+            LOCALISO="${2}"
+            shift
+            shift;;
+         -h|--h|-help|--help)
+            usage
+            exit 0;;
+         -l|--l|-list|--list|list|list_csv)
+            list_csv;;
+          -j|--j|-json|--json|list_json)
+            list_json;;
+          -v|--v|-version|--version|version )
+             whereIam=$(dirname "${BASH_SOURCE[0]}")
+              quickemu_version=$( "${whereIam}"/quickemu --version)
+              echo "Quickemu Version: ${quickemu_version}"
+              exit 0;;
+          test*)
+             echo "you are just testing
+             ISODIR:  ${ISODIR}
+             LOCALISO: ${LOCALISO}"
+             exit 0;;
+          *)
+
 if [ -n "${1}" ]; then
     OS="${1,,}"
-    if [ "${OS}" == "list" ] || [ "${OS}" == "list_csv" ]; then
-        list_csv
-    elif [ "${OS}" == "list_json" ]; then
-        list_json
-    elif [ "${OS}" == "--version" ] || [ "${OS}" == "-version" ] || [ "${OS}" == "version" ]; then
-      whereIam=$(dirname "${BASH_SOURCE[0]}")
-      quickemu_version=$( "${whereIam}"/quickemu --version)
-      echo "Quickemu Version: ${quickemu_version}"
-      exit 0
-    fi
 else
     echo "ERROR! You must specify an operating system:"
     os_support
@@ -1777,4 +1834,12 @@ else
         os_support
     fi
     exit 1
+fi
+;;
+   esac
+    done
+    if [ $# == 0 ]; then
+      echo "Error: You must supply an OS!"
+      os_support
+      exit 1
 fi


### PR DESCRIPTION
 -optional parameters added
--localiso <filename of iso>  (if not supplied will use the distro/download filename
--isodir <directory> search root for `find  ...` 

copies in the first file found then carries on with wget/zsync 

Also gathered the other parameters into the same fold.

Added usage() for  --help (no parameters at all still behave as before since I think that is better UX)