### PR TITLE
Fix all Language variations for Windows. Close #250

### DIFF
--- a/quickget
+++ b/quickget
@@ -2113,7 +2113,7 @@ if [ -n "${2}" ]; then
     elif [ "${OS}" == "windows" ]; then
         if [ -n "${3}" ]; then
             LANG_NAME="${3}"
-            if [[ ! ${LANGS[*]} =~ ${LANG_NAME} ]]; then
+            if [[ ! ${LANGS[*]} =~ "${LANG_NAME}" ]]; then
                 echo "ERROR! ${LANG_NAME} is not a supported language:"
                 for LANG in "${LANGS[@]}"; do
                   echo "${LANG}"


### PR DESCRIPTION
Quotes needed to  allow bracketed langs to match.
User still needs to wrap the LANG parameter in quotes.
This closes bug #250