### PR TITLE
Add some whitespace-formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/quickemu
+++ b/quickemu
@@ -1300,3 +1300,5 @@ if [ ${SHORTCUT} -eq 1 ]; then
 fi
 
 vm_boot
+
+# vim:tabstop=2:shiftwidth=2:expandtab

--- a/quickget
+++ b/quickget
@@ -2038,3 +2038,5 @@ else
     esac
     exit 1
 fi
+
+# vim:tabstop=2:shiftwidth=2:expandtab


### PR DESCRIPTION
Every time I'm making changes to quickemu and quickget, I find myself indenting things with the wrong number of spaces, because the convention used in this project differs from my default.

I've also seen inconsistencies and therefore commits reformatting the code. So I added some Vim rules at the end of the files and an .editorconfig file, hopefully this will help!