### PR TITLE
Fix Pop!_OS install

### DIFF
--- a/quickget
+++ b/quickget
@@ -779,7 +779,7 @@ EOF
 
         # OS specific tweaks
         case ${OS} in
-          alma|centos-stream|oraclelinux|rockylinux)
+          alma|centos-stream|oraclelinux|popos|rockylinux)
             echo "disk_size=\"32G\"" >> "${CONF_FILE}";;
           batocera)
             echo "disk_size=\"8G\"" >> "${CONF_FILE}";;


### PR DESCRIPTION
Pop!_OS 22.04 fails to install with 16G disk_size. With 32G it installs successfully.