### PR TITLE
Updates MSRs alert comment to include windows

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -629,7 +629,7 @@ function vm_boot() {
   fi
 
   if [ "${guest_os}" == "macos" ] || [ "${guest_os}" == "windows" ]; then
-    # Display MSRs alert if the guest is macOS
+    # Display MSRs alert if the guest is macOS or windows
     ignore_msrs_alert
   fi
 


### PR DESCRIPTION
As the `ignore_msrs_alert()` is called if the guest is macOS or windows, perhaps windows should also be included to the MSRs alert comment.