### PR TITLE
Updates for 23.04 testing

### DIFF
--- a/quickget
+++ b/quickget
@@ -1558,7 +1558,7 @@ function get_ubuntu() {
 
     elif [[ "${RELEASE}" == *"daily"* ]] || [ "${RELEASE}" == "dvd" ]; then
         URL="https://cdimage.ubuntu.com/${OS}/${RELEASE}/current"
-        VM_PATH="${OS}-daily-live"
+        VM_PATH="${OS}-${RELEASE}"
     elif [ "${OS}" == "ubuntu" ]; then
         URL="https://releases.ubuntu.com/${RELEASE}"
     else

--- a/quickget
+++ b/quickget
@@ -138,7 +138,7 @@ function list_csv() {
     for RELEASE in $("releases_${FUNC}"); do
       if [ "${OS}" == "macos" ]; then
         DOWNLOADER="macrecovery"
-      elif [ "${OS}" == "ubuntu" ] && [ "${RELEASE}" == "canary" ] && [ ${HAS_ZSYNC} -eq 1 ]; then
+      elif [ "${OS}" == "ubuntu" ] && [ "${RELEASE}" == "daily-canary" ] && [ ${HAS_ZSYNC} -eq 1 ]; then
         DOWNLOADER="zsync"
       elif [[ "${OS}" == *"ubuntu"* ]] && [ "${RELEASE}" == "devel" ] && [ ${HAS_ZSYNC} -eq 1 ]; then
         DOWNLOADER="zsync"

--- a/quickget
+++ b/quickget
@@ -879,6 +879,10 @@ EOF
             ;;
         esac
 
+        if [ "${OS}" == "ubuntu" ] && [[ ${RELEASE} == *"daily"*  ]]; then
+        # wont install  lobster testing with less than 18GB
+          echo "disk_size=\"32G\"" >> "${CONF_FILE}"
+        fi
         # Enable TPM for Windows 11
         if [ "${OS}" == "windows" ] && [ "${RELEASE}" -ge 11 ]; then
             echo "tpm=\"on\"" >> "${CONF_FILE}"

--- a/quickget
+++ b/quickget
@@ -140,6 +140,8 @@ function list_csv() {
         DOWNLOADER="macrecovery"
       elif [ "${OS}" == "ubuntu" ] && [ "${RELEASE}" == "daily-canary" ] && [ ${HAS_ZSYNC} -eq 1 ]; then
         DOWNLOADER="zsync"
+      elif [ "${OS}" == "ubuntu" ] && [ "${RELEASE}" == "daily-legacy" ] && [ ${HAS_ZSYNC} -eq 1 ]; then
+        DOWNLOADER="zsync"
       elif [[ "${OS}" == *"ubuntu"* ]] && [ "${RELEASE}" == "devel" ] && [ ${HAS_ZSYNC} -eq 1 ]; then
         DOWNLOADER="zsync"
       else
@@ -554,11 +556,12 @@ function releases_ubuntu() {
              ;
 
     else
+              # daily-canary \ # seems to have vanished, to be replaced by daily-legacy
         echo ${LTS_SUPPORT} \
             ${INTERIM_SUPPORT} \
             jammy-daily \
             daily-live \
-            daily-canary \
+            daily-legacy \
             eol-4.10 \
             eol-5.04 \
             eol-5.10 \
@@ -1548,6 +1551,9 @@ function get_ubuntu() {
     elif [ "${RELEASE}" == "daily-canary" ] && [ "${OS}" != "ubuntu" ]; then
         # daily-canary is only available for Ubuntu, switch flavours to daily-live
         RELEASE="daily-live"
+    elif [ "${RELEASE}" == "daily-legacy" ] && [ "${OS}" != "ubuntu" ]; then
+        # daily-legacy is only available for Ubuntu, switch flavours to daily-live
+        RELEASE="daily-live"
     fi
 
     if [[ "${RELEASE}" == "eol-"* ]]; then
@@ -1555,7 +1561,9 @@ function get_ubuntu() {
     elif [[ "${RELEASE}" == "jammy-daily" ]]; then
         URL="https://cdimage.ubuntu.com/${OS}/jammy/daily-live/current"
         VM_PATH="${OS}-jammy-live"
-
+    elif [[ "${RELEASE}" == "daily-legacy" ]]; then
+        URL="https://cdimage.ubuntu.com/${RELEASE}/current"
+        VM_PATH="${OS}-${RELEASE}"
     elif [[ "${RELEASE}" == *"daily"* ]] || [ "${RELEASE}" == "dvd" ]; then
         URL="https://cdimage.ubuntu.com/${OS}/${RELEASE}/current"
         VM_PATH="${OS}-${RELEASE}"


### PR DESCRIPTION
The dailies now demand more space to install, plus `Ubuntu` also has a `daily-legacy` test candidate with altered location on `cdimage` and is seems to have replaced `daily-canary`.