### PR TITLE
OpenBSD: Fix download of versions 6.8 & 6.9

### DIFF
--- a/quickget
+++ b/quickget
@@ -1316,7 +1316,7 @@ function get_nixos() {
 function get_openbsd() {
     local HASH=""
     local ISO="install${RELEASE//\./}.iso"
-    local URL="https://cdn.openbsd.org/pub/OpenBSD/${RELEASE}/amd64"
+    local URL="https://mirror.leaseweb.com/pub/OpenBSD/${RELEASE}/amd64"
     HASH=$(wget -q -O- "${URL}/SHA256" | grep "${ISO}" | cut -d' ' -f4)
     echo "${URL}/${ISO} ${HASH}"
 }


### PR DESCRIPTION
The CDN we were using in QuickGet only carries version 7.0 and 7.1. By switching to a different CDN provided for the OpenBSD Community (listed on https://www.openbsd.org/ftp.html) we can regain access to version 6.8 and 6.9.