### PR TITLE
Reduce future pain

### DIFF
--- a/quickget
+++ b/quickget
@@ -646,11 +646,6 @@ function make_vm_config() {
     IMAGE_FILE="${1}"
     ISO_FILE="${2}"
     case "${OS}" in
-        alma | android | archlinux | debian | elementary | fedora | kali | \
-        garuda | kdeneon | linuxmint* | nixos* | opensuse | oraclelinux | \
-        popos | regolith | rockylinux | solus | *ubuntu* | zorin )
-            GUEST="linux"
-            IMAGE_TYPE="iso";;
         freebsd )
             GUEST="freebsd"
             IMAGE_TYPE="iso";;
@@ -670,7 +665,7 @@ function make_vm_config() {
             GUEST="windows"
             IMAGE_TYPE="iso";;
         *)
-            echo "Undefined OS Defaulting to Guest=Linux and IMAGE_TYPE=iso"
+            echo "Defaulting to Guest=Linux and IMAGE_TYPE=iso"
             GUEST="linux"
             IMAGE_TYPE="iso";;
     esac

--- a/quickget
+++ b/quickget
@@ -665,7 +665,6 @@ function make_vm_config() {
             GUEST="windows"
             IMAGE_TYPE="iso";;
         *)
-            echo "Defaulting to Guest=Linux and IMAGE_TYPE=iso"
             GUEST="linux"
             IMAGE_TYPE="iso";;
     esac


### PR DESCRIPTION
Now the excellent `case` refactoring by @the-mentor has made it in, and given all the potential fun maintaining the several lists of OS and OS flavours etc. , and given he added a catch-all default, it made sense to me to remove the list from the top of the `case`  and the chatty echo so that in future contributors have one fewer place to edit and there is one fewer location where all the merge collisions happen.