### PR TITLE
Add shebang to conf and mark it as executable

### DIFF
--- a/quickget
+++ b/quickget
@@ -703,10 +703,13 @@ function make_vm_config() {
     if [ ! -e "${CONF_FILE}" ]; then
         echo "Making ${CONF_FILE}"
         cat << EOF > "${CONF_FILE}"
+#!$(which quickemu) --vm
 guest_os="${GUEST}"
 disk_img="${VM_PATH}/disk.qcow2"
 ${IMAGE_TYPE}="${VM_PATH}/${IMAGE_FILE}"
 EOF
+        echo "Giving user execute permissions on ${CONF_FILE},"
+        chmod u+x "${CONF_FILE}"
         if [ -n "${ISO_FILE}" ]; then
             echo "fixed_iso=\"${VM_PATH}/${ISO_FILE}\"" >> "${CONF_FILE}"
         fi


### PR DESCRIPTION
This is a very small, unobtrusive change, which adds a single line to the beginning of the .conf files generated by `quickget`, and marks it as executable. This allows them to be run directly (i.e. `./macos-catalina.conf`.