### PR TITLE
Remove thumbnail's black bars & shorten YouTube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ We have a Discord for this project:
 See this (old) video where I explain some of my motivations for creating
 Quickemu.
 
-[![Replace VirtualBox with Bash &
-QEMU](https://img.youtube.com/vi/AOTYWEgw0hI/0.jpg)](https://www.youtube.com/watch?v=AOTYWEgw0hI)
+<a href="https://youtu.be/AOTYWEgw0hI">
+  <img src="https://i3.ytimg.com/vi/AOTYWEgw0hI/maxresdefault.jpg" alt="Replace VirtualBox with Bash &amp; QEMU" width="480">
+</a>
 
 ## Requirements
 


### PR DESCRIPTION
# README.md Improvement

Uses HTML instead of simple Markdown, so I'll understand if you don't like it.

# Previews

## Before:

See this (old) video where I explain some of my motivations for creating Quickemu.

[![Replace VirtualBox with Bash &
QEMU](https://img.youtube.com/vi/AOTYWEgw0hI/0.jpg)](https://www.youtube.com/watch?v=AOTYWEgw0hI)

## After:

See this (old) video where I explain some of my motivations for creating Quickemu.

<a href="https://youtu.be/AOTYWEgw0hI">
  <img src="https://i3.ytimg.com/vi/AOTYWEgw0hI/maxresdefault.jpg" alt="Replace VirtualBox with Bash &amp; QEMU" width="480">
</a>

# Summarizing
The width is the same (480), but the height is now 270 instead of 360. Those black bars were annoying to look at. I've also shortened the YouTube link from `https://www.youtube.com/watch?v=AOTYWEgw0hI` to `https://youtu.be/AOTYWEgw0hI`.