### PR TITLE
Remove old release from elementary - they only present current release

### DIFF
--- a/quickget
+++ b/quickget
@@ -300,7 +300,7 @@ function releases_dragonflybsd() {
 }
 
 function releases_elementary() {
-    echo 6.1 7.0
+    echo 7.0
 }
 
 function releases_endeavouros() {


### PR DESCRIPTION
#625 left 6.1 in but they have removed that from their download page so we can no longer get it
see #629 
