### PR TITLE
Fix ventura RecoveryImage download

### DIFF
--- a/quickget
+++ b/quickget
@@ -1432,7 +1432,8 @@ function get_macos() {
         monterey)       #12
             BOARD_ID="Mac-E43C1C25D4880AD6";;
         ventura)        #13
-            BOARD_ID="Mac-7BA5B2D9E42DDD94";;
+            BOARD_ID="Mac-7BA5B2D9E42DDD94"
+            OS_TYPE="latest";;
         *) echo "ERROR! Unknown release: ${RELEASE}"
            releases_macos
            exit 1;;


### PR DESCRIPTION
i spend a day to fix this problem :joy: 
before this patch, when we try `quickget macos ventura` it's download `Sonoma` version :joy: