### PR TITLE
Correct disk to format in Big Sur and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,8 @@ supported.
 -   Use cursor keys and enter key to select the **macOS Base System**
 -   From **macOS Utilities**
     -   Click **Disk Utility** and **Continue**
-        -   Select `QEMU HARDDISK Media` (\~103.08GB) from the list and
+        -   Select `QEMU HARDDISK Media` (\~103.08GB) from the list
+            (on Big Sur and above use `Apple Inc. VirtIO Block Device`) and
             click **Erase**.
         -   Enter a `Name:` for the disk
         -   If you are installing macOS Mojave or later (Catalina, Big


### PR DESCRIPTION
On Big Sur and up apple includes the VirtIO driver and therefore the install disk is named Apple Inc. VirtIO Block Device instead of  QEMU HARDDISK Media. This PR lets the documentation reflect that.