### PR TITLE
Updated Linux Mint and added LMDE in Quickget

### DIFF
--- a/quickget
+++ b/quickget
@@ -45,6 +45,7 @@ function pretty_name() {
     kdeneon)            PRETTY_NAME="KDE Neon";;
     kolibrios)          PRETTY_NAME="KolibriOS";;
     linuxmint)          PRETTY_NAME="Linux Mint";;
+    lmde)               PRETTY_NAME="Linux Mint Debian Edition";;
     mxlinux)            PRETTY_NAME="MX Linux";;
     netboot)            PRETTY_NAME="netboot.xyz";;
     netbsd)             PRETTY_NAME="NetBSD";;
@@ -177,6 +178,7 @@ function os_support() {
     kolibrios \
     kubuntu \
     linuxmint \
+    lmde \
     manjaro \
     mxlinux \
     netboot \
@@ -342,11 +344,15 @@ function releases_kolibrios() {
 }
 
 function releases_linuxmint(){
-    echo 20.2
+    echo 20.3
 }
 
 function editions_linuxmint(){
     echo cinnamon mate xfce
+}
+
+function releases_lmde(){
+    echo 5
 }
 
 function releases_mxlinux(){
@@ -1002,6 +1008,16 @@ function get_linuxmint() {
     local HASH=""
     local ISO="linuxmint-${RELEASE}-${EDITION}-64bit.iso"
     local URL="https://mirror.bytemark.co.uk/linuxmint/stable/${RELEASE}"
+
+    HASH=$(wget -q -O- "${URL}/sha256sum.txt" | grep "${ISO}" | cut -d' ' -f1)
+    echo "${URL}/${ISO} ${HASH}"
+}
+
+function get_lmde() {
+    local EDITION="${1:-}"
+    local HASH=""
+    local ISO="lmde-${RELEASE}-cinnamon-64bit.iso"
+    local URL="https://mirror.bytemark.co.uk/linuxmint/debian/"
 
     HASH=$(wget -q -O- "${URL}/sha256sum.txt" | grep "${ISO}" | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"


### PR DESCRIPTION
Updated Linux Mint version to 20.3 (latest)
Added LMDE (Linux Mint Debian Edition), current version is 5