### PR TITLE
add support for  LTS daily-live testing for point releases

### DIFF
--- a/quickget
+++ b/quickget
@@ -485,6 +485,7 @@ function releases_ubuntu() {
         ;;
     esac
     echo ${LTS_SUPPORT} \
+        jammy-daily \
         daily-live \
         daily-canary \
         eol-4.10 \
@@ -1380,6 +1381,10 @@ function get_ubuntu() {
 
     if [[ "${RELEASE}" == "eol-"* ]]; then
         URL="https://old-releases.ubuntu.com/releases/${RELEASE/eol-/}"
+    elif [[ "${RELEASE}" == "jammy-daily" ]]; then
+        URL="https://cdimage.ubuntu.com/${OS}/jammy/daily-live/current"
+        VM_PATH="${OS}-jammy-live"
+
     elif [[ "${RELEASE}" == *"daily"* ]] || [ "${RELEASE}" == "dvd" ]; then
         URL="https://cdimage.ubuntu.com/${OS}/${RELEASE}/current"
         VM_PATH="${OS}-daily-live"


### PR DESCRIPTION
As the daily-live and daily-canary releases point to "next release" builds it was not possible easily to spin up a 22.04.1 daily test iso to help with the testing for the delayed point release. This was my attempt at a solution. It adds a "jammy-daily" release that points to the current jammy daily live isos (which were the ones being requested for testing at the time of the call) .

It might be worth adding this to the "eol-" filter to remove it from general view but add a note to the documentation.
It will be worth adding the next LTS codename in before it enters the testing cycle. 