### PR TITLE
Use geo-distributed mirror for Alma URL

### DIFF
--- a/quickget
+++ b/quickget
@@ -980,7 +980,7 @@ function get_alma() {
     local EDITION="${1:-}"
     local HASH=""
     local ISO="AlmaLinux-${RELEASE}-x86_64-${EDITION}.iso"
-    local URL="http://lon.mirror.rackspace.com/almalinux/${RELEASE/beta-1/beta}/isos/x86_64/"
+    local URL="https://mirror.rackspace.com/almalinux/${RELEASE/beta-1/beta}/isos/x86_64/"
     HASH="$(wget -q -O- "${URL}/CHECKSUM" | grep "(${ISO}" | cut -d' ' -f4)"
     echo "${URL}/${ISO} ${HASH}"
 }


### PR DESCRIPTION
Rackspace's mirror network is geographically distributed.  Requesting the mirror.rackspace.com endpoint will point you at the closest mirror to your location.  It will even route you to the next nearest mirror in the case of an outage.  Hard coding this to the lon.mirror.rackspace.com endpoint forces every user to route through London, regardless of their location.