### PR TITLE
Add convenient external repository packaging info

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ cd quickemu
 
 Now install all the **Requirements** documented above.
 
+### Other sources
+
+[Repology.org](https://repology.org/) found the following releases have been packaged.
+
+#### Quickemu
+[![Packaging status](https://repology.org/badge/vertical-allrepos/quickemu.svg)](https://repology.org/project/quickemu/versions)
+#### Quickgui
+[![Packaging status](https://repology.org/badge/vertical-allrepos/quickgui.svg)](https://repology.org/project/quickgui/versions)
+
 # Usage
 
 ## Graphical User Interfaces


### PR DESCRIPTION
came across this and thought it might be handy in the README.md


#### Quickemu
[![Packaging status](https://repology.org/badge/vertical-allrepos/quickemu.svg)](https://repology.org/project/quickemu/versions)
#### Quickgui
[![Packaging status](https://repology.org/badge/vertical-allrepos/quickgui.svg)](https://repology.org/project/quickgui/versions)

Badges can be [tweaked extensively](https://repology.org/project/quickemu/badges)

We may want to add a little disclaimer about the packaging. Either way it's handy to see where it is being found, and with a link to find who the maintainer is.