### PR TITLE
Correct basic error to get to downloading isos

### DIFF
--- a/quickget
+++ b/quickget
@@ -839,9 +839,10 @@ EOF
           truenas-scale|truenas-core)
             echo
             echo "boot=\"legacy\"" >> "${CONF_FILE}"
-            echo "bootdrive_size=\"5G\"" >> "${CONF_FILE}" # boot drive
-            echo "1stdrive_size=\"20G\"" >> "${CONF_FILE}" # for testing
-            echo "2nddrive_size=\"20G\"" >> "${CONF_FILE}" # again, for testing
+           # the rest is non-functional
+           # echo "bootdrive_size=\"5G\"" >> "${CONF_FILE}" # boot drive
+           # echo "1stdrive_size=\"20G\"" >> "${CONF_FILE}" # for testing
+           # echo "2nddrive_size=\"20G\"" >> "${CONF_FILE}" # again, for testing
             ;;
           zorin)
             case  ${EDITION} in

--- a/quickget
+++ b/quickget
@@ -61,6 +61,8 @@ function pretty_name() {
     popos)              PRETTY_NAME="Pop!_OS";;
     reactos)            PRETTY_NAME="ReactOS";;
     rockylinux)         PRETTY_NAME="Rocky Linux";;
+    truenas-core)       PRETTY_NAME="TrueNAS Core";;
+    truenas-scale)      PRETTY_NAME="TrueNAS Scale";;
     ubuntu-budgie)      PRETTY_NAME="Ubuntu Budgie";;
     ubuntukylin)       PRETTY_NAME="Ubuntu Kylin";;
     ubuntu-mate)        PRETTY_NAME="Ubuntu MATE";;
@@ -68,7 +70,6 @@ function pretty_name() {
     ubuntu-unity)       PRETTY_NAME="Ubuntu Unity";;
     void)               PRETTY_NAME="Void Linux";;
     zorin)              PRETTY_NAME="Zorin OS";;
-    truenas)            PRETTY_NAME="TrueNAS";;
     *)                  PRETTY_NAME="${SIMPLE_NAME^}";;
   esac
   echo "${PRETTY_NAME}"
@@ -207,7 +208,8 @@ function os_support() {
     slackware \
     solus \
     tails \
-    truenas \
+    truenas-core \
+    truenas-scale \
     ubuntu \
     ubuntu-budgie \
     ubuntukylin \
@@ -497,12 +499,19 @@ function releases_tails() {
     echo stable
 }
 
-function editions_truenas() {
-    echo core scale # enterprise is proprietary and paid
+function releases_truenas() {
+  if [[ $OS == truenas ]] ; then
+    echo "ERROR! The supported TrueNAS OS values are truenas-core or truenas-scale"
+    exit 1;
+  fi
+  }
+
+function releases_truenas-core() {
+   echo 12.0 13.0
 }
 
-function releases_truenas() {
-    echo 22.12 13.0
+function releases_truenas-scale() {
+    echo 22.02 22.12
 }
 
 function releases_ubuntu() {
@@ -774,7 +783,7 @@ function make_vm_config() {
         reactos)
             GUEST="reactos"
             IMAGE_TYPE="iso";;
-        truenas)
+        truenas*)
             GUEST="truenas"
             IMAGE_TYPE="iso";;
         windows)
@@ -827,7 +836,7 @@ EOF
             echo "disk_size=\"2G\"" >> "${CONF_FILE}"
             echo "ram=\"128M\"" >> "${CONF_FILE}"
             ;;
-          truenas)
+          truenas-scale|truenas-core)
             echo
             echo "boot=\"legacy\"" >> "${CONF_FILE}"
             echo "bootdrive_size=\"5G\"" >> "${CONF_FILE}" # boot drive
@@ -1485,15 +1494,27 @@ function get_tails() {
     echo "${URL} ${HASH}"
 }
 
-function get_truenas() {
+function get_truenas-scale() {
     local ISO=""
     local URL=""
 
-    if [ "${RELEASE}" == "13.0" ] && [ "${OS}" == "CORE" ]; then
-        URL="$(wget https://download.freenas.org/13.0/STABLE/U3.1/x64/${OS}.iso)"
-    elif [ "${RELEASE}" == "22.12" ] && [ "${OS}" == "SCALE" ]; then
-        URL="$(https://download.truenas.com/TrueNAS-SCALE-Bluefin/${RELEASE}.0/TrueNAS-${OS}-22.12.0.iso)"
-    fi
+    local DLINFO="https://www.truenas.com/download-truenas-scale/"
+
+    URL=$(wget -q ${DLINFO} -O- | grep -o "\"https://.*${RELEASE}.*\.iso\""|cut -d\" -f2)
+    HASH=$(wget -q ${URL}.sha256 -O- | cut -d' ' -f1 )
+
+    echo "${URL} ${HASH}"
+}
+
+function get_truenas-core() {
+    local ISO=""
+    local URL=""
+
+    local DLINFO="https://www.truenas.com/download-truenas-core/"
+    URL=$(wget -q ${DLINFO} -O- | grep -o "\"https://.*${RELEASE}.*\.iso\""|cut -d\" -f2)
+    HASH=$(wget -q ${URL}.sha256 -O- | cut -d' ' -f1)
+
+    echo "${URL} ${HASH}"
 }
 
 function get_ubuntu() {
@@ -2048,6 +2069,7 @@ if [ -n "${2}" ]; then
                 exit 1;
             fi
         fi
+
 
         VM_PATH="${OS}-${RELEASE}-${EDITION}"
         validate_release "releases_${OS}"


### PR DESCRIPTION
This gets to download and run the installers with a 32G disk.
The 1st/2nd disk and boot disk nonsense in the conf gets ignored.
I'll  remove it when I get a moment.