### PR TITLE
Make dragonflybsd release dynamic

### DIFF
--- a/quickget
+++ b/quickget
@@ -296,7 +296,10 @@ function releases_devuan() {
 }
 
 function releases_dragonflybsd() {
-    echo 6.4.0
+    # If you remove "".bz2" from the end of the searched URL, you will get only the current release - currently 6.4.0
+    # We could add a variable so this behaviour is optional/switchable (maybe from option or env)
+    DBSD_RELEASES=$(curl -sL  http://mirror-master.dragonflybsd.org/iso-images/| grep -E -o '\"dfly-x86_64-.*_REL.iso.bz2\"' | grep -o -E '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+' )
+    echo $DBSD_RELEASES
 }
 
 function releases_elementary() {
@@ -1080,7 +1083,7 @@ function get_devuan() {
 
 function get_dragonflybsd() {
     local HASH=""
-    local ISO="dfly-x86_64-${RELEASE}_REL.iso"
+    local ISO="dfly-x86_64-${RELEASE}_REL.iso.bz2"
     local URL="http://mirror-master.dragonflybsd.org/iso-images"
 
     HASH=$(wget -q -O- "${URL}/md5.txt" | grep "(${ISO})" | cut -d' ' -f4)
@@ -2041,6 +2044,13 @@ create_vm() {
     if [[ ${OS} == "batocera" ]] && [[ ${ISO} =~ ".gz" ]]; then
         gzip -d "${VM_PATH}/${ISO}"
         ISO="${ISO/.gz/}"
+    fi
+
+    #  Could be other OS iso files compressed with bzip2 or gzip
+    #  but for now we'll keep this to know cases
+    if [[ ${OS} == "dragonflybsd" ]] && [[ ${ISO} =~ ".bz2" ]]; then
+        bzip2 -d  "${VM_PATH}/${ISO}"
+        ISO="${ISO/.bz2/}"
     fi
 
     if [ ${OS} == "reactos" ] && [[ $ISO =~ ".zip" ]]; then


### PR DESCRIPTION
Also this searches the bzip2-compressed isos, giving access to all older releases.
if the ".bz2" is removed from the search (e.g. using an empty variable that can be populated with .bz2 somehow (  if [[ -n ${USE_BZIP2}  ]] ; then ... )   ) then the search only returns the current uncompressed ISO, but should pick up any new release