### PR TITLE
fix window 11 config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ disk_img="windows-11/disk.qcow2"
 iso="windows-11/Win11_EnglishInternational_x64.iso"
 fixed_iso="windows-11/virtio-win.iso"
 tpm="on"
+secureboot="on"
 ```
 
 -   `guest_os="windows"` instructs `quickemu` to optimise for Windows.


### PR DESCRIPTION
The default configuration for windows 11 has `secureboot="on"` in it.
The readme is updated accordingly