### PR TITLE
Added check if file /etc/modprobe.d/kvm-quickemu.conf exists in function ignore_msrs_always()

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -10,7 +10,7 @@ function ignore_msrs_always() {
   # Make sure the host has /etc/modprobe.d
   if [ -d /etc/modprobe.d ]; then
     # Skip if ignore_msrs is already enabled, assumes initramfs has been rebuilt
-    if grep -lq 'ignore_msrs=Y' /etc/modprobe.d/kvm-quickemu.conf >/dev/null 2>&1; then
+    if [ ! -f /etc/modprobe.d/kvm-quickemu.conf ] || grep -lq 'ignore_msrs=Y' /etc/modprobe.d/kvm-quickemu.conf >/dev/null 2>&1; then
       echo "options kvm ignore_msrs=Y" | sudo tee /etc/modprobe.d/kvm-quickemu.conf
       sudo update-initramfs -k all -u
     fi


### PR DESCRIPTION
Function does nothing if file doesn't exists since grep fails.  Not sure if this is the intended behavior since the settings won't apply if the file does not exists.  So I added the file existence check condition.