### PR TITLE
Add NetBSD 9.3 release

### DIFF
--- a/quickget
+++ b/quickget
@@ -439,7 +439,7 @@ function releases_netboot() {
 }
 
 function releases_netbsd() {
-    echo 9.0 9.1 9.2
+    echo 9.0 9.1 9.2 9.3
 }
 
 function releases_nixos(){


### PR DESCRIPTION
NetBSD 9.3 is available now as of August 4, 2022:
https://netbsd.org/releases/formal-9/NetBSD-9.3.html