### PR TITLE
Added zero write detection to system disk configuration

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -968,16 +968,16 @@ function vm_boot() {
 
     # shellcheck disable=SC2054,SC2206
     args+=(-device ${MAC_DISK_DEV},drive=SystemDisk
-           -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+           -drive id=SystemDisk,if=none,format=qcow2,detect-zeroes=on,file="${disk_img}" ${STATUS_QUO})
   elif [ "${guest_os}" == "kolibrios" ]; then
     # shellcheck disable=SC2054,SC2206
     args+=(-device ahci,id=ahci
            -device ide-hd,bus=ahci.0,drive=SystemDisk
-           -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+           -drive id=SystemDisk,if=none,format=qcow2,detect-zeroes=on,file="${disk_img}" ${STATUS_QUO})
   else
     # shellcheck disable=SC2054,SC2206
     args+=(-device virtio-blk-pci,drive=SystemDisk
-           -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+           -drive id=SystemDisk,if=none,format=qcow2,detect-zeroes=on,file="${disk_img}" ${STATUS_QUO})
   fi
 
   # https://wiki.qemu.org/Documentation/9psetup


### PR DESCRIPTION
Writing zeroes to the free space on a virtual disk (to later shrink the image) causes the disk image file to expand to its maximum size. Adding "detect-zeroes=on" converts these to sparse writes for unallocated parts of the disk.