### PR TITLE
use long hv-* attributes for qemu 6.0.0

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -568,7 +568,11 @@ function vm_boot() {
       fi
       ;;
     windows)
-      CPU="-cpu host,kvm=on,+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
+      if [ "${QEMU_VER_SHORT}" -gt 60 ]; then
+        CPU="-cpu host,kvm=on,+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
+      else
+        CPU="-cpu host,kvm=on,+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies,kvm_pv_unhalt,hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
+      fi
       if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
         CPU="${CPU},topoext"
       fi


### PR DESCRIPTION
Fix for issue https://github.com/quickemu-project/quickemu/issues/594 that introduced by the commit https://github.com/quickemu-project/quickemu/commit/ddbbc23d3447ceb1503bf549a000e0cace5cc723