### PR TITLE
Include path to OVMF files for openSUSE Tumbleweed

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -393,8 +393,11 @@ function vm_boot() {
           EFI_CODE="/usr/share/OVMF/x64/OVMF_CODE.secboot.fd"
           efi_vars "/usr/share/OVMF/x64/OVMF_VARS.fd" "${EFI_VARS}"
         elif [ -e "/usr/share/edk2-ovmf/OVMF_CODE.fd" ]; then
-	        EFI_CODE="/usr/share/edk2-ovmf/OVMF_CODE.secboot.fd"
-	        efi_vars "/usr/share/edk2-ovmf/OVMF_VARS.fd" "${EFI_VARS}"
+	  EFI_CODE="/usr/share/edk2-ovmf/OVMF_CODE.secboot.fd"
+	  efi_vars "/usr/share/edk2-ovmf/OVMF_VARS.fd" "${EFI_VARS}"
+        elif [ -e "/usr/share/qemu/ovmf-x86_64-smm-code.bin" ]; then
+          EFI_CODE="/usr/share/qemu/ovmf-x86_64-smm-code.bin"
+          efi_vars "/usr/share/qemu/ovmf-x86_64-smm-vars.bin" "${EFI_VARS}"
         else
           echo "ERROR! SecureBoot was requested but no SecureBoot capable firmware was found."
           echo "       Please install OVMF firmware."
@@ -415,8 +418,11 @@ function vm_boot() {
           EFI_CODE="/usr/share/OVMF/x64/OVMF_CODE.fd"
           efi_vars "/usr/share/OVMF/x64/OVMF_VARS.fd" "${EFI_VARS}"
         elif [ -e "/usr/share/edk2-ovmf/OVMF_CODE.fd" ]; then
-	        EFI_CODE="/usr/share/edk2-ovmf/OVMF_CODE.fd"
-	        efi_vars "/usr/share/edk2-ovmf/OVMF_VARS.fd" "${EFI_VARS}"
+	  EFI_CODE="/usr/share/edk2-ovmf/OVMF_CODE.fd"
+	  efi_vars "/usr/share/edk2-ovmf/OVMF_VARS.fd" "${EFI_VARS}"
+        elif [ -e "/usr/share/qemu/ovmf-x86_64-code.bin" ]; then
+          EFI_CODE="/usr/share/qemu/ovmf-x86_64-code.bin"
+          efi_vars "/usr/share/qemu/ovmf-x86_64-vars.bin" "${EFI_VARS}"
         else
           echo "ERROR! EFI boot requested but no EFI firmware found."
           echo "       Please install OVMF firmware."


### PR DESCRIPTION
Include path to OVMF files for openSUSE Tumbleweed.

before
```
quickemu --vm ubuntu-focal.conf
Quickemu 3.11 using /usr/bin/qemu-system-x86_64 v6.2.0
 - Host:     "openSUSE Tumbleweed" running Linux 5.16 (latte)
 - CPU:      11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
 - CPU VM:   1 Socket(s), 2 Core(s), 2 Thread(s), 4G RAM
ERROR! EFI boot requested but no EFI firmware found.
       Please install OVMF firmware.
```
after

```
quickemu --vm ubuntu-focal.conf --display gtk
Quickemu 3.11 using /usr/bin/qemu-system-x86_64 v6.2.0
 - Host:     "openSUSE Tumbleweed" running Linux 5.16 (latte)
 - CPU:      11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
 - CPU VM:   1 Socket(s), 2 Core(s), 2 Thread(s), 4G RAM
 - BOOT:     EFI (Linux), OVMF (/usr/share/qemu/ovmf-x86_64-code.bin), SecureBoot (off).
 - Disk:     ubuntu-focal/disk.qcow2 (16G)
             Looks unused, booting from ubuntu-focal/ubuntu-20.04.3-desktop-amd64.iso
 - Boot ISO: ubuntu-focal/ubuntu-20.04.3-desktop-amd64.iso
 - Display:  GTK, virtio-vga, GL (off), VirGL (off)
 - ssh:      On host:  ssh user@localhost -p 22220
 - SPICE:    On host:  spicy --title "ubuntu-focal" --port 5930 --spice-shared-dir /home/username/Public
 - WebDAV:   On guest: dav://localhost:9843/
 - 9P:       On guest: sudo mount -t 9p -o trans=virtio,version=9p2000.L,msize=104857600 Public-username ~/Public
 - smbd:     On guest: smb://10.0.2.4/qemu
 - Process:  Starting ubuntu-focal.conf as ubuntu-focal (29199)
```
