### PR TITLE
Fix Gentoo hash check in quickget

### DIFF
--- a/quickget
+++ b/quickget
@@ -1316,7 +1316,7 @@ function get_gentoo() {
     local URL="https://mirror.bytemark.co.uk/gentoo/releases/amd64/autobuilds/"
 
     ISO=$(wget -q -O- "${URL}/${RELEASE}-iso.txt" | grep install | cut -d' ' -f1)
-    HASH=$( wget -q -O- "${URL}/${ISO}.DIGESTS" | grep iso | grep -v CONTENTS | cut -d' ' -f1)
+    HASH=$( wget -q -O- "${URL}/${ISO}.DIGESTS" | grep -A 1 SHA512 | grep iso | grep -v CONTENTS | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"
 }
 


### PR DESCRIPTION
Gentoo DIGESTS file contains BLAKE2B and SHA512 hashes. Since BLAKE2B comes first in the file, it was incorrectly selected when checking SHA512 checksum.