### PR TITLE
update cachyos release and edition structure

### DIFF
--- a/quickget
+++ b/quickget
@@ -237,7 +237,11 @@ function editions_arcolinux() {
 }
 
 function releases_cachyos() {
-    echo 2022.01.09 2022.02.11
+    echo 220330
+}
+
+function editions_cachyos(){
+        echo kde cli xfce
 }
 
 function releases_debian() {
@@ -814,8 +818,19 @@ function get_arcolinux() {
 
 function get_cachyos() {
     local HASH=""
-    local ISO="cachyos-${RELEASE}-x86_64.iso"
-    local URL="https://mirror.cachyos.org/ISO"
+    #https://mirror.cachyos.org/ISO/kde/220330/cachyos-kde-linux-cachyos-220330.iso
+    #https://mirror.cachyos.org/ISO/cli/220330/cachyos-cli-linux-220330.iso
+    #https://mirror.cachyos.org/ISO/xfce/220330/cachyos-xfce-linux-cachyos-220330.iso
+    #
+    #https://mirror.cachyos.org/ISO/kde/cachyos-2022.05.08-x86_64-4.iso
+    #
+    local CACHY=""
+    if [[ ! $EDITION == "cli" ]] ; then
+        CACHY="-cachyos"
+    fi
+    local ISO="cachyos-${EDITION}-linux${CACHY}-${RELEASE}.iso"
+    local URL="https://mirror.cachyos.org/ISO/${EDITION}/${RELEASE}"
+    ASH=$(wget -q -O- "${URL}/${ISO}.sha256" | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"
 }
 


### PR DESCRIPTION
they have also added hashes.  May version appears not to be
in the same structure
and possibly will appear/change again soon
when the spurious naming may get fixed too

this replaces the removed  `cachyos-2022.01.09-x86_64.iso` and `cachyos-2022.02.11-x86_64.iso` files with the 3 editions of 220330.  I note some have an extra `-cachyos` in the name and have handled that.  I also noted several later isos under `kde` : 
```[cachyos-2022.05.06-x86_64.iso](https://mirror.cachyos.org/ISO/kde/cachyos-2022.05.06-x86_64.iso)                      06-May-2022 21:50      2G
[cachyos-2022.05.08-x86_64-2.iso](https://mirror.cachyos.org/ISO/kde/cachyos-2022.05.08-x86_64-2.iso)                    08-May-2022 19:27      2G
[cachyos-2022.05.08-x86_64-3.iso](https://mirror.cachyos.org/ISO/kde/cachyos-2022.05.08-x86_64-3.iso)                    08-May-2022 21:35      2G
[cachyos-2022.05.08-x86_64-4.iso](https://mirror.cachyos.org/ISO/kde/cachyos-2022.05.08-x86_64-4.iso)                    08-May-2022 22:49      2G
[cachyos-2022.05.08-x86_64.iso](https://mirror.cachyos.org/ISO/kde/cachyos-2022.05.08-x86_64.iso)                      08-May-2022 02:34      2G
```
but since there were 4 in 24 hrs and they are not on Sourceforge I have not included any of these.
