### PR TITLE
3 commits:  Fix  Windows boot,  fix --extra_args,  add  human readable --show_args

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,7 +770,7 @@ You can also pass optional parameters
   --keyboard_layout <layout>        : Set keyboard layout.
   --mouse <type>                    : Set mouse. @Options: 'tablet' (default), 'ps2', 'usb', 'virtio'
   --usb-controller <type>           : Set usb-controller. @Options: 'ehci' (default), 'xhci', 'none'
-  --extra_args <arguments>          : Pass additional arguments to qemu
+  --extra_args|--xa <arguments>     : Pass additional arguments to qemu. 1 per element eg --xa '-device' --xa 'tpm-tis,tpmdev=tpm0'
   --version                         : Print version
 
 ```

--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ You can also pass optional parameters
   --mouse <type>                    : Set mouse. @Options: 'tablet' (default), 'ps2', 'usb', 'virtio'
   --usb-controller <type>           : Set usb-controller. @Options: 'ehci' (default), 'xhci', 'none'
   --extra_args|--xa <arguments>     : Pass additional arguments to qemu. 1 per element eg --xa '-device' --xa 'tpm-tis,tpmdev=tpm0'
+  --show_args                       : Show all the compiled qemu & swmtp arguments as a human readable list, before starting VM
   --version                         : Print version
 
 ```

--- a/quickemu
+++ b/quickemu
@@ -1102,6 +1102,11 @@ function vm_boot() {
     # shellcheck disable=SC2054,SC2206
     args+=(-drive if=ide,index=0,media=disk,file="${disk_img}")
 
+  elif [ "${guest_os}" == "windows" ]; then
+  # shellcheck disable=SC2054,SC2206
+  args+=(-device virtio-blk-pci,drive=SystemDisk
+        -drive id=SystemDisk,if=none,format=qcow2,discard=unmap,file="${disk_img}" ${STATUS_QUO})
+
   else
     # shellcheck disable=SC2054,SC2206
     args+=(-device virtio-scsi-pci,id=scsi0

--- a/quickemu
+++ b/quickemu
@@ -1332,7 +1332,7 @@ function usage() {
   echo "  --keyboard_layout <layout>        : Set keyboard layout."
   echo "  --mouse <type>                    : Set mouse. @Options: 'tablet' (default), 'ps2', 'usb', 'virtio'"
   echo "  --usb-controller <type>           : Set usb-controller. @Options: 'ehci' (default), 'xhci', 'none'"
-  echo "  --extra_args <arguments>          : Pass additional arguments to qemu"
+  echo "  --extra_args|--xa <arguments>     : Pass additional arguments to qemu. 1 per element eg --xa '-device' --xa 'tpm-tis,tpmdev=tpm0'"
   echo "  --version                         : Print version"
   exit 1
 }
@@ -1634,10 +1634,11 @@ else
             USB_CONTROLLER="${2}"
             shift;
             shift;;
-          -extra_args|--extra_args)
-            EXTRA_ARGS="${2}"
-            shift;
-            shift;;
+          -extra_args|--extra_args|--xa)
+            shift
+            if [[ ! $EXTRA_ARGS ]]; then EXTRA_ARGS="$1" 
+            else EXTRA_ARGS+=" $1" ; fi
+            shift ;;
           -version|--version)
             echo "${VERSION}"
             exit;;

--- a/quickemu
+++ b/quickemu
@@ -1226,6 +1226,33 @@ function vm_boot() {
   SHELL_ARGS="${SHELL_ARGS//)/\\)}"
   SHELL_ARGS="${SHELL_ARGS//Quickemu Project/\"Quickemu Project\"}"
 
+  # Show all the compiled qemu & swmtp arguments as a human readable list
+
+  QemuArgsFile="${VMDIR}/QemuArgsList.txt"
+
+  printf "\n\n  Present Working Directory:  %s"  "$(pwd)" > "$QemuArgsFile"
+  printf "\n\n  Qemu:  %s\n" "$QEMU" >> "$QemuArgsFile"
+
+  for a in "${args[@]}"; do
+    if [[ "$a" == -dev* ]]; then printf "\n\n  %s" "$a" >> "$QemuArgsFile"
+    elif [[ "$a" == -* ]]; then printf "\n  %s" "$a" >> "$QemuArgsFile" 
+    else printf " %s" "$a" >> "$QemuArgsFile"
+    fi
+  done
+
+  if [[ $tpm == "on" ]]; then 
+    printf "\n\n\n  Secure Boot:  %s \n\n  %s " "$SWTPM" "${tpm_args[*]}" >> "$QemuArgsFile"
+  else    
+    printf "\n\n\n  Secure Boot:  Not Set" >> "$QemuArgsFile"
+  fi
+    printf "\n\n\n"  >> "$QemuArgsFile"
+    
+  if [[ $ShowQemuArgs ]]; then
+    cat "$QemuArgsFile"
+    read -rp "  [enter] to continue, ctrl-c to quit >  "
+    printf "\n\n"
+  fi
+
   if [ ${VM_UP} -eq 0 ]; then
     # Enable grab-on-hover for SDL: https://github.com/quickemu-project/quickemu/issues/541
     case "${OUTPUT}" in
@@ -1333,6 +1360,7 @@ function usage() {
   echo "  --mouse <type>                    : Set mouse. @Options: 'tablet' (default), 'ps2', 'usb', 'virtio'"
   echo "  --usb-controller <type>           : Set usb-controller. @Options: 'ehci' (default), 'xhci', 'none'"
   echo "  --extra_args|--xa <arguments>     : Pass additional arguments to qemu. 1 per element eg --xa '-device' --xa 'tpm-tis,tpmdev=tpm0'"
+  echo "  --show_args                       : Show all the compiled qemu & swmtp arguments as a human readable list, before starting VM"
   echo "  --version                         : Print version"
   exit 1
 }
@@ -1639,6 +1667,9 @@ else
             if [[ ! $EXTRA_ARGS ]]; then EXTRA_ARGS="$1" 
             else EXTRA_ARGS+=" $1" ; fi
             shift ;;
+          -show_args|--show_args|--show-qemu-args)
+            ShowQemuArgs=1
+            shift;;
           -version|--version)
             echo "${VERSION}"
             exit;;


### PR DESCRIPTION
The multipart PR #588  now separated into bite size pieces.

GitHub seems to want to list this as 1 request but with 3 separate commits:

1.  Windows 10 VM won't launch after upgrade from 4.3 to 4.4

This fix works and is needed.   The real issues, highlighted in  my comments  at #572, don't get addressed by this fix.  But it does kick the can down the road for a while ....

During the examining of  the Windows boot args and sorting the above fix:

2.   --extra_args \-   I found that a fix was needed so multiple args could be added.  See my comments attached to second the commit.

3.   --show_args \-  In  order to further examine the args output, I wrote a routine that would unpack the args array into clear human readable format that could be checked both before starting the actual boot sequence and afterwards.   This commit  makes error tracing much easier && allows a check to be made on the formatting of the --extra_args 