### PR TITLE
Add option to use spice-app as the --display

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1057,7 +1057,7 @@ function usage() {
   echo "  --braille               : Enable braille support. Requires SDL."
   echo "  --delete-disk           : Delete the disk image and EFI variables"
   echo "  --delete-vm             : Delete the entire VM and it's configuration"
-  echo "  --display               : Select display backend. 'sdl' (default), 'gtk', 'none', or 'spice'"
+  echo "  --display               : Select display backend. 'sdl' (default), 'gtk', 'none', 'spice' or 'spice-app'"
   echo "  --fullscreen            : Starts VM in full screen mode (Ctl+Alt+f to exit)"
   echo "  --ignore-msrs-always    : Configure KVM to always ignore unhandled machine-specific registers"
   echo "  --screen <screen>       : Use specified screen to determine the window size."
@@ -1072,7 +1072,7 @@ function usage() {
 }
 
 function display_param_check() {
-  if [ "${OUTPUT}" != "gtk" ] && [ "${OUTPUT}" != "none" ] && [ "${OUTPUT}" != "sdl" ] && [ "${OUTPUT}" != "spice" ]; then
+  if [ "${OUTPUT}" != "gtk" ] && [ "${OUTPUT}" != "none" ] && [ "${OUTPUT}" != "sdl" ] && [ "${OUTPUT}" != "spice" ] && [ "${OUTPUT}" != "spice-app" ]; then
     echo "ERROR! Requested output '${OUTPUT}' is not recognised."
     exit 1
   elif [ "${OUTPUT}" == "spice" ] && ! command -v spicy &>/dev/null; then

--- a/quickemu
+++ b/quickemu
@@ -1247,16 +1247,14 @@ if [ -n "${VM}" ] && [ -e "${VM}" ]; then
     disk_size="${disk}"
   fi
 
+  # Set the default OUTPUT if not provided by user
   if [ -z "${OUTPUT}" ]; then
-    # Braille support requires SDL. Override OUTPUT if braille was requested.
-    if [ -n "${BRAILLE}" ]; then
-      OUTPUT="sdl"
-    elif [ -z "${display}" ]; then
-      OUTPUT="sdl"
-    else
-      OUTPUT="${display}"
-      display_param_check
-    fi
+    OUTPUT="sdl"
+  fi
+
+  # Braille support requires SDL. Override OUTPUT if braille was requested.
+  if [ -n "${BRAILLE}" ]; then
+    OUTPUT="sdl"
   fi
 
   if [ "${tpm}" == "on" ]; then


### PR DESCRIPTION
All the plumbing to use spice-app as the viewer seems t be in place  already. 
First, commit adds spice-app to display_param_check().

The second commit reworks how the default viewer is selected. The variable display is never set, so the else part of the if statement can never be reached. 
Also, display_param_check() is already run when parsing command arguments.
