### PR TITLE
RFC: Add old/obsolete/eol Ubuntu releases (hidden by default)

### DIFF
--- a/quickget
+++ b/quickget
@@ -437,7 +437,49 @@ function releases_tails() {
 }
 
 function releases_ubuntu() {
-    echo 18.04 20.04 21.10 daily-live daily-canary
+    echo 14.04 \
+        16.04 \
+        18.04 \
+        20.04 \
+        21.10 \
+        daily-live \
+        daily-canary \
+        eol-4.10 \
+        eol-5.04 \
+        eol-5.10 \
+        eol-6.06.0 eol-6.06.1 eol-6.06.2 \
+        eol-6.10 \
+        eol-7.04 \
+        eol-7.10 \
+        eol-8.04.0 eol-8.04.1 eol-8.04.2 eol-8.04.3 eol-8.04.4 \
+        eol-8.10 \
+        eol-9.04 \
+        eol-9.10 \
+        eol-10.04.0 eol-10.04.1 eol-10.04.2 eol-10.04.3 eol-10.04.4 \
+        eol-10.10 \
+        eol-11.04 \
+        eol-11.10 \
+        eol-12.04 eol-12.04.0 eol-12.04.1 eol-12.04.2 eol-12.04.3 eol-12.04.4 eol-12.04.5 \
+        eol-12.10 \
+        eol-13.04 \
+        eol-13.10 \
+        eol-14.04.0 eol-14.04.1 eol-14.04.2 eol-14.04.3 eol-14.04.4 eol-14.04.5 \
+        eol-14.10 \
+        eol-15.04 \
+        eol-15.10 \
+        eol-16.04.0 eol-16.04.1 eol-16.04.2 eol-16.04.3 eol-16.04.4 eol-16.04.5 eol-16.04.6 \
+        eol-16.10 \
+        eol-17.04 \
+        eol-17.10 \
+        eol-18.04 eol-18.04.0 eol-18.04.1 eol-18.04.2 eol-18.04.3 eol-18.04.4 eol-18.04.5 \
+        eol-18.10 \
+        eol-19.04 \
+        eol-19.10 \
+        eol-20.04 eol-20.04.0 eol-20.04.1 eol-20.04.2 \
+        eol-20.10 \
+        eol-21.04 \
+        eol-21.10 \
+        ;
 }
 
 function releases_void() {
@@ -1169,17 +1211,24 @@ function get_ubuntu() {
         RELEASE="daily-live"
     fi
 
-    if [[ "${RELEASE}" == *"daily"* ]] || [ "${RELEASE}" == "dvd" ]; then
-        URL="http://cdimage.ubuntu.com/${OS}/${RELEASE}/current"
+    if [[ "${RELEASE}" == "eol-"* ]]; then
+        URL="https://old-releases.ubuntu.com/releases/${RELEASE/eol-/}"
+    elif [[ "${RELEASE}" == *"daily"* ]] || [ "${RELEASE}" == "dvd" ]; then
+        URL="https://cdimage.ubuntu.com/${OS}/${RELEASE}/current"
         VM_PATH="${OS}-devel"
     elif [ "${OS}" == "ubuntu" ]; then
-        URL="http://releases.ubuntu.com/${RELEASE}"
+        URL="https://releases.ubuntu.com/${RELEASE}"
     else
-        URL="http://cdimage.ubuntu.com/${OS}/releases/${RELEASE}/release"
+        URL="https://cdimage.ubuntu.com/${OS}/releases/${RELEASE}/release"
     fi
 
-    ISO=$(wget -q -O- "${URL}/SHA256SUMS" | grep 'desktop\|dvd' | grep amd64 | cut -d'*' -f2)
-    HASH=$(wget -q -O- "${URL}/SHA256SUMS" | grep 'desktop\|dvd' | grep amd64 | cut -d' ' -f1)
+    if wget -q --spider "${URL}/SHA256SUMS"; then
+        ISO=$(wget -q -O- "${URL}/SHA256SUMS" | grep 'desktop\|dvd\|install' | grep amd64 | cut -d'*' -f2)
+        HASH=$(wget -q -O- "${URL}/SHA256SUMS" | grep 'desktop\|dvd\|install' | grep amd64 | cut -d' ' -f1)
+    else
+        ISO=$(wget -q -O- "${URL}/MD5SUMS" | grep 'desktop\|dvd\|install' | grep amd64 | cut -d' ' -f3)
+        HASH=$(wget -q -O- "${URL}/MD5SUMS" | grep 'desktop\|dvd\|install' | grep amd64 | cut -d' ' -f1)
+    fi
     #echo "${URL}/${ISO} ${HASH}"
 
     if [[ "${RELEASE}" == *"daily"* ]] || [ "${RELEASE}" == "dvd" ]; then
@@ -1719,7 +1768,7 @@ else
     case ${OS} in
       *ubuntu*)
         echo -n " - Releases: "
-        releases_ubuntu
+        releases_ubuntu | sed -Ee 's/eol-\S+//g' # hide eol releases
         ;;
       *)
         echo -n " - Releases: "


### PR DESCRIPTION
* Ensure Ubuntu releases are all downloaded via HTTPS URLs
* Add eol-4.10 thru to eol-21.10 releases for Ubuntu
* Add special handling of MD5SUMS-only Ubuntu releases on old-releases.ubuntu.com
* Add detection of Ubuntu `*-install.iso` files for very early Ubuntu releases

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>