### PR TITLE
Fix aria2 using wrong destination directory

### DIFF
--- a/quickget
+++ b/quickget
@@ -703,7 +703,7 @@ function web_get() {
     fi
 
     if command -v aria2c &>/dev/null; then
-        if ! aria2c --stderr -x16 --continue=true --summary-interval=0 --download-result=hide --console-log-level=error "${URL}" -o "${DIR}/${FILE}"; then
+        if ! aria2c --stderr -x16 --continue=true --summary-interval=0 --download-result=hide --console-log-level=error "${URL}" --dir "${DIR}" -o "${FILE}"; then
           echo #Necessary as aria2c in suppressed mode does not have new lines
           echo "ERROR! Failed to download ${URL} with aria2c. Try running 'quickget' again."
           exit 1


### PR DESCRIPTION
If you have set a download directory in aria2's config, quickget will download files to the wrong directory. This overwrites that setting and downloads files to the correct location.

Quote from `aria2c(1)`:
> `-o, --out=<FILE>`
>   The file name of the downloaded file. It is
>   always relative to the directory given in
>   `--dir` option.