### PR TITLE
Fixed boot problems and logic correction in FreeDOS support. Fixes #382

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -476,6 +476,12 @@ function vm_boot() {
         NET_DEVICE="rtl8139"
       fi
 
+      if [ "${guest_os}" == "freedos" ] ; then
+        # fix for #382
+        SMM="on"
+      fi
+
+
       if [ -z "${disk_size}" ]; then
         disk_size="16G"
       fi

--- a/quickemu
+++ b/quickemu
@@ -933,7 +933,7 @@ function vm_boot() {
     args+=(-drive media=cdrom,index=1,file="${fixed_iso}")
   fi
 
-  if [ -n "{iso}" ] && [ "${guest_os}" == "freedos" ]; then
+  if [ -n "${iso}" ] && [ "${guest_os}" == "freedos" ]; then
     # FreeDOS reboots after partitioning the disk, and QEMU tries to boot from disk after first restart
     # This flag sets the boot order to cdrom,disk. It will persist until powering down the VM
     args+=(-boot order=dc)


### PR DESCRIPTION
Solution to the booting problem discussed in #382 and elsewhere implementing the fix identified by @chasecovello  in https://github.com/quickemu-project/quickemu/issues/382#issuecomment-1059635250_

Also  fixed missing  "$" (causing flawed test to always be true) added to correct logic