### PR TITLE
Add reactos

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1011,21 +1011,6 @@ function vm_boot() {
            -drive if=pflash,format=raw,unit=1,file="${EFI_VARS}")
   fi
 
-  if [ -n "${floppy}" ]; then
-    # shellcheck disable=SC2054
-    args+=(-drive if=floppy,format=raw,file="${floppy}")
-  fi
-
-  if [ -n "${iso}" ]; then
-    # shellcheck disable=SC2054
-    args+=(-drive media=cdrom,index=0,file="${iso}")
-  fi
-
-  if [ -n "${fixed_iso}" ]; then
-    # shellcheck disable=SC2054
-    args+=(-drive media=cdrom,index=1,file="${fixed_iso}")
-  fi
-
   if [ -n "${iso}" ] && [ "${guest_os}" == "freedos" ]; then
     # FreeDOS reboots after partitioning the disk, and QEMU tries to boot from disk after first restart
     # This flag sets the boot order to cdrom,disk. It will persist until powering down the VM
@@ -1045,6 +1030,21 @@ function vm_boot() {
     # Attach the unattended configuration to Windows guests when booting from ISO
     # shellcheck disable=SC2054
     args+=(-drive media=cdrom,index=2,file="${VMDIR}/unattended.iso")
+  fi
+
+  if [ -n "${floppy}" ]; then
+    # shellcheck disable=SC2054
+    args+=(-drive if=floppy,format=raw,file="${floppy}")
+  fi
+
+  if [ -n "${iso}" ]; then
+    # shellcheck disable=SC2054
+    args+=(-drive media=cdrom,index=0,file="${iso}")
+  fi
+
+  if [ -n "${fixed_iso}" ]; then
+    # shellcheck disable=SC2054
+    args+=(-drive media=cdrom,index=1,file="${fixed_iso}")
   fi
 
   if [ "${guest_os}" == "macos" ]; then

--- a/quickemu
+++ b/quickemu
@@ -509,6 +509,14 @@ function vm_boot() {
       MACHINE_TYPE="pc"
       NET_DEVICE="rtl8139"
       ;;
+    reactos)
+      CPU="-cpu qemu32,kvm=on"
+      if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
+        CPU="${CPU},topoext"
+      fi
+      MACHINE_TYPE="pc"
+      NET_DEVICE="e1000"
+      ;;
     macos)
       #https://www.nicksherlock.com/2020/06/installing-macos-big-sur-on-proxmox/
       # A CPU with SSE4.1 support is required for >= macOS Sierra
@@ -1027,6 +1035,12 @@ function vm_boot() {
     # shellcheck disable=SC2054
     args+=(-drive media=cdrom,index=2,file="${iso}")
     iso=""
+  elif [ -n "${iso}" ] && [ "${guest_os}" == "reactos" ]; then
+    # shellcheck disable=SC2054
+    # https://reactos.org/wiki/QEMU
+    args+=(-boot order=d
+           -drive if=ide,index=2,media=cdrom,file="${iso}")
+    iso=""
   elif [ -n "${iso}" ] && [ "${guest_os}" == "windows" ] && [ -e "${VMDIR}/unattended.iso" ]; then
     # Attach the unattended configuration to Windows guests when booting from ISO
     # shellcheck disable=SC2054
@@ -1053,12 +1067,19 @@ function vm_boot() {
     args+=(-device ahci,id=ahci
            -device ide-hd,bus=ahci.0,drive=SystemDisk
            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+
   elif [ "${guest_os}" == "batocera" ] ; then
     # shellcheck disable=SC2054,SC2206
     args+=(-device virtio-blk-pci,drive=BootDisk
            -drive id=BootDisk,if=none,format=raw,file="${img}"
            -device virtio-blk-pci,drive=SystemDisk
            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+
+  elif [ "${guest_os}" == "reactos" ]; then
+    # shellcheck disable=SC2054,SC2206
+    # https://reactos.org/wiki/QEMU
+    args+=(-drive if=ide,index=0,media=disk,file="${disk_img}")
+
   else
     # shellcheck disable=SC2054,SC2206
     args+=(-device virtio-blk-pci,drive=SystemDisk

--- a/quickget
+++ b/quickget
@@ -57,6 +57,7 @@ function pretty_name() {
     opensuse)           PRETTY_NAME="openSUSE";;
     oraclelinux)        PRETTY_NAME="Oracle Linux";;
     popos)              PRETTY_NAME="Pop!_OS";;
+    reactos)            PRETTY_NAME="ReactOS";;
     regolith)           PRETTY_NAME="Regolith Linux";;
     rockylinux)         PRETTY_NAME="Rocky Linux";;
     ubuntu-budgie)      PRETTY_NAME="Ubuntu Budgie";;
@@ -196,6 +197,7 @@ function os_support() {
     opensuse \
     oraclelinux \
     popos \
+    reactos \
     regolith \
     rockylinux \
     slackware \
@@ -435,6 +437,10 @@ function releases_popos() {
 
 function editions_popos() {
     echo intel nvidia
+}
+
+function releases_reactos() {
+    echo latest
 }
 
 function releases_regolith() {
@@ -719,6 +725,9 @@ function make_vm_config() {
         openbsd)
             GUEST="openbsd"
             IMAGE_TYPE="iso";;
+        reactos)
+            GUEST="reactos"
+            IMAGE_TYPE="iso";;
         windows)
             GUEST="windows"
             IMAGE_TYPE="iso";;
@@ -764,6 +773,11 @@ EOF
             echo "boot=\"legacy\"" >> "${CONF_FILE}"
             echo "disk_size=\"2G\"" >> "${CONF_FILE}"
             echo "ram=\"128M\"" >> "${CONF_FILE}"
+            ;;
+          reactos)
+            echo "boot=\"legacy\"" >> "${CONF_FILE}"
+            echo "disk_size=\"12G\"" >> "${CONF_FILE}"
+            echo "ram=\"2048M\"" >> "${CONF_FILE}"
             ;;
           macos) echo "macos_release=\"${RELEASE}\"" >> "${CONF_FILE}";;
         esac
@@ -1307,6 +1321,16 @@ function get_popos() {
     echo "${URL} ${HASH}"
 }
 
+function get_reactos() {
+    local HASH=""
+    local URL=""
+    local TMPURL=""
+
+    TMPURL=$(wget -q -S -O- --max-redirect=0 "https://sourceforge.net/projects/reactos/files/latest/download" 2>&1 | grep Location | cut -d' ' -f4)
+    URL=${TMPURL%\?*}
+    echo "${URL} ${HASH}"
+}
+
 function get_regolith() {
     local EDITION="${1:-}"
     local HASH=""
@@ -1841,6 +1865,11 @@ create_vm() {
     if [[ ${OS} == "batocera" ]] && [[ ${ISO} =~ ".gz" ]]; then
         gzip -d "${VM_PATH}/${ISO}"
         ISO="${ISO/.gz/}"
+    fi
+
+    if [ ${OS} == "reactos" ] && [[ $ISO =~ ".zip" ]]; then
+        unzip ${VM_PATH}/${ISO} -d ${VM_PATH}
+        ISO=$(ls ${VM_PATH} | grep -i '.iso' | grep -v '.zip')
     fi
 
     make_vm_config "${ISO}"


### PR DESCRIPTION
Initial support for ReactOS
https://reactos.org/

VM configuration is based on upstream documentation for QEMU:
https://reactos.org/wiki/QEMU

Only latest released version is supported. I was not able to find a good solution to download nightly builds.