### PR TITLE
Remove duplicate option (usb_controller)

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1411,8 +1411,6 @@ keyboard="usb"
 keyboard_layout="en-us"
 # options: ps2, usb, tablet, virtio
 mouse="tablet"
-# options: ehci, xhci
-usb_controller="ehci"
 
 BRAILLE=""
 DELETE_DISK=0


### PR DESCRIPTION
the default for `usb_controller` is set twice in `quickemu` script.

Remove the second `usb_controller` default setting.