### PR TITLE
Use local isos fixed

### DIFF
--- a/quickget
+++ b/quickget
@@ -539,17 +539,17 @@ function check_hash() {
 function copy_local(){
   if [ -n "${ISODIR}" ]; then
     # use supplied filename or default to original distro ISO name
-      if [ -z ${LOCALISO} ]; then
+      if [ -z "${LOCALISO}" ]; then
         LOCALISO=${FILE}
       fi
-      LOCALFILE=$(find ${ISODIR} -type f -name "${LOCALISO}" -print -quit )
+      LOCALFILE=$(find "${ISODIR}" -type f -name "${LOCALISO}" -print -quit )
       #echo got local file "${LOCALFILE}"
       if [ -f "${DIR}/${FILE}" ]; then
         echo "ERROR! File Exists - not copying over local file"
         echo "Move it out of the way to replace it with a local file"
         exit 1
       else
-        cp -pv "${LOCALFILE}" ${DIR}/${FILE}
+        cp -pv "${LOCALFILE}" "${DIR}"/"${FILE}"
       # if ! ; then echo ERROR! Failed to copy ${LOCALFILE}" to ${DIR}/${FILE}"
       fi
       #exit 0 # while testing
@@ -572,7 +572,19 @@ function web_get() {
       echo "ERROR! Unable to create directory ${DIR}"
       exit 1
     fi
+
+    if [ -n "${LOCALISO}" ] || [ -n "${ISODIR}" ] ; then
     copy_local
+    # you only get one shot
+    LOCALISO=""
+    ISODIR=""
+    # echo "you are just testing
+    #          ISODIR:  ${ISODIR}
+    #          LOCALISO: ${LOCALISO}"
+    # echo stopped in web_get
+    # exit 0
+    fi
+
 
     if command -v aria2c > /dev/null; then
         if ! aria2c -x16 --continue=true --summary-interval=0 --download-result=hide --console-log-level=error "${URL}" -o "${DIR}/${FILE}"; then
@@ -613,7 +625,18 @@ function zsync_get() {
         exit 1
       fi
 
+    if [ -n "${LOCALISO}" ] || [ -n "${ISODIR}" ] ; then
     copy_local
+    # you only get one shot
+    LOCALISO=""
+    ISODIR=""
+    ##
+    # echo "you are just testing
+    #          ISODIR:  ${ISODIR}
+    #          LOCALISO: ${LOCALISO}"
+    # echo stopped in zsync_get
+    # exit 0
+    fi
 
       if ! zsync "${URL}.zsync" -i "${DIR}/${OUT}" -o "${DIR}/${OUT}" 2>/dev/null; then
           echo "ERROR! Failed to download ${URL}.zsync"
@@ -634,6 +657,7 @@ function start_vm_info() {
     echo "To start your ${OS} ${RELEASE} virtual machine run:"
     echo "    quickemu --vm ${OS}-${RELEASE}.conf"
     echo
+    exit 0
 }
 
 function make_vm_config() {
@@ -690,7 +714,7 @@ EOF
             echo "fixed_iso=\"${VM_PATH}/${ISO_FILE}\"" >> "${OS}-${RELEASE}.conf"
         fi
 
-        if [ "${OS}" == "alma"  ] && [ ${ISOTYPE} == "dvd" ]; then
+        if [ "${OS}" == "alma"  ] && [ "${ISOTYPE}" == "dvd" ]; then
             echo "disk_size=\"32G\"" >> "${OS}-${RELEASE}.conf"
         fi
 
@@ -1947,10 +1971,10 @@ languages_windows
 # handle parameters
 
 # Take command line arguments
-#if [ $# -lt 1 ]; then
-#    usage
-#    exit 0
-#else
+if [ $# -lt 1 ]; then
+    usage
+    exit 0
+fi
     while [ $# -gt 0 ]; do
         case "${1}" in
           -isodir|--isodir)
@@ -1973,10 +1997,11 @@ languages_windows
               quickemu_version=$( "${whereIam}"/quickemu --version)
               echo "Quickemu Version: ${quickemu_version}"
               exit 0;;
-          test*)
+          -t|--t|-test|--test)
              echo "you are just testing
              ISODIR:  ${ISODIR}
              LOCALISO: ${LOCALISO}"
+             ls -lh "${ISODIR}/${LOCALISO}"
              exit 0;;
           *)
 

--- a/quickget
+++ b/quickget
@@ -540,6 +540,14 @@ function copy_local(){
   case $OS in
     windows)
       echo "${OS} not (yet?)  supported for local isos" ;;
+    macos)
+      # echo "${OS} not (yet?)  supported for local isos" ;;
+      if [ -n "${ISODIR}" ]; then
+      for macfile in RecoveryImage.dmg RecoveryImage.chunklist
+      do
+        find "${ISODIR}" -type f -name "${macfile}" -exec cp -pv \{\} "$DIR"/ \;
+      done
+      fi;;
     *)
       if [ -n "${ISODIR}" ]; then
         # use supplied filename or default to original distro ISO name

--- a/quickget
+++ b/quickget
@@ -543,7 +543,6 @@ function copy_local(){
         LOCALISO=${FILE}
       fi
       LOCALFILE=$(find "${ISODIR}" -type f -name "${LOCALISO}" -print -quit )
-      #echo got local file "${LOCALFILE}"
       if [ -f "${DIR}/${FILE}" ]; then
         echo "ERROR! File Exists - not copying over local file"
         echo "Move it out of the way to replace it with a local file"
@@ -552,7 +551,6 @@ function copy_local(){
         cp -pv "${LOCALFILE}" "${DIR}"/"${FILE}"
       # if ! ; then echo ERROR! Failed to copy ${LOCALFILE}" to ${DIR}/${FILE}"
       fi
-      #exit 0 # while testing
     fi
 }
 
@@ -578,11 +576,6 @@ function web_get() {
     # you only get one shot
     LOCALISO=""
     ISODIR=""
-    # echo "you are just testing
-    #          ISODIR:  ${ISODIR}
-    #          LOCALISO: ${LOCALISO}"
-    # echo stopped in web_get
-    # exit 0
     fi
 
 
@@ -630,12 +623,6 @@ function zsync_get() {
     # you only get one shot
     LOCALISO=""
     ISODIR=""
-    ##
-    # echo "you are just testing
-    #          ISODIR:  ${ISODIR}
-    #          LOCALISO: ${LOCALISO}"
-    # echo stopped in zsync_get
-    # exit 0
     fi
 
       if ! zsync "${URL}.zsync" -i "${DIR}/${OUT}" -o "${DIR}/${OUT}" 2>/dev/null; then

--- a/quickget
+++ b/quickget
@@ -537,21 +537,26 @@ function check_hash() {
 }
 
 function copy_local(){
-  if [ -n "${ISODIR}" ]; then
-    # use supplied filename or default to original distro ISO name
-      if [ -z "${LOCALISO}" ]; then
-        LOCALISO=${FILE}
-      fi
-      LOCALFILE=$(find "${ISODIR}" -type f -name "${LOCALISO}" -print -quit )
-      if [ -f "${DIR}/${FILE}" ]; then
-        echo "ERROR! File Exists - not copying over local file"
-        echo "Move it out of the way to replace it with a local file"
-        exit 1
-      else
-        cp -pv "${LOCALFILE}" "${DIR}"/"${FILE}"
-      # if ! ; then echo ERROR! Failed to copy ${LOCALFILE}" to ${DIR}/${FILE}"
-      fi
-    fi
+  case $OS in
+    windows)
+      echo "${OS} not (yet?)  supported for local isos" ;;
+    *)
+      if [ -n "${ISODIR}" ]; then
+        # use supplied filename or default to original distro ISO name
+          if [ -z "${LOCALISO}" ]; then
+            LOCALISO=${FILE}
+          fi
+          LOCALFILE=$(find "${ISODIR}" -type f -name "${LOCALISO}" -print -quit )
+          if [ -f "${DIR}/${FILE}" ]; then
+            echo "ERROR! File Exists - not copying over local file"
+            echo "Move it out of the way to replace it with a local file"
+            exit 1
+          else
+            cp -pv "${LOCALFILE}" "${DIR}"/"${FILE}"
+          # if ! ; then echo ERROR! Failed to copy ${LOCALFILE}" to ${DIR}/${FILE}"
+          fi
+        fi
+      esac
 }
 
 function web_get() {


### PR DESCRIPTION
This works again.
Needs more indentation fixing to save sanity, but minimally changed for now since white space diffs seem to be upsetting github more than it should and I don't want to risk blocking any other PRs for silly reasons.  

To use/try this feature you must supply a base path as `--isodir`, beneath which `find` will hunt for your iso.  You can supply an optional `--localiso` parameter to give an alternate existing filename for which to search. 

Sadly it doesn't (yet) deal with the complexities of the windows fetching.

For macOS  `--isodir` need to point to a path containing RecoveryImage.dmg and RecoveryImage.chunklist for the supported macOS version.  Be careful to be more precise because it is doing a fairly indescriminate `find <here> -exec cp .. <there>` for those names, so if you start above a pool of mac images it will break because you held it wrong.