### PR TITLE
Workaround zsync http-only failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,13 @@ Features
 
 -   **macOS** Monterey, Big Sur, Catalina, Mojave & High Sierra
 -   **Windows** 8.1, 10 and 11 including TPM 2.0
--   [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu
-    flavours](https://ubuntu.com/download/flavours)**
+-   [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu flavours](https://ubuntu.com/download/flavours)**
 -   **Over 360 operating system editions are supported!**
 -   Full SPICE support including host/guest clipboard sharing
 -   VirtIO-webdavd file sharing for Linux and Windows guests
 -   VirtIO-9p file sharing for Linux and macOS guests
--   [QEMU Guest Agent
-    support](https://wiki.qemu.org/Features/GuestAgent); provides access
-    to a system-level agent via standard QMP commands
--   Samba file sharing for Linux, macOS and Windows guests (*if `smbd`
-    is installed on the host*)
+-   [QEMU Guest Agent support](https://wiki.qemu.org/Features/GuestAgent); provides access to a system-level agent via standard QMP commands
+-   Samba file sharing for Linux, macOS and Windows guests (*if `smbd` is installed on the host*)
 -   VirGL acceleration
 -   USB device pass-through
 -   Smartcard pass-through
@@ -70,8 +66,7 @@ QEMU](https://img.youtube.com/vi/AOTYWEgw0hI/0.jpg)](https://www.youtube.com/wat
 Requirements
 ------------
 
--   [QEMU](https://www.qemu.org/) (*6.0.0 or newer*) **with GTK, SDL,
-    SPICE & VirtFS support**
+-   [QEMU](https://www.qemu.org/) (*6.0.0 or newer*) **with GTK, SDL, SPICE & VirtFS support**
 -   [bash](https://www.gnu.org/software/bash/) (*4.0 or newer*)
 -   [Coreutils](https://www.gnu.org/software/coreutils/)
 -   [EDK II](https://github.com/tianocore/edk2)
@@ -243,7 +238,7 @@ Other Operating Systems
 -   `popos` (Pop!\_OS)
 -   `regolith` (Regolith Linux)
 -   `rockylinux` (Rocky Linux)
--   `slackware` (Slackware Linux)
+-   `slackware` (Slackware)
 -   `solus` (Solus)
 -   `tails` (Tails)
 -   `void` (Void Linux)
@@ -404,9 +399,6 @@ tpm="on"
 -   `fixed_iso=` specifies the ISO image that provides VirtIO drivers.
 -   `tpm="on"` instructs `quickemu` to create a software emulated TPM
     device using `swtpm`.
-
-Other Guests
-------------
 
 SPICE
 =====
@@ -621,6 +613,7 @@ All the options
 Here are the usage instructions:
 
 ``` {.bash}
+
 
 Usage
   quickemu --vm ubuntu.conf

--- a/README.md
+++ b/README.md
@@ -33,13 +33,17 @@ Features
 
 -   **macOS** Monterey, Big Sur, Catalina, Mojave & High Sierra
 -   **Windows** 8.1, 10 and 11 including TPM 2.0
--   [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu flavours](https://ubuntu.com/download/flavours)**
+-   [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu
+    flavours](https://ubuntu.com/download/flavours)**
 -   **Over 360 operating system editions are supported!**
 -   Full SPICE support including host/guest clipboard sharing
 -   VirtIO-webdavd file sharing for Linux and Windows guests
 -   VirtIO-9p file sharing for Linux and macOS guests
--   [QEMU Guest Agent support](https://wiki.qemu.org/Features/GuestAgent); provides access to a system-level agent via standard QMP commands
--   Samba file sharing for Linux, macOS and Windows guests (*if `smbd` is installed on the host*)
+-   [QEMU Guest Agent
+    support](https://wiki.qemu.org/Features/GuestAgent); provides access
+    to a system-level agent via standard QMP commands
+-   Samba file sharing for Linux, macOS and Windows guests (*if `smbd`
+    is installed on the host*)
 -   VirGL acceleration
 -   USB device pass-through
 -   Smartcard pass-through
@@ -66,7 +70,8 @@ QEMU](https://img.youtube.com/vi/AOTYWEgw0hI/0.jpg)](https://www.youtube.com/wat
 Requirements
 ------------
 
--   [QEMU](https://www.qemu.org/) (*6.0.0 or newer*) **with GTK, SDL, SPICE & VirtFS support**
+-   [QEMU](https://www.qemu.org/) (*6.0.0 or newer*) **with GTK, SDL,
+    SPICE & VirtFS support**
 -   [bash](https://www.gnu.org/software/bash/) (*4.0 or newer*)
 -   [Coreutils](https://www.gnu.org/software/coreutils/)
 -   [EDK II](https://github.com/tianocore/edk2)
@@ -237,7 +242,7 @@ Other Operating Systems
 -   `popos` (Pop!\_OS)
 -   `regolith` (Regolith Linux)
 -   `rockylinux` (Rocky Linux)
--   `slackware` (Slackware)
+-   `slackware` (Slackware Linux)
 -   `solus` (Solus)
 -   `tails` (Tails)
 -   `void` (Void Linux)
@@ -398,6 +403,9 @@ tpm="on"
 -   `fixed_iso=` specifies the ISO image that provides VirtIO drivers.
 -   `tpm="on"` instructs `quickemu` to create a software emulated TPM
     device using `swtpm`.
+
+Other Guests
+------------
 
 SPICE
 =====
@@ -612,7 +620,6 @@ All the options
 Here are the usage instructions:
 
 ``` {.bash}
-
 
 Usage
   quickemu --vm ubuntu.conf

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ operating system you want to run and Quickemu will figure out the best
 way to do it for you. For example:
 
 ``` {.bash}
-quickget ubuntu-mate impish
-quickemu --vm ubuntu-mate-impish.conf
+quickget ubuntu-mate 21.10
+quickemu --vm ubuntu-mate-21.10-.conf
 ```
 
 The original objective of the project was to enable quick testing of
@@ -33,13 +33,17 @@ Features
 
 -   **macOS** Monterey, Big Sur, Catalina, Mojave & High Sierra
 -   **Windows** 8.1, 10 and 11 including TPM 2.0
--   [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu flavours](https://ubuntu.com/download/flavours)**
+-   [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu
+    flavours](https://ubuntu.com/download/flavours)**
 -   **Over 360 operating system editions are supported!**
 -   Full SPICE support including host/guest clipboard sharing
 -   VirtIO-webdavd file sharing for Linux and Windows guests
 -   VirtIO-9p file sharing for Linux and macOS guests
--   [QEMU Guest Agent support](https://wiki.qemu.org/Features/GuestAgent); provides access to a system-level agent via standard QMP commands
--   Samba file sharing for Linux, macOS and Windows guests (*if `smbd` is installed on the host*)
+-   [QEMU Guest Agent
+    support](https://wiki.qemu.org/Features/GuestAgent); provides access
+    to a system-level agent via standard QMP commands
+-   Samba file sharing for Linux, macOS and Windows guests (*if `smbd`
+    is installed on the host*)
 -   VirGL acceleration
 -   USB device pass-through
 -   Smartcard pass-through
@@ -66,7 +70,8 @@ QEMU](https://img.youtube.com/vi/AOTYWEgw0hI/0.jpg)](https://www.youtube.com/wat
 Requirements
 ------------
 
--   [QEMU](https://www.qemu.org/) (*6.0.0 or newer*) **with GTK, SDL, SPICE & VirtFS support**
+-   [QEMU](https://www.qemu.org/) (*6.0.0 or newer*) **with GTK, SDL,
+    SPICE & VirtFS support**
 -   [bash](https://www.gnu.org/software/bash/) (*4.0 or newer*)
 -   [Coreutils](https://www.gnu.org/software/coreutils/)
 -   [EDK II](https://github.com/tianocore/edk2)
@@ -162,8 +167,8 @@ Ubuntu Guest
 virtual machine configuration.
 
 ``` {.bash}
-quickget ubuntu focal
-quickemu --vm ubuntu-focal.conf
+quickget ubuntu 20.04
+quickemu --vm ubuntu-20.04.conf
 ```
 
 -   Complete the installation as normal.
@@ -197,9 +202,9 @@ with your preferred flavour.
 -   `kubuntu` (Kubuntu)
 -   `lubuntu` (Lubuntu)
 -   `ubuntu-budgie` (Ubuntu Budgie)
--   `ubuntu-kylin` (Ubuntu Kylin)
+-   `ubuntukylin` (Ubuntu Kylin)
 -   `ubuntu-mate` (Ubuntu MATE)
--   `ubuntu-studio` (Ubuntu Studio)
+-   `ubuntustudio` (Ubuntu Studio)
 -   `ubuntu` (Ubuntu)
 -   `xubuntu` (Xubuntu)
 
@@ -216,11 +221,11 @@ Other Operating Systems
 -   `cachyos` (CachyOS)
 -   `debian` (Debian)
 -   `devuan` (Devuan)
--    `dragonflybsd` (DragonFlyBSD)
+-   `dragonflybsd` (DragonFlyBSD)
 -   `elementary` (elementary OS)
 -   `fedora` (Fedora)
 -   `freebsd` (FreeBSD)
--    `freedos` (FreeDOS)
+-   `freedos` (FreeDOS)
 -   `garuda` (Garuda Linux)
 -   `gentoo` (Gentoo)
 -   `ghostbsd` (GhostBSD)
@@ -416,7 +421,7 @@ requires that the `spicy` client is installed, available from the
 `spice-client-gtk` package in Debian/Ubuntu.
 
 ``` {.bash}
-quickemu --vm ubuntu-focal.conf --display spice
+quickemu --vm ubuntu-20.04.conf --display spice
 ```
 
 Headless
@@ -428,14 +433,14 @@ available from the `spice-client-gtk` package in Debian/Ubuntu to
 connect to the running VM
 
 ``` {.bash}
-quickemu --vm ubuntu-focal.conf --display none
+quickemu --vm ubuntu-20.04.conf --display none
 ```
 
 You can also use the `.ports` file in the VM directory to lookup what
 SSH and SPICE ports the VM is connected to.
 
 ``` {.bash}
-cat ubuntu-focal/ubuntu-focal.ports
+cat ubuntu-20.04/ubuntu-20.04.ports
 ```
 
 Accessibility
@@ -445,13 +450,7 @@ Qemu provides support for using BrlAPI to display braille output on a
 real or fake device.
 
 ``` {.bash}
-quickemu --vm ubuntu-impish.conf --accessibility braille --display sdl
-```
-
-or even
-
-``` {.bash}
-quickemu --vm ubuntu-impish.conf --acc brl --display sdl
+quickemu --vm ubuntu-21.10.conf --braille --display sdl
 ```
 
 BIOS and EFI
@@ -616,7 +615,6 @@ Here are the usage instructions:
 
 ``` {.bash}
 
-
 Usage
   quickemu --vm ubuntu.conf
 
@@ -646,7 +644,7 @@ Desktop shortcuts can be created for a VM, the shortcuts are saved in
 shortcut.
 
 ``` {.bash}
-quickemu --vm ubuntu-focal-desktop.conf --shortcut
+quickemu --vm ubuntu-20.04-desktop.conf --shortcut
 ```
 
 Screen and window size (Linux guests only)

--- a/quickget
+++ b/quickget
@@ -625,8 +625,9 @@ function zsync_get() {
           exit 1
         fi
 
-        if ! zsync "${URL}.zsync" -i "${DIR}/${OUT}" -o "${DIR}/${OUT}" 2>/dev/null; then
-            echo "ERROR! Failed to download ${URL}.zsync"
+        # Only force http for zsync - not earlier because we might fall through here
+        if ! zsync "${URL/https/http}.zsync" -i "${DIR}/${OUT}" -o "${DIR}/${OUT}" 2>/dev/null; then
+            echo "ERROR! Failed to download ${URL/https/http}.zsync"
             exit 1
         fi
 


### PR DESCRIPTION
Fixes #395

Also corrects some old examples in in Readme

Fixes #391

```bash
 ~/src/quickemu-project/quickemu/quickget ubuntu-mate daily-live
#################### 100.0% 2490.0 kBps DONE     

##############------ 74.6% 17.1 kBps         
#################### 100.0% 6783.3 kBps DONE     

verifying download...checksum matches OK
used 3288150016 local, fetched 1120187253
Making ubuntu-mate-daily-live.conf

To start your Ubuntu MATE virtual machine run:
    quickemu --vm ubuntu-mate-daily-live.conf

```