### PR TITLE
Add multiscreen mode

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -753,6 +753,11 @@ function vm_boot() {
     ati-vga|cirrus-vga|VGA) VIDEO="${VIDEO},vgamem_mb=64";;
   esac
 
+  # Configure multiscreen if max_outputs was provided in the .conf file
+  if [ -v max_outputs ]; then
+    VIDEO="${VIDEO},max_outputs=${max_outputs}"
+  fi
+
   # Add fullscreen options
   VIDEO="${VIDEO} ${FULLSCREEN}"
 


### PR DESCRIPTION
This commit adds max_outputs parameter to the graphic device if max_outputs option was provided in the .conf file of the VM.

Example:
```
guest_os="xx"
disk_img="xx.qcow2"
max_outputs="2"
```

This option only reliably works with spice-app as the display (#472).

Other display options:
- sdl is crashing on qemu 7.0, could be an archlinux issue,
- gtk I can't find options to open 2 windows and mouse coordinates are messed up,
- spice I can't find options to open 2 windows,