### PR TITLE
fix for dynamically selecting debian releases

### DIFF
--- a/quickget
+++ b/quickget
@@ -263,7 +263,11 @@ function editions_centos-stream() {
 }
 
 function releases_debian() {
-    echo 10.11.0 11.2.0 11.3.0 11.4.0
+    DEBCURRENT=$(wget -q https://cdimage.debian.org/debian-cd/ -O- |grep '\.[0-9]/'|cut -d\> -f9|cut -d\/ -f1)
+    local DEBOLD=$(wget -q https://cdimage.debian.org/cdimage/archive/ -O- |grep -e '>[1-9][0-9]\.'|grep -v 'live' | cut -d\> -f9|cut -d\/ -f1 )
+
+    echo  ${DEBOLD} ${DEBCURRENT}
+    #10.11.0 10.12.0 10.13.0 11.2.0 11.3.0 11.4.0 11.5.0
 }
 
 function editions_debian() {
@@ -937,9 +941,9 @@ function get_debian() {
     local HASH=""
     local ISO="debian-live-${RELEASE}-amd64-${EDITION}.iso"
     local URL=""
-
-    case ${RELEASE} in
-      11.4.0) URL="https://cdimage.debian.org/debian-cd/${RELEASE}-live/amd64/iso-hybrid";;
+    DEBCURRENT=$(wget -q https://cdimage.debian.org/debian-cd/ -O- |grep '\.[0-9]/'|cut -d\> -f9|cut -d\/ -f1)
+   case ${RELEASE} in
+      "${DEBCURRENT}") URL="https://cdimage.debian.org/debian-cd/${RELEASE}-live/amd64/iso-hybrid";;
       *)      URL="https://cdimage.debian.org/cdimage/archive/${RELEASE}-live/amd64/iso-hybrid/";;
     esac
 

--- a/quickget
+++ b/quickget
@@ -988,7 +988,7 @@ function get_devuan() {
 
     case ${RELEASE} in
       beowulf) ISO="devuan_${RELEASE}_3.1.1_amd64_desktop-live.iso";;
-      chimaera) ISO="devuan_${RELEASE}_4.0.0_amd64_desktop-live.iso";;
+      chimaera) ISO="devuan_${RELEASE}_4.0.2_amd64_desktop-live.iso";;
     esac
     HASH=$(wget -q -O- "${URL}/SHASUMS.txt" | grep "${ISO}" | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"

--- a/quickget
+++ b/quickget
@@ -275,7 +275,7 @@ function editions_debian() {
 }
 
 function releases_deepin() {
-    echo 20 20.1 20.2 20.2.1 20.2.2 20.2.3 20.2.4 20.3 20.4 20.5
+    echo 20 20.1 20.2 20.2.1 20.2.2 20.2.3 20.2.4 20.3 20.4 20.5 20.6 20.7
 }
 
 function releases_devuan() {

--- a/quickget
+++ b/quickget
@@ -267,7 +267,6 @@ function releases_debian() {
     local DEBOLD=$(wget -q https://cdimage.debian.org/cdimage/archive/ -O- |grep -e '>[1-9][0-9]\.'|grep -v 'live' | cut -d\> -f9|cut -d\/ -f1 )
 
     echo  ${DEBOLD} ${DEBCURRENT}
-    #10.11.0 10.12.0 10.13.0 11.2.0 11.3.0 11.4.0 11.5.0
 }
 
 function editions_debian() {

--- a/quickget
+++ b/quickget
@@ -386,7 +386,7 @@ function releases_lmde(){
 }
 
 function releases_mxlinux(){
-    echo 21.1
+    echo 21.2
 }
 
 function editions_mxlinux(){


### PR DESCRIPTION
This should dynamically pick up debian releases for a while.
closes #546 