### PR TITLE
update links for Void

### DIFF
--- a/quickget
+++ b/quickget
@@ -1486,8 +1486,8 @@ function get_void() {
 
     DATE=$(wget -q -O- "${URL}/sha256sum.txt" | head -n1 | cut -d'.' -f1 | cut -d'-' -f4)
     case ${EDITION} in
-        glibc)      ISO="void-live-x86_64-${DATE}.iso";;
-        musl)       ISO="void-live-x86_64-musl-${DATE}.iso";;
+        glibc)      ISO="void-live-x86_64-${DATE}-base.iso";;
+        musl)       ISO="void-live-x86_64-musl-${DATE}-base.iso";;
         xfce-glibc) ISO="void-live-x86_64-${DATE}-xfce.iso";;
         xfce-musl)  ISO="void-live-x86_64-musl-${DATE}-xfce.iso";;
     esac


### PR DESCRIPTION
Void use new format for the base live image iso:

- https://repo-default.voidlinux.org/live/current/void-live-x86_64-20221001-base.iso
- https://repo-default.voidlinux.org/live/current/void-live-x86_64-musl-20221001-base.iso