### PR TITLE
Updated 4.2 Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,9 +323,9 @@ supported.
             -   Select `QEMU HARDDISK Media` (\~103.08GB) from the list
                 and click **Erase**.
     -   Enter a `Name:` for the disk
-    -   If your installing macOS Mojave or later (Catalina, Big Sur,
-        and Monterey), choose any of the APFS options as the filesystem.
-        MacOS Extended may not work.
+        -   If you are installing macOS Mojave or later (Catalina, Big
+            Sur, and Monterey), choose any of the APFS options as the
+            filesystem. MacOS Extended may not work.
     -   Click **Erase**.
     -   Click **Done**.
     -   Close Disk Utility

--- a/docs/quickemu.1
+++ b/docs/quickemu.1
@@ -14,7 +14,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "QUICKEMU" "1" "September 19, 2022" "quickemu" "Quickemu User Manual"
+.TH "QUICKEMU" "1" "September 22, 2022" "quickemu" "Quickemu User Manual"
 .hy
 .SH NAME
 .PP
@@ -486,7 +486,15 @@ click \f[B]Erase\f[R].
 .RE
 .RE
 .IP \[bu] 2
-Enter a \f[V]Name:\f[R] for the disk and click \f[B]Erase\f[R].
+Enter a \f[V]Name:\f[R] for the disk
+.RS 2
+.IP \[bu] 2
+If you are installing macOS Mojave or later (Catalina, Big Sur, and
+Monterey), choose any of the APFS options as the filesystem.
+MacOS Extended may not work.
+.RE
+.IP \[bu] 2
+Click \f[B]Erase\f[R].
 .IP \[bu] 2
 Click \f[B]Done\f[R].
 .IP \[bu] 2

--- a/docs/quickemu.1.md
+++ b/docs/quickemu.1.md
@@ -1,6 +1,6 @@
 ---
 author: Martin Wimpress
-date: September 19, 2022
+date: September 22, 2022
 footer: quickemu
 header: Quickemu User Manual
 section: 1
@@ -346,7 +346,11 @@ supported.
         -   On macOS Mojave and High Sierra
             -   Select `QEMU HARDDISK Media` (\~103.08GB) from the list
                 and click **Erase**.
-    -   Enter a `Name:` for the disk and click **Erase**.
+    -   Enter a `Name:` for the disk
+        -   If you are installing macOS Mojave or later (Catalina, Big
+            Sur, and Monterey), choose any of the APFS options as the
+            filesystem. MacOS Extended may not work.
+    -   Click **Erase**.
     -   Click **Done**.
     -   Close Disk Utility
 -   From **macOS Utilities**

--- a/docs/quickemu_conf.1
+++ b/docs/quickemu_conf.1
@@ -14,7 +14,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "QUICKEMU_CONF" "1" "September 19, 2022" "quickemu_conf" "Quickemu Configuration Manual"
+.TH "QUICKEMU_CONF" "1" "September 22, 2022" "quickemu_conf" "Quickemu Configuration Manual"
 .hy
 .SH NAME
 .PP

--- a/docs/quickemu_conf.1.md
+++ b/docs/quickemu_conf.1.md
@@ -1,6 +1,6 @@
 ---
 author: Martin Wimpress
-date: September 19, 2022
+date: September 22, 2022
 footer: quickemu_conf
 header: Quickemu Configuration Manual
 section: 1

--- a/docs/quickget.1
+++ b/docs/quickget.1
@@ -14,7 +14,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "QUICKGET" "1" "September 19, 2022" "quickget" "Quickget User Manual"
+.TH "QUICKGET" "1" "September 22, 2022" "quickget" "Quickget User Manual"
 .hy
 .SH NAME
 .PP
@@ -268,7 +268,15 @@ click \f[B]Erase\f[R].
 .RE
 .RE
 .IP \[bu] 2
-Enter a \f[V]Name:\f[R] for the disk and click \f[B]Erase\f[R].
+Enter a \f[V]Name:\f[R] for the disk
+.RS 2
+.IP \[bu] 2
+If you are installing macOS Mojave or later (Catalina, Big Sur, and
+Monterey), choose any of the APFS options as the filesystem.
+MacOS Extended may not work.
+.RE
+.IP \[bu] 2
+Click \f[B]Erase\f[R].
 .IP \[bu] 2
 Click \f[B]Done\f[R].
 .IP \[bu] 2

--- a/docs/quickget.1.md
+++ b/docs/quickget.1.md
@@ -1,6 +1,6 @@
 ---
 author: Martin Wimpress
-date: September 19, 2022
+date: September 22, 2022
 footer: quickget
 header: Quickget User Manual
 section: 1
@@ -178,7 +178,11 @@ supported.
         -   On macOS Mojave and High Sierra
             -   Select `QEMU HARDDISK Media` (\~103.08GB) from the list
                 and click **Erase**.
-    -   Enter a `Name:` for the disk and click **Erase**.
+    -   Enter a `Name:` for the disk
+        -   If you are installing macOS Mojave or later (Catalina, Big
+            Sur, and Monterey), choose any of the APFS options as the
+            filesystem. MacOS Extended may not work.
+    -   Click **Erase**.
     -   Click **Done**.
     -   Close Disk Utility
 -   From **macOS Utilities**


### PR DESCRIPTION
Added later and missed documentation updates in 4.2 to builder and regenerated docs.

Include change from PR 548
 - replace shallow with unblobby clone Catch up with macOS note from merged PR 559
 - note on macOS filesystems

Co-authored-by: giladwo <giladwo@users.noreply.github.com>
Co-authored-by:  tinsami1 <tinsami1@users.noreply.github.com>