### PR TITLE
Garuda update to quickget to support latest release

### DIFF
--- a/quickget
+++ b/quickget
@@ -290,23 +290,12 @@ function releases_freedos() {
 }
 
 function releases_garuda() {
-    echo 220131
+  echo latest
 }
 
 function editions_garuda() {
-    echo dr460nized \
-    dr460nized-blackarch \
-    dr460nized-gaming \
-    bspwm \
-    cinnamon \
-    gnome \
-    i3 \
-    kde-barebones \
-    lxqt-kwin \
-    mate \
-    qtile \
-    sway \
-    xfce
+  URL="https://mirrors.fossho.st/garuda/iso/latest/garuda/"
+  echo $(wget -q -O - ${URL} | grep '^<a href' | sed -e 's/^.*="//' -e 's/\/.*//')
 }
 
 function releases_gentoo() {
@@ -918,22 +907,15 @@ function get_freedos() {
 }
 
 function get_garuda() {
-    local EDITION="${1:-}"
-    local HASH=""
-    local ISO=""
-    local URL=""
+  local EDITION="${1:-}"
+  local HASH=""
+  local ISO=""
+  local URL="https://mirrors.fossho.st/garuda/iso/latest/garuda/"
 
-    case ${EDITION} in
-      cinnamon|mate) URL="http://mirrors.fossho.st/garuda/iso/community/${EDITION}/${RELEASE}";;
-      *) URL="http://mirrors.fossho.st/garuda/iso/garuda/${EDITION}/${RELEASE}";;
-    esac
-    case ${EDITION} in
-        xfce|kde-barebones)  ISO="garuda-${EDITION}-linux-lts-${RELEASE}.iso";;
-        *) ISO="garuda-${EDITION}-linux-zen-${RELEASE}.iso";;
-    esac
+  ISO=${EDITION}/latest.iso
 
-    HASH="$(wget -q -O- "${URL}/${ISO}.sha256" | cut -d' ' -f1)"
-    echo "${URL}/${ISO} ${HASH}"
+  HASH="$(wget -q -O- "${URL}/${ISO}.sha256" | cut -d' ' -f1)"
+  echo "${URL}/${ISO} ${HASH}"
 }
 
 function get_gentoo() {


### PR DESCRIPTION
* reformated quickget to use consistant 2 space indentation
* removed the vim config line so would respect .editorconfig
* updated .editorconfig to be consistant with quickemu
* updated garuda release function to support only latest release
* updated function editions_garuda to get valid editions from
  distribution web site
* updated function get_garuda to use the garuda latest iso images
* also change the default disk_size to 32G as I got error that 16G was
  to small when I tested