### PR TITLE
switch to version numbers fixes #376

### DIFF
--- a/quickget
+++ b/quickget
@@ -514,10 +514,10 @@ function releases_tails() {
 }
 
 function releases_ubuntu() {
-    echo bionic \
-    focal \
-    hirsute \
-    impish \
+    echo 18.04 \
+    20.04 \
+    21.04 \
+    21.10 \
     devel \
     canary
 }


### PR DESCRIPTION
This switches from codenames such as `bionic` to version numbers such as `18.04. 
This is more consistent with other distros that quickget can download. It's also the commonly used parlance for releases of Ubuntu. Internally the codename is used, for sure, and is used in release identification in some configuration files, but marketing wise, release numbers are used, and always have been.

I have tested downloading all the Ubuntu releases that quickget currently supports after this change.

