### PR TITLE
add support for Linux Mint Debian Edition (LMDE)

### DIFF
--- a/quickget
+++ b/quickget
@@ -45,6 +45,7 @@ function pretty_name() {
     kdeneon)            PRETTY_NAME="KDE Neon";;
     kolibrios)          PRETTY_NAME="KolibriOS";;
     linuxmint)          PRETTY_NAME="Linux Mint";;
+    lmde)               PRETTY_NAME="Linux Mint Debian Edition";;
     mxlinux)            PRETTY_NAME="MX Linux";;
     netboot)            PRETTY_NAME="netboot.xyz";;
     netbsd)             PRETTY_NAME="NetBSD";;
@@ -177,6 +178,7 @@ function os_support() {
     kolibrios \
     kubuntu \
     linuxmint \
+    lmde \
     manjaro \
     mxlinux \
     netboot \
@@ -347,6 +349,13 @@ function releases_linuxmint(){
 
 function editions_linuxmint(){
     echo cinnamon mate xfce
+}
+
+function editions_lmde(){
+    echo cinnamon
+}
+function releases_lmde(){
+    echo 5
 }
 
 function releases_mxlinux(){
@@ -1002,6 +1011,16 @@ function get_linuxmint() {
     local HASH=""
     local ISO="linuxmint-${RELEASE}-${EDITION}-64bit.iso"
     local URL="https://mirror.bytemark.co.uk/linuxmint/stable/${RELEASE}"
+
+    HASH=$(wget -q -O- "${URL}/sha256sum.txt" | grep "${ISO}" | cut -d' ' -f1)
+    echo "${URL}/${ISO} ${HASH}"
+}
+
+function get_lmde() {
+    local EDITION="${1:-}"
+    local HASH=""
+    local ISO="lmde-${RELEASE}-${EDITION}-64bit.iso"
+    local URL="https://mirror.bytemark.co.uk/linuxmint/debian"
 
     HASH=$(wget -q -O- "${URL}/sha256sum.txt" | grep "${ISO}" | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"


### PR DESCRIPTION
requested in #482
will need another icon (or will it?) : heads-up https://github.com/quickemu-project/quickemu-icons/issues/12