### PR TITLE
Guix qcow2

### DIFF
--- a/quickget
+++ b/quickget
@@ -231,6 +231,7 @@ function os_support() {
     garuda \
     gentoo \
     ghostbsd \
+    guix \
     haiku \
     holoiso \
     kali \
@@ -317,6 +318,7 @@ function os_homepages(){
         garuda)            HOMEPAGE="https://garudalinux.org/";;
         gentoo)            HOMEPAGE="https://www.gentoo.org/";;
         ghostbsd)          HOMEPAGE="https://www.ghostbsd.org/";;
+        guix)              HOMEPAGE="https://guix.gnu.org/";;
         haiku)             HOMEPAGE="https://www.haiku-os.org/";;
         holoiso)           HOMEPAGE="https://github.com/HoloISO/holoiso";;
         kali)              HOMEPAGE="https://www.kali.org/";;
@@ -573,6 +575,10 @@ function releases_ghostbsd() {
 
 function editions_ghostbsd() {
     echo mate xfce
+}
+
+function releases_guix() {
+    echo 1.4.0 1.3.0
 }
 
 function releases_haiku() {
@@ -1563,6 +1569,16 @@ function get_ghostbsd() {
     esac
     HASH=$(wget -q -O- "${URL}/${ISO}.sha256" | grep "${ISO}" | cut -d' ' -f4)
     echo "${URL}/${ISO} ${HASH}"
+}
+
+function get_guix() {
+    #local HASH=""
+    #local ISO="guix-system-vm-image-1.4.0.x86_64-linux.qcow2"
+    local ISO="guix-system-install-1.4.0.x86_64-linux.iso"
+    local URL="https://ftpmirror.gnu.org/gnu/guix"
+
+    #HASH=$(wget -q -O- "${URL}/${ISO}.sig")
+    echo "${URL}/${ISO}" #${HASH}"
 }
 
 function get_haiku() {
@@ -2703,6 +2719,11 @@ create_vm() {
         unzip ${VM_PATH}/${ISO} -d ${VM_PATH}
         ISO=$(ls ${VM_PATH} | grep -i '.iso')
     fi
+
+    #if [ ${OS} == "guix" ] && [[ $ISO =~ ".qcow2" ]]; then
+        #cp ${VM_PATH}/${ISO} ${VM_PATH}/disc.qcow2
+    #fi
+
     if [[ ${OS} == "batocera" ]] && [[ ${ISO} =~ ".gz" ]]; then
         gzip -d "${VM_PATH}/${ISO}"
         ISO="${ISO/.gz/}"


### PR DESCRIPTION
- [ ] use qcow2 directly instead of ISO #837
- [ ] use .sig for download check #838
- [x] temporary solution! Using ISO, without HASH check 