### PR TITLE
repair NetBSD releases

### DIFF
--- a/quickget
+++ b/quickget
@@ -488,7 +488,7 @@ function releases_netboot() {
 }
 
 function releases_netbsd() {
-    local NBSD_RELEASES=$(curl -sL  http://cdn.netbsd.org/pub/NetBSD/iso/ | grep -o -E '\"[[:digit:]]+\.[[:digit:]]+/\"' |tr -d '"/' |sort -nr )
+    local NBSD_RELEASES=$(curl -sL  http://cdn.netbsd.org/pub/NetBSD/iso/ | grep -o -E '"[[:digit:]]+\.[[:digit:]]+/"' |tr -d '"/' |sort -nr )
     echo ${NBSD_RELEASES}
 }
 


### PR DESCRIPTION
show error when listing releases (twice): `grep: warning: stray \ before "`