### PR TITLE
Pop-OS 22.04 update

### DIFF
--- a/quickget
+++ b/quickget
@@ -400,7 +400,7 @@ function releases_oraclelinux() {
 }
 
 function releases_popos() {
-    echo 20.04 21.10
+    echo 20.04 22.04
 }
 
 function editions_popos() {


### PR DESCRIPTION
Added 22.04, removed 21.10.
21.10 end-of-support is 2022-07-14.