### PR TITLE
Switch to disk devices that support TRIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,8 +351,6 @@ macos_release="catalina"
     particular macOS release.
     -   For example VirtIO Network and Memory Ballooning are available
         in Big Sur and newer, but not previous releases.
-    -   And VirtIO Block Media (disks) are supported/stable in Catalina
-        and newer.
 
 ### macOS compatibility
 
@@ -370,9 +368,6 @@ There are some considerations when running macOS via Quickemu.
 -   Optimised by default, but no GPU acceleration is available.
     -   Host CPU vendor is detected and guest CPU is optimised
         accordingly.
-    -   [VirtIO Block
-        Media](https://www.kraxel.org/blog/2019/06/macos-qemu-guest/) is
-        used for the system disk where supported.
     -   [VirtIO `usb-tablet`](http://philjordan.eu/osx-virt/) is used
         for the mouse.
     -   VirtIO Network (`virtio-net`) is supported and enabled on macOS

--- a/README.md
+++ b/README.md
@@ -332,6 +332,28 @@ supported.
         **macOS Installer**
     -   On the subsequent reboots use cursor keys and enter key to
         select the disk you named
+-   Once you have finished installing macOS you will be presented with an the out-of-the-box first-start wizard to configure various options and set up your username and password
+-   OPTIONAL: After you have concluded the out-of-the-box wizard, you may want to enable the TRIM feature that the computer industry created for SSD disks. This feature in our macOS installation will allow QuickEmu to compact (shrink) your macOS disk image whenever you delete files inside the Virtual Machine. Without this step your macOS disk image will only ever get larger and will not shrink even when you delete lots of data inside macOS.
+    -   To enable TRIM, open the Terminal application and type the following command followed by pressing <kbd>enter</kbd> to tell macos to use the TRIM command on the hard disk when files are deleted:
+        ```bash
+        sudo trimforce enable
+        ```
+
+        You will be prompted to enter your account's password to gain the privilege needed. Once you've entered your password and pressed <kbd>enter</kbd> the command will request confirmation in the form of two questions that require you to type <kbd>y</kbd> (for a "yes" response) followed by <kbd>enter</kbd> to confirm. If you press <kbd>enter</kbd> without first typing <kbd>y</kbd> the system will consider that a negative response as though you said "no":
+
+        ```plain
+        IMPORTANT NOTICE: This tool force-enables TRIM for all relevant attached devices, even though such devices may not have been validated for data integrity while using TRIM. Use of this tool to enable TRIM may result in unintended data loss or data corruption. It should not be used in a commercial operating environment or with important data. Before using this tool, you should back up all of your data and regularly back up data while TRIM is enabled. This tool is provided on an "as is" basis. APPLE MAKES NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION THE IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, REGARDING THIS TOOL OR ITS USE ALONE OR IN COMBINATION WITH YOUR DEVICES, SYSTEMS, OR SERVICES. BY USING THIS TOOL TO ENABLE TRIM, YOU AGREE THAT, TO THE EXTENT PERMITTED BY APPLICABLE LAW, USE OF THE TOOL IS AT YOUR SOLE RISK AND THAT THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY AND EFFORT IS WITH YOU.
+        Are you sure you with to proceed (y/N)?
+        ```
+
+        And a second confirmation once you've confirmed the previous one:
+
+        ```plain
+        Your system will immediately reboot when this is complete.
+        Is this OK (y/N)?
+        ```
+
+        As the last message states, your system will automatically reboot as soon as the command completes.
 
 The default macOS configuration looks like this:
 

--- a/README.md
+++ b/README.md
@@ -316,12 +316,8 @@ supported.
 -   Use cursor keys and enter key to select the **macOS Base System**
 -   From **macOS Utilities**
     -   Click **Disk Utility** and **Continue**
-        -   On macOS Catalina, Big Sur & Monterey
-            -   Select `Apple Inc. VirtIO Block Media` from the list and
-                click **Erase**.
-        -   On macOS Mojave and High Sierra
-            -   Select `QEMU HARDDISK Media` (\~103.08GB) from the list
-                and click **Erase**.
+        -   Select `QEMU HARDDISK Media` (\~103.08GB) from the list
+            and click **Erase**.
     -   Enter a `Name:` for the disk
         -   If you are installing macOS Mojave or later (Catalina, Big
             Sur, and Monterey), choose any of the APFS options as the

--- a/quickemu
+++ b/quickemu
@@ -542,13 +542,13 @@ function vm_boot() {
       case ${macos_release} in
         catalina)
           BALLOON=""
-          MAC_DISK_DEV="virtio-blk-pci"
+          MAC_DISK_DEV="ide-hd,bus=ahci.2"
           NET_DEVICE="vmxnet3"
           USB_HOST_PASSTHROUGH_CONTROLLER="usb-ehci"
           ;;
         big-sur|monterey|ventura)
           BALLOON="-device virtio-balloon"
-          MAC_DISK_DEV="virtio-blk-pci"
+          MAC_DISK_DEV="ide-hd,bus=ahci.2"
           NET_DEVICE="virtio-net"
           USB_HOST_PASSTHROUGH_CONTROLLER="nec-usb-xhci"
           GUEST_TWEAKS="${GUEST_TWEAKS} -global nec-usb-xhci.msi=off"
@@ -1071,18 +1071,19 @@ function vm_boot() {
   if [ "${guest_os}" == "macos" ]; then
     # shellcheck disable=SC2054
     args+=(-device ahci,id=ahci
-           -device ide-hd,bus=ahci.0,drive=BootLoader,bootindex=0
-           -drive id=BootLoader,if=none,format=qcow2,file="${MAC_BOOTLOADER}")
+           -device ide-hd,bus=ahci.0,drive=BootLoader,bootindex=0,rotation_rate=1
+           -drive id=BootLoader,if=none,format=qcow2,discard=unmap,file="${MAC_BOOTLOADER}")
 
     if [ -n "${img}" ]; then
       # shellcheck disable=SC2054
-      args+=(-device ide-hd,bus=ahci.1,drive=RecoveryImage
-             -drive id=RecoveryImage,if=none,format=raw,file="${img}")
+      args+=(-device ide-hd,bus=ahci.1,drive=RecoveryImage,rotation_rate=1
+             -drive id=RecoveryImage,if=none,format=raw,discard=unmap,file="${img}")
     fi
 
     # shellcheck disable=SC2054,SC2206
-    args+=(-device ${MAC_DISK_DEV},drive=SystemDisk
-           -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+    args+=(-device ${MAC_DISK_DEV},drive=SystemDisk,rotation_rate=1
+           -drive id=SystemDisk,if=none,format=qcow2,discard=unmap,file="${disk_img}" ${STATUS_QUO})
+
   elif [ "${guest_os}" == "kolibrios" ]; then
     # shellcheck disable=SC2054,SC2206
     args+=(-device ahci,id=ahci

--- a/quickemu
+++ b/quickemu
@@ -1103,8 +1103,9 @@ function vm_boot() {
 
   else
     # shellcheck disable=SC2054,SC2206
-    args+=(-device virtio-blk-pci,drive=SystemDisk
-           -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+    args+=(-device virtio-scsi-pci,id=scsi0
+          -device scsi-hd,drive=SystemDisk,bus=scsi0.0,lun=0,rotation_rate=1
+          -drive id=SystemDisk,if=none,format=qcow2,discard=unmap,file="${disk_img}" ${STATUS_QUO})
   fi
 
   # https://wiki.qemu.org/Documentation/9psetup


### PR DESCRIPTION
Currently, the virtio specification does not include provision for the TRIM (aka DISCARD) command that allows a guest operating system to signal the disk hardware that blocks have become unused so that the underlying device may clear the physical data.

The TRIM/DISCARD command was introduced for SSD disks as an extension to the AHCI specification that is used in SATA systems.

With Virtual Machines we can use this command to tell QEMU's Qcow2 driver to reclaim unused space in the disk image. This ensures the disk image file is kept to the smallest size possible where without the TRIM/DISCARD command it grows to it's maximum configured size and never shrinks again when data is deleted.