### PR TITLE
quickget: new features

### DIFF
--- a/quickget
+++ b/quickget
@@ -25,15 +25,27 @@ function cleanup() {
   fi
 }
 
-if [ "${1}" == '-t' ]; then
-  testmode="on"
-  if [ -n "$4" ]; then
-    set -- "$2" "$3" "$4"
-  elif [ -n "$3" ]; then
-    set -- "$2" "$3"
-  else
+if [ "${1}" == '--test-iso-url' ]; then
+    test_iso_url="on"
+    if [ -n "$4" ]; then
+        set -- "$2" "$3" "$4"
+    elif [ -n "$3" ]; then
+        set -- "$2" "$3"
+    else
+        set -- "$2"
+    fi
+elif [ "${1}" == '--show-iso-url' ]; then
+    show_iso_url="on"
+    if [ -n "$4" ]; then
+        set -- "$2" "$3" "$4"
+    elif [ -n "$3" ]; then
+        set -- "$2" "$3"
+    else
+        set -- "$2"
+    fi
+elif [ "${1}" == '--open-distro-homepage' ]; then
+    open_distro_homepage="on"
     set -- "$2"
-  fi
 fi
 
 function pretty_name() {
@@ -860,10 +872,14 @@ function web_get() {
         fi
         echo #Necessary as aria2c in suppressed mode does not have new lines
 # Test mode for ISO (yet wget only)
-    elif [ "${testmode}" == 'on' ]; then
+    elif [ "${show_iso_url}" == 'on' ]; then
           echo "${URL}"
-          #wget --spider "${URL}"
-          exit 1
+          exit 0
+    elif [ "${test_iso_url}" == 'on' ]; then
+          wget --spider "${URL}"
+          exit 0
+    elif [ "${open_distro_homepage}" == 'on' ]; then
+          xdgopen "${distro_homepage}" && exit 0
     else
         if ! wget --quiet --continue --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
           echo "ERROR! Failed to download ${URL} with wget. Try running 'quickget' again."

--- a/quickget
+++ b/quickget
@@ -25,6 +25,17 @@ function cleanup() {
   fi
 }
 
+if [ "${1}" == '-t' ]; then
+  testmode="on"
+  if [ -n "$4" ]; then
+    set -- "$2" "$3" "$4"
+  elif [ -n "$3" ]; then
+    set -- "$2" "$3"
+  else
+    set -- "$2"
+  fi
+fi
+
 function pretty_name() {
   local SIMPLE_NAME=""
   local PRETTY_NAME=""
@@ -796,6 +807,9 @@ function editions_zorin() {
 }
 
 function check_hash() {
+    if  [ "${testmode}" == 'on' ]; then
+      exit 0
+    fi
     local iso=""
     local hash=""
     local hash_algo=""
@@ -845,6 +859,11 @@ function web_get() {
           exit 1
         fi
         echo #Necessary as aria2c in suppressed mode does not have new lines
+# Test mode for ISO (yet wget only)
+    elif [ "${testmode}" == 'on' ]; then
+          echo "${URL}"
+          #wget --spider "${URL}"
+          exit 1
     else
         if ! wget --quiet --continue --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
           echo "ERROR! Failed to download ${URL} with wget. Try running 'quickget' again."

--- a/quickget
+++ b/quickget
@@ -2597,6 +2597,14 @@ else
     echo "ERROR! You must specify an operating system."
     echo -n " - Operating Systems: "
     os_support
+    echo "
+        You can also use this arguments:
+        Only show ISO download URL
+            --show-iso-url / -s {distro} {release} [edition]
+        Test if ISO is available
+            --test-iso-url / -t {distro} {release} [edition]
+        Open distro homepage
+            --open-distro-homepage / -o {distro}"
     exit 1
 fi
 

--- a/quickget
+++ b/quickget
@@ -3,21 +3,23 @@ export LC_ALL=C
 
 # Here the quick 'n dirty guide to adding a new OS to quickget
 #
-#  1. Update os_support() - add new OS, all lowercase
-#  2. Update pretty_name() - add a pretty name for new OS *only if the catch all is not suitable*
-#  3. Create a releases_newos() generator (required) outputs the current supported release versions
-#  4. Create a editions_newos() generator (optional) outputs the editions if new OS has multiple flavours/editions
-#  5. Update make_vm_config() - add any *required* new OS tweaks
-#  6. Create a get_newos() function - that does something like this:
-#     function get_newos() {
-#         local EDITION="${1:-}"
-#         local HASH=""
-#         local ISO="newos-${RELEASE}-${EDITION}-amd64.iso"
-#         local URL="https://www.newos.org/download/${RELEASE}/${EDITION}"
+#    1. Update os_support() - add new OS, all lowercase
+#    2. Update pretty_name() - add a pretty name for new OS *only if the catch all is not suitable*
+#    3. Update os_homepages() - add a homepage for new OS
+#    4. Create a releases_newos() generator (required) outputs the current supported release versions
+#    5. Create a editions_newos() generator (optional) outputs the editions if new OS has multiple flavours/editions
+#    6. Update make_vm_config() - add any *required* new OS tweaks
+#    7. Create a get_newos() function - that does something like this:
 #
-#         HASH=$(wget -q -O- "${URL}/SHA512SUMS" | grep "${ISO}" | cut -d' ' -f1)
-#         echo "${URL}/${ISO} ${HASH}"
-#     }
+#function get_newos() {
+#    local EDITION="${1:-}"
+#    local HASH=""
+#    local ISO="newos-${RELEASE}-${EDITION}-amd64.iso"
+#    local URL="https://www.newos.org/download/${RELEASE}/${EDITION}"
+#
+#    HASH=$(wget -q -O- "${URL}/SHA512SUMS" | grep "${ISO}" | cut -d' ' -f1)
+#    echo "${URL}/${ISO} ${HASH}"
+#}
 
 function cleanup() {
   if [ -n "$(jobs -p)" ]; then
@@ -283,84 +285,90 @@ function os_support() {
 }
 
 function os_homepages(){
-    echo alma/https://almalinux.org/ \
-        alpine/https://alpinelinux.org/ \
-        android/https://www.android-x86.org/ \
-        antix/https://antixlinux.com/ \
-        archlinux/https://archlinux.org/ \
-        archcraft/https://archcraft.io/ \
-        arcolinux/https://arcolinux.com/ \
-        batocera/https://batocera.org/ \
-        blendos/https://blendos.co/ \
-        bodhi/https://www.bodhilinux.com/ \
-        bunsenlabs/https://www.bunsenlabs.org/ \
-        cachyos/https://cachyos.org/ \
-        centos-stream/https://www.centos.org/centos-stream/ \
-        debian/https://www.debian.org/ \
-        deepin/https://www.deepin.org/ \
-        devuan/https://www.devuan.org/ \
-        dragonflybsd/https://www.dragonflybsd.org/ \
-        edubuntu/https://www.edubuntu.org/ \
-        elementary/https://elementary.io/ \
-        endeavouros/https://endeavouros.com/ \
-        endless/https://www.endlessos.org/os \
-        fedora/https://www.fedoraproject.org/ \
-        freebsd/https://www.freebsd.org/ \
-        freedos/https://freedos.org/ \
-        garuda/https://garudalinux.org/ \
-        gentoo/https://www.gentoo.org/ \
-        ghostbsd/https://www.ghostbsd.org/ \
-        haiku/https://www.haiku-os.org/ \
-        holoiso/https://github.com/HoloISO/holoiso \
-        kali/https://www.kali.org/ \
-        kdeneon/https://neon.kde.org/ \
-        kolibrios/http://kolibrios.org/en/ \
-        kubuntu/https://kubuntu.org/ \
-        linuxlite/https://www.linuxliteos.com/ \
-        linuxmint/https://linuxmint.com/ \
-        lmde/https://www.linuxmint.com/download_lmde.php \
-        mageia/https://www.mageia.org/ \
-        manjaro/https://manjaro.org/ \
-        mxlinux/https://mxlinux.org/ \
-        netboot/https://netboot.xyz/ \
-        netbsd/https://www.netbsd.org/ \
-        nixos/https://nixos.org/ \
-        lubuntu/https://lubuntu.me/ \
-        macos/https://www.apple.com/macos/ \
-        openbsd/https://www.openbsd.org/ \
-        openindiana/https://www.openindiana.org/ \
-        opensuse/https://www.opensuse.org/ \
-        oraclelinux/https://www.oracle.com/linux/ \
-        peppermint/https://peppermintos.com/ \
-        popos/https://pop.system76.com/ \
-        porteus/http://www.porteus.org/ \
-        reactos/https://reactos.org/ \
-        rebornos/https://rebornos.org/ \
-        rockylinux/https://rockylinux.org/ \
-        siduction/https://siduction.org/ \
-        slackware/http://www.slackware.com/ \
-        solus/https://getsol.us/ \
-        spiral/https://spirallinux.github.io/ \
-        tails/https://tails.net/ \
-        tinycore/http://www.tinycorelinux.net/ \
-        trisquel/https://trisquel.info/ \
-        truenas-core/https://www.truenas.com/truenas-core/ \
-        truenas-scale/https://www.truenas.com/truenas-scale/ \
-        ubuntu/https://ubuntu.com/ \
-        ubuntu-budgie/https://ubuntubudgie.org/ \
-        ubuntucinnamon/https://ubuntucinnamon.org/ \
-        ubuntukylin/https://ubuntukylin.com/ \
-        ubuntu-mate/https://ubuntu-mate.org/ \
-        ubuntu-server/https://ubuntu.com/server \
-        ubuntustudio/https://ubuntustudio.org/ \
-        ubuntu-unity/https://ubuntuunity.org/ \
-        vanillaos/https://vanillaos.org/ \
-        void/https://voidlinux.org/ \
-        vxlinux/https://vxlinux.org/ \
-        windows/https://www.microsoft.com/en-us/windows/ \
-        xerolinux/https://xerolinux.xyz/ \
-        xubuntu/https://xubuntu.org/ \
-        zorin/https://zorin.com/os/
+    local SIMPLE_NAME=""
+    local HOMEPAGE=""
+    SIMPLE_NAME="${1}"
+    case ${SIMPLE_NAME} in
+        alma)              HOMEPAGE="https://almalinux.org/";;
+        alpine)            HOMEPAGE="https://alpinelinux.org/";;
+        android)           HOMEPAGE="https://www.android-x86.org/";;
+        antix)             HOMEPAGE="https://antixlinux.com/";;
+        archlinux)         HOMEPAGE="https://archlinux.org/";;
+        archcraft)         HOMEPAGE="https://archcraft.io/";;
+        arcolinux)         HOMEPAGE="https://arcolinux.com/";;
+        batocera)          HOMEPAGE="https://batocera.org/";;
+        blendos)           HOMEPAGE="https://blendos.co/";;
+        bodhi)             HOMEPAGE="https://www.bodhilinux.com/";;
+        bunsenlabs)        HOMEPAGE="https://www.bunsenlabs.org/";;
+        cachyos)           HOMEPAGE="https://cachyos.org/";;
+        centos-stream)     HOMEPAGE="https://www.centos.org/centos-stream/";;
+        debian)            HOMEPAGE="https://www.debian.org/";;
+        deepin)            HOMEPAGE="https://www.deepin.org/";;
+        devuan)            HOMEPAGE="https://www.devuan.org/";;
+        dragonflybsd)      HOMEPAGE="https://www.dragonflybsd.org/";;
+        edubuntu)          HOMEPAGE="https://www.edubuntu.org/";;
+        elementary)        HOMEPAGE="https://elementary.io/";;
+        endeavouros)       HOMEPAGE="https://endeavouros.com/";;
+        endless)           HOMEPAGE="https://www.endlessos.org/os";;
+        fedora)            HOMEPAGE="https://www.fedoraproject.org/";;
+        freebsd)           HOMEPAGE="https://www.freebsd.org/";;
+        freedos)           HOMEPAGE="https://freedos.org/";;
+        garuda)            HOMEPAGE="https://garudalinux.org/";;
+        gentoo)            HOMEPAGE="https://www.gentoo.org/";;
+        ghostbsd)          HOMEPAGE="https://www.ghostbsd.org/";;
+        haiku)             HOMEPAGE="https://www.haiku-os.org/";;
+        holoiso)           HOMEPAGE="https://github.com/HoloISO/holoiso";;
+        kali)              HOMEPAGE="https://www.kali.org/";;
+        kdeneon)           HOMEPAGE="https://neon.kde.org/";;
+        kolibrios)         HOMEPAGE="http://kolibrios.org/en/";;
+        kubuntu)           HOMEPAGE="https://kubuntu.org/";;
+        linuxlite)         HOMEPAGE="https://www.linuxliteos.com/";;
+        linuxmint)         HOMEPAGE="https://linuxmint.com/";;
+        lmde)              HOMEPAGE="https://www.linuxmint.com/download_lmde.php";;
+        mageia)            HOMEPAGE="https://www.mageia.org/";;
+        manjaro)           HOMEPAGE="https://manjaro.org/";;
+        mxlinux)           HOMEPAGE="https://mxlinux.org/";;
+        netboot)           HOMEPAGE="https://netboot.xyz/";;
+        netbsd)            HOMEPAGE="https://www.netbsd.org/";;
+        nixos)             HOMEPAGE="https://nixos.org/";;
+        lubuntu)           HOMEPAGE="https://lubuntu.me/";;
+        macos)             HOMEPAGE="https://www.apple.com/macos/";;
+        openbsd)           HOMEPAGE="https://www.openbsd.org/";;
+        openindiana)       HOMEPAGE="https://www.openindiana.org/";;
+        opensuse)          HOMEPAGE="https://www.opensuse.org/";;
+        oraclelinux)       HOMEPAGE="https://www.oracle.com/linux/";;
+        peppermint)        HOMEPAGE="https://peppermintos.com/";;
+        popos)             HOMEPAGE="https://pop.system76.com/";;
+        porteus)           HOMEPAGE="http://www.porteus.org/";;
+        reactos)           HOMEPAGE="https://reactos.org/";;
+        rebornos)          HOMEPAGE="https://rebornos.org/";;
+        rockylinux)        HOMEPAGE="https://rockylinux.org/";;
+        siduction)         HOMEPAGE="https://siduction.org/";;
+        slackware)         HOMEPAGE="http://www.slackware.com/";;
+        solus)             HOMEPAGE="https://getsol.us/";;
+        spiral)            HOMEPAGE="https://spirallinux.github.io/";;
+        tails)             HOMEPAGE="https://tails.net/";;
+        tinycore)          HOMEPAGE="http://www.tinycorelinux.net/";;
+        trisquel)          HOMEPAGE="https://trisquel.info/";;
+        truenas-core)      HOMEPAGE="https://www.truenas.com/truenas-core/";;
+        truenas-scale)     HOMEPAGE="https://www.truenas.com/truenas-scale/";;
+        ubuntu)            HOMEPAGE="https://ubuntu.com/";;
+        ubuntu-budgie)     HOMEPAGE="https://ubuntubudgie.org/";;
+        ubuntucinnamon)    HOMEPAGE="https://ubuntucinnamon.org/";;
+        ubuntukylin)       HOMEPAGE="https://ubuntukylin.com/";;
+        ubuntu-mate)       HOMEPAGE="https://ubuntu-mate.org/";;
+        ubuntu-server)     HOMEPAGE="https://ubuntu.com/server";;
+        ubuntustudio)      HOMEPAGE="https://ubuntustudio.org/";;
+        ubuntu-unity)      HOMEPAGE="https://ubuntuunity.org/";;
+        vanillaos)         HOMEPAGE="https://vanillaos.org/";;
+        void)              HOMEPAGE="https://voidlinux.org/";;
+        vxlinux)           HOMEPAGE="https://vxlinux.org/";;
+        windows)           HOMEPAGE="https://www.microsoft.com/en-us/windows/";;
+        xerolinux)         HOMEPAGE="https://xerolinux.xyz/";;
+        xubuntu)           HOMEPAGE="https://xubuntu.org/";;
+        zorin)             HOMEPAGE="https://zorin.com/os/";;
+    esac
+    echo "${HOMEPAGE}"
 }
 
 function releases_alma() {
@@ -2687,8 +2695,8 @@ if [ -n "${2}" ]; then
     fi
 else
     if [ "${open_distro_homepage}" == 'on' ]; then
-        homepage=$(os_homepages | sed 's/\s\+/\n/g' |  grep ${OS} | cut -d'/' -f2-9)
-        open_url "${homepage}" && exit 0
+        HOMEPAGE=$(os_homepages ${OS})
+        open_url "${HOMEPAGE}" && exit 0
     fi
     echo "ERROR! You must specify a release."
     case ${OS} in

--- a/quickget
+++ b/quickget
@@ -219,6 +219,7 @@ function os_support() {
     deepin \
     devuan \
     dragonflybsd \
+    edubuntu \
     elementary \
     endeavouros \
     endless \
@@ -279,6 +280,87 @@ function os_support() {
     xerolinux \
     xubuntu \
     zorin
+}
+
+function os_homepages(){
+    echo alma/https://almalinux.org/ \
+        alpine/https://alpinelinux.org/ \
+        android/https://www.android-x86.org/ \
+        antix/https://antixlinux.com/ \
+        archlinux/https://archlinux.org/ \
+        archcraft/https://archcraft.io/ \
+        arcolinux/https://arcolinux.com/ \
+        batocera/https://batocera.org/ \
+        blendos/https://blendos.co/ \
+        bodhi/https://www.bodhilinux.com/ \
+        bunsenlabs/https://www.bunsenlabs.org/ \
+        cachyos/https://cachyos.org/ \
+        centos-stream/https://www.centos.org/centos-stream/ \
+        debian/https://www.debian.org/ \
+        deepin/https://www.deepin.org/ \
+        devuan/https://www.devuan.org/ \
+        dragonflybsd/https://www.dragonflybsd.org/ \
+        edubuntu/https://www.edubuntu.org/ \
+        elementary/https://elementary.io/ \
+        endeavouros/https://endeavouros.com/ \
+        endless/https://www.endlessos.org/os \
+        fedora/https://www.fedoraproject.org/ \
+        freebsd/https://www.freebsd.org/ \
+        freedos/https://freedos.org/ \
+        garuda/https://garudalinux.org/ \
+        gentoo/https://www.gentoo.org/ \
+        ghostbsd/https://www.ghostbsd.org/ \
+        haiku/https://www.haiku-os.org/ \
+        holoiso/https://github.com/HoloISO/holoiso \
+        kali/https://www.kali.org/ \
+        kdeneon/https://neon.kde.org/ \
+        kolibrios/http://kolibrios.org/en/ \
+        kubuntu/https://kubuntu.org/ \
+        linuxlite/https://www.linuxliteos.com/ \
+        linuxmint/https://linuxmint.com/ \
+        lmde/https://www.linuxmint.com/download_lmde.php \
+        mageia/https://www.mageia.org/ \
+        manjaro/https://manjaro.org/ \
+        mxlinux/https://mxlinux.org/ \
+        netboot/https://netboot.xyz/ \
+        netbsd/https://www.netbsd.org/ \
+        nixos/https://nixos.org/ \
+        lubuntu/https://lubuntu.me/ \
+        macos/https://www.apple.com/macos/ \
+        openbsd/https://www.openbsd.org/ \
+        openindiana/https://www.openindiana.org/ \
+        opensuse/https://www.opensuse.org/ \
+        oraclelinux/https://www.oracle.com/linux/ \
+        peppermint/https://peppermintos.com/ \
+        popos/https://pop.system76.com/ \
+        porteus/http://www.porteus.org/ \
+        reactos/https://reactos.org/ \
+        rebornos/https://rebornos.org/ \
+        rockylinux/https://rockylinux.org/ \
+        siduction/https://siduction.org/ \
+        slackware/http://www.slackware.com/ \
+        solus/https://getsol.us/ \
+        spiral/https://spirallinux.github.io/ \
+        tails/https://tails.net/ \
+        tinycore/http://www.tinycorelinux.net/ \
+        trisquel/https://trisquel.info/ \
+        truenas-core/https://www.truenas.com/truenas-core/ \
+        truenas-scale/https://www.truenas.com/truenas-scale/ \
+        ubuntu/https://ubuntu.com/ \
+        ubuntu-budgie/https://ubuntubudgie.org/ \
+        ubuntucinnamon/https://ubuntucinnamon.org/ \
+        ubuntukylin/https://ubuntukylin.com/ \
+        ubuntu-mate/https://ubuntu-mate.org/ \
+        ubuntu-server/https://ubuntu.com/server \
+        ubuntustudio/https://ubuntustudio.org/ \
+        ubuntu-unity/https://ubuntuunity.org/ \
+        vanillaos/https://vanillaos.org/ \
+        void/https://voidlinux.org/ \
+        vxlinux/https://vxlinux.org/ \
+        windows/https://www.microsoft.com/en-us/windows/ \
+        xerolinux/https://xerolinux.xyz/ \
+        xubuntu/https://xubuntu.org/ \
+        zorin/https://zorin.com/os/
 }
 
 function releases_alma() {
@@ -819,9 +901,6 @@ function editions_zorin() {
 }
 
 function check_hash() {
-    if  [ "${testmode}" == 'on' ]; then
-      exit 0
-    fi
     local iso=""
     local hash=""
     local hash_algo=""
@@ -871,15 +950,13 @@ function web_get() {
           exit 1
         fi
         echo #Necessary as aria2c in suppressed mode does not have new lines
-# Test mode for ISO (yet wget only)
+    # Test mode for ISO (yet wget only)
     elif [ "${show_iso_url}" == 'on' ]; then
           echo "${URL}"
           exit 0
     elif [ "${test_iso_url}" == 'on' ]; then
           wget --spider "${URL}"
           exit 0
-    elif [ "${open_distro_homepage}" == 'on' ]; then
-          xdgopen "${distro_homepage}" && exit 0
     else
         if ! wget --quiet --continue --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
           echo "ERROR! Failed to download ${URL} with wget. Try running 'quickget' again."
@@ -2596,6 +2673,11 @@ if [ -n "${2}" ]; then
         create_vm "$("get_${OS}")"
     fi
 else
+    if [ "${open_distro_homepage}" == 'on' ]; then
+        homepage=$(os_homepages | sed 's/\s\+/\n/g' |  grep ${OS} | cut -d'/' -f2-9)
+        echo "${homepage}"
+        xdg-open "${homepage}" && exit 0
+    fi
     echo "ERROR! You must specify a release."
     case ${OS} in
       *ubuntu-server*)

--- a/quickget
+++ b/quickget
@@ -25,7 +25,7 @@ function cleanup() {
   fi
 }
 
-if [ "${1}" == '--test-iso-url' ]; then
+if [ "${1}" == '--test-iso-url' ] || [ "${1}" == '-t' ]; then
     test_iso_url="on"
     if [ -n "$4" ]; then
         set -- "$2" "$3" "$4"
@@ -34,7 +34,7 @@ if [ "${1}" == '--test-iso-url' ]; then
     else
         set -- "$2"
     fi
-elif [ "${1}" == '--show-iso-url' ]; then
+elif [ "${1}" == '--show-iso-url' ] || [ "${1}" ==  '-s' ]; then
     show_iso_url="on"
     if [ -n "$4" ]; then
         set -- "$2" "$3" "$4"
@@ -43,7 +43,7 @@ elif [ "${1}" == '--show-iso-url' ]; then
     else
         set -- "$2"
     fi
-elif [ "${1}" == '--open-distro-homepage' ]; then
+elif [ "${1}" == '--open-distro-homepage' ] || [ "${1}" == '-o' ]; then
     open_distro_homepage="on"
     set -- "$2"
 fi

--- a/quickget
+++ b/quickget
@@ -2533,6 +2533,11 @@ function get_windows() {
     esac
 }
 
+open_url() {
+    local URL="$1";
+    xdg-open $URL || sensible-browser $URL || x-www-browser $URL || gnome-open $URL;
+}
+
 create_vm() {
     # shellcheck disable=SC2206
     local URL_HASH=(${1// / })
@@ -2683,8 +2688,7 @@ if [ -n "${2}" ]; then
 else
     if [ "${open_distro_homepage}" == 'on' ]; then
         homepage=$(os_homepages | sed 's/\s\+/\n/g' |  grep ${OS} | cut -d'/' -f2-9)
-        echo "${homepage}"
-        xdg-open "${homepage}" && exit 0
+        open_url "${homepage}" && exit 0
     fi
     echo "ERROR! You must specify a release."
     case ${OS} in


### PR DESCRIPTION
no i didn't read : https://github.com/quickemu-project/quickemu/pull/370
so...

why not?
@philclifford
tested from external script quickfzf https://github.com/quickemu-project/quickemu/pull/773

new features:
quickget commands
- [x] --show-iso-url (not fully tested)
    `quickget --show-iso-url alpine latest`
    or
    `quickget -s bodhi 7.0.0 standard`
- [x] --test-iso-url (not fully tested)
    `quickget --test-iso-url alpine latest`
    or
    `quickget -t bodhi 7.0.0 standard`
- [x] --open-distro-homepage
    `quickget --open-distro-homepage alpine`
    or
    `quickget -o vxlinux`
- [ ] zsync/aria2 support
- [ ] more testing

test and show URL needs more testing and implementing zsync..

Long list of obtained ISOs (from my fork):
<details>
<summary>Details</summary>
`https://sourceforge.net/projects/agarimos/files/Plasma/AgarimOS-Plasma-Dracula-Live-x86_64-6.3.13_1-20230913.iso
https://sourceforge.net/projects/agarimos/files/XFCE4/AgarimOS-XFCE4-Catppuccin-Live-x86_64-6.3.13_1-20230916.iso
https://sourceforge.net/projects/agarimos/files/LXQT-KWIN/AgarimOS-LXQT-KWIN-Dracula-Live-x86_64-6.3.13_1-20230915.iso
https://sourceforge.net/projects/agarimos/files/Gnome/AgarimOS-Gnome-Catppuccin-Liv-x86_64-6.3.13_1-20230914.iso
https://repo.almalinux.org/almalinux/8
https://repo.almalinux.org/almalinux/8
https://repo.almalinux.org/almalinux/8
https://dl-cdn.alpinelinux.org/alpine/v3.12/releases/x86_64/alpine-virt-3.12.12-x86_64.iso
https://dl-cdn.alpinelinux.org/alpine/v3.13/releases/x86_64/alpine-virt-3.13.12-x86_64.iso
https://dl-cdn.alpinelinux.org/alpine/v3.14/releases/x86_64/alpine-virt-3.14.10-x86_64.iso
https://dl-cdn.alpinelinux.org/alpine/v3.15/releases/x86_64/alpine-virt-3.15.10-x86_64.iso
https://dl-cdn.alpinelinux.org/alpine/v3.16/releases/x86_64/alpine-virt-3.16.7-x86_64.iso
https://dl-cdn.alpinelinux.org/alpine/v3.17/releases/x86_64/alpine-virt-3.17.5-x86_64.iso
https://dl-cdn.alpinelinux.org/alpine/v3.18/releases/x86_64/alpine-virt-3.18.4-x86_64.iso
https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64/alpine-virt-3.18.4-x86_64.iso
https://mirrors.gigenet.com/OSDN/android-x86/71931/
https://mirrors.gigenet.com/OSDN/android-x86/71931/
https://mirror.rackspace.com/archlinux//iso/2023.09.01/archlinux-2023.09.01-x86_64.iso
https://downloads.sourceforge.net/project/archcraft/v23.10/archcraft-2023.10.12-x86_64.iso
https://ant.seedhost.eu/arcolinux/iso/v21.09.08
https://ant.seedhost.eu/arcolinux/iso/v21.09.08
https://iso.artixlinux.org/iso/artix-base-dinit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-base-openrc-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-base-runit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-base-s6-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-cinnamon-dinit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-cinnamon-openrc-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-cinnamon-runit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-cinnamon-s6-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-lxde-dinit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-lxde-openrc-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-lxde-runit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-lxde-s6-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-lxqt-dinit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-lxqt-openrc-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-lxqt-runit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-lxqt-s6-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-mate-dinit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-mate-openrc-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-mate-runit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-mate-s6-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-plasma-dinit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-plasma-openrc-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-plasma-runit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-plasma-s6-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-xfce-dinit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-xfce-openrc-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-xfce-runit-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-xfce-s6-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-community-gtk-openrc-20230814-x86_64.iso
https://iso.artixlinux.org/iso/artix-community-qt-openrc-20230814-x86_64.iso
https://downloads.sourceforge.net/project/athena-iso/v23.06.23/athena-2023.06.23-x86_64.iso
https://mirrors.o2switch.fr/batocera/x86_64/stable/last/archives/32/batocera-x86_64-32-20210920.img.gz
https://mirrors.o2switch.fr/batocera/x86_64/stable/last/archives/33/batocera-x86_64-33-20220203.img.gz
https://mirrors.o2switch.fr/batocera/x86_64/stable/last/archives/34/batocera-x86_64-34-20220523.img.gz
https://iso.biglinux.com.br/biglinux_2023-10-10_k61.iso
https://sourceforge.net/projects/blendos/files/ISOs/plasma/1688424625/blendOS.iso
https://sourceforge.net/projects/blendos/files/ISOs/plasma/1688424625/blendOS.iso
https://sourceforge.net/projects/bodhilinux/files///bodhi-7.0.0-64-hwe.iso
https://sourceforge.net/projects/bodhilinux/files///bodhi-7.0.0-64-s76.iso
https://ddl.bunsenlabs.org/ddl/beryllium-1-amd64.hybrid.iso
https://mirror.cachyos.org/ISO/kde/230813/cachyos-kde-linux-230813.iso
https://mirror.cachyos.org/ISO/gnome/230813/cachyos-gnome-linux-230813.iso
/
/
https://repo.chimera-linux.org/live/latest/chimera-linux-x86_64-LIVE-20230915-base.iso
https://repo.chimera-linux.org/live/latest/chimera-linux-x86_64-LIVE-20230915-gnome.iso
https://cdimage.debian.org/cdimage/archive/10.0.0
https://cdimage.debian.org/cdimage/archive/10.0.0
https://cdimage.debian.org/cdimage/archive/10.0.0
https://cdimage.debian.org/cdimage/archive/10.0.0
https://cdimage.debian.org/cdimage/archive/10.0.0
https://cdimage.debian.org/cdimage/archive/10.0.0
https://cdimage.debian.org/cdimage/archive/10.0.0
https://cdimage.debian.org/cdimage/archive/10.0.0
https://cdimage.debian.org/cdimage/archive/10.0.0
https://cdimage.deepin.com/releases/20/deepin-desktop-community-1003-amd64.iso
https://cdimage.deepin.com/releases/20.1/deepin-desktop-community-1010-amd64.iso
https://cdimage.deepin.com/releases/20.2.1/deepin-desktop-community-20.2.1-amd64.iso
https://cdimage.deepin.com/releases/20.2.2/deepin-desktop-community-20.2.2-amd64.iso
https://cdimage.deepin.com/releases/20.2.3/deepin-desktop-community-20.2.3-amd64.iso
https://cdimage.deepin.com/releases/20.2.4/deepin-desktop-community-20.2.4-amd64.iso
https://cdimage.deepin.com/releases/20.3/deepin-desktop-community-20.3-amd64.iso
https://cdimage.deepin.com/releases/20.4/deepin-desktop-community-20.4-amd64.iso
https://cdimage.deepin.com/releases/20.5/deepin-desktop-community-20.5-amd64.iso
https://cdimage.deepin.com/releases/20.7/deepin-desktop-community-20.7-amd64.iso
https://files.devuan.org/devuan_beowulf/desktop-live/devuan_beowulf_3.1.1_amd64_desktop-live.iso
https://files.devuan.org/devuan_chimaera/desktop-live/devuan_chimaera_4.0.2_amd64_desktop-live.iso
https://files.devuan.org/devuan_daedalus/desktop-live/devuan_daedalus_5.0.0_amd64_desktop-live.iso
https://dietpi.com/downloads/images/
https://dietpi.com/downloads/images/
https://dietpi.com/downloads/images/
https://dietpi.com/downloads/images/
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-6.4.0_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-6.2.2_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-6.2.1_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-6.0.1_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-6.0.0_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.8.3_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.8.2_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.8.1_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.6.3_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.8.0_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.6.2_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.6.1_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.6.0_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.4.3_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.4.2_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.4.1_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.4.0_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.2.2_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.2.1_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.2.0_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.0.2_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.0.1_REL.iso.bz2
http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.0.0_REL.iso.bz2
https://cdimage.ubuntu.com/edubuntu/releases/23.04/release/edubuntu-23.04-desktop-amd64.iso
https://ams3.dl.elementary.io/download/MTY5NzE3OTA5Nwo=/elementaryos-7.0-stable.20230129rc.iso
https://ams3.dl.elementary.io/download/MTY5NzE3OTA5Nwo=/elementaryos-7.1-stable.20230926rc.iso
https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_Apollo_22_1.iso
https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_Artemis-22_6.iso
https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_Artemis_neo_22_7.iso
https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_Artemis_neo_22_8.iso
https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_Artemis_nova_22_9.iso
https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_Atlantis-21_4.iso
https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_Atlantis_neo-21_5.iso
https://github.com/endeavouros-team/ISO/releases/download/1-EndeavourOS-ISO-releases-archive/EndeavourOS_Cassini_22_12.iso
https://images-dl.endlessm.com/release/5.0.0/eos-amd64-amd64/base/eos-eos5.0-amd64-amd64.230127-211122.base.iso
https://images-dl.endlessm.com/release/5.0.0/eos-amd64-amd64/en/eos-eos5.0-amd64-amd64.230127-212436.en.iso
https://images-dl.endlessm.com/release/5.0.0/eos-amd64-amd64/fr/eos-eos5.0-amd64-amd64.230127-213415.fr.iso
https://images-dl.endlessm.com/release/5.0.0/eos-amd64-amd64/pt_BR/eos-eos5.0-amd64-amd64.230127-220328.pt_BR.iso
https://images-dl.endlessm.com/release/5.0.0/eos-amd64-amd64/es/eos-eos5.0-amd64-amd64.230127-212646.es.iso














https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/12.4
https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/12.4
http://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/official/FD12CD.iso
http://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.3/official/FD13-LiveCD.zip
https://downloads.sourceforge.net/project/f-void/26_08_2023/fvoid-live-x86_64-20230826-lxqt.iso
https://sourceforge.net/projects/gabeeoslinux/files/Distro/Openbox/beta/gabeeOSLinux-Openbox-Cherry-x86_64-6.1.25_1-20230502.iso
https://sourceforge.net/projects/gabeeoslinux/files/Distro/Qtile/beta/gabeeOSLinux-Qtile-x86_64-6.1.25_1-20230508.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/cinnamon/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/dr460nized/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/dr460nized-gaming/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/gnome/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/i3/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/kde-git/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/kde-lite/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/lxqt-kwin/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/mate/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/qtile/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/sway/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/wayfire/latest.iso
https://iso.builds.garudalinux.org/iso/latest/garuda/xfce/latest.iso
https://mirror.bytemark.co.uk/gentoo/releases/amd64/autobuilds//20231008T170201Z/install-amd64-minimal-20231008T170201Z.iso
https://download.ghostbsd.org/releases/amd64/21.10.16
https://download.ghostbsd.org/releases/amd64/21.10.16
http://mirror.rit.edu/haiku/r1beta3
http://mirror.rit.edu/haiku/r1beta3
http://holoiso.itsvixano.me/HoloISO_4.5_ux_changes-20230626_66f7c74061_bootchoice_fixes-1-x86-64.iso.iso
https://cdimage.kali.org/current/kali-linux-2023.3-installer-amd64.iso
https://cdimage.kali.org/kali-weekly/kali-linux-2023-W41-installer-amd64.iso
https://files.kde.org/neon/images/user/current/neon-user-20231012-0714.iso
https://files.kde.org/neon/images/testing/current/neon-testing-20231003-0251.iso
https://files.kde.org/neon/images/unstable/current/neon-unstable-20231008-1122.iso
https://files.kde.org/neon/images/developer/current/neon-developer-20230921-1641.iso
https://builds.kolibrios.org/eng/kolibri.iso
https://cdimage.ubuntu.com/kubuntu/releases/16.04/release/kubuntu-16.04.6-desktop-amd64.iso
https://cdimage.ubuntu.com/kubuntu/releases/18.04/release/kubuntu-18.04.5-desktop-amd64.iso
https://cdimage.ubuntu.com/kubuntu/releases/20.04/release/kubuntu-20.04.6-desktop-amd64.iso
https://cdimage.ubuntu.com/kubuntu/releases/22.04/release/kubuntu-22.04.3-desktop-amd64.iso
https://cdimage.ubuntu.com/kubuntu/releases/23.04/release/kubuntu-23.04-desktop-amd64.iso
https://sourceforge.net/projects/linux-lite/files/6.2/linux-lite-6.2-64bit.iso
https://sourceforge.net/projects/linux-lite/files/6.4/linux-lite-6.4-64bit.iso
https://sourceforge.net/projects/linux-lite/files/6.6/linux-lite-6.6-64bit.iso
https://mirror.bytemark.co.uk/linuxmint/debian/lmde-5-cinnamon-64bit.iso
https://cdimage.ubuntu.com/lubuntu/releases/16.04/release/lubuntu-16.04.6-desktop-amd64.iso
https://cdimage.ubuntu.com/lubuntu/releases/18.04/release/lubuntu-18.04.5-desktop-amd64.iso
https://cdimage.ubuntu.com/lubuntu/releases/20.04/release/lubuntu-20.04.5-desktop-amd64.iso
https://cdimage.ubuntu.com/lubuntu/releases/22.04/release/lubuntu-22.04.3-desktop-amd64.iso
https://cdimage.ubuntu.com/lubuntu/releases/23.04/release/lubuntu-23.04-desktop-amd64.iso
https://ftp.fi.muni.cz/pub/linux/mageia/iso/8/Mageia-8-Live-Plasma-x86_64/Mageia-8-Live-Plasma-x86_64.iso
https://ftp.fi.muni.cz/pub/linux/mageia/iso/8/Mageia-8-Live-GNOME-x86_64/Mageia-8-Live-GNOME-x86_64.iso
https://ftp.fi.muni.cz/pub/linux/mageia/iso/8/Mageia-8-Live-Xfce-x86_64/Mageia-8-Live-Xfce-x86_64.iso


https://mirror.bytemark.co.uk/linuxmint/stable/20.2
https://mirror.bytemark.co.uk/linuxmint/stable/20.2
https://mirror.bytemark.co.uk/linuxmint/stable/20.2
https://mirror.bytemark.co.uk/linuxmint/stable/20.2
https://sourceforge.net/projects/miyolinux/files/2022-Release/Kwin/miyo-kwin-x86_64-BIOS-20220526.iso
https://sourceforge.net/projects/miyolinux/files/2022-Release/Deboot-Ceres/Deboot-Ceres-x86-64-BIOS-20220415.iso
https://sourceforge.net/projects/miyolinux/files/2022-Release/JWM/miyolinux-jwm-x86_64-BIOS-20220226.iso
https://sourceforge.net/projects/miyolinux/files/2022-Release/Openbox/MiyoLinux-x86_64-BIOS-20220129.iso
https://sourceforge.net/projects/miyolinux/files/2022-Release/MATE/mate-minimal-x86_64-BIOS-20220107.iso
https://sourceforge.net/projects/mx-linux/files/Final/Xfce/MX-21.3_x64.iso
https://sourceforge.net/projects/mx-linux/files/Final/KDE/MX-21.3_KDE_x64.iso
https://sourceforge.net/projects/mx-linux/files/Final/Fluxbox/MX-21.3_fluxbox_x64.iso
https://boot.netboot.xyz/ipxe/netboot.xyz.iso
https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.3/images//NetBSD-9.3-amd64.iso
https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/images//NetBSD-9.2-amd64.iso
https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.1/images//NetBSD-9.1-amd64.iso
https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.0/images//NetBSD-9.0-amd64.iso
https://cdn.netbsd.org/pub/NetBSD/NetBSD-8.2/images//NetBSD-8.2-amd64.iso
https://cdn.netbsd.org/pub/NetBSD/NetBSD-8.1/images//NetBSD-8.1-amd64.iso
https://cdn.netbsd.org/pub/NetBSD/NetBSD-8.0/images//NetBSD-8.0-amd64.iso
https://channels.nixos.org/nixos-21.05
https://channels.nixos.org/nixos-21.05
https://channels.nixos.org/nixos-21.05
https://github.com/kholia/OSX-KVM/raw/master/OpenCore/OpenCore.qcow2
https://github.com/kholia/OSX-KVM/raw/master/OpenCore/OpenCore.qcow2
https://github.com/kholia/OSX-KVM/raw/master/OpenCore/OpenCore.qcow2
https://github.com/kholia/OSX-KVM/raw/master/OpenCore/OpenCore.qcow2
https://github.com/kholia/OSX-KVM/raw/master/OpenCore/OpenCore.qcow2
https://github.com/kholia/OSX-KVM/raw/master/OpenCore/OpenCore.qcow2
https://mirror.leaseweb.com/pub/OpenBSD/6.8/amd64/install68.iso
https://mirror.leaseweb.com/pub/OpenBSD/6.9/amd64/install69.iso
https://mirror.leaseweb.com/pub/OpenBSD/7.0/amd64/install70.iso
https://mirror.leaseweb.com/pub/OpenBSD/7.1/amd64/install71.iso
https://mirror.leaseweb.com/pub/OpenBSD/7.2/amd64/install72.iso
https://mirror.leaseweb.com/pub/OpenBSD/7.3/amd64/install73.iso
https://mirror.leaseweb.com/pub/OpenBSD/7.4/amd64/install74.iso
https://dlc.openindiana.org/isos/hipster/20230421/OI-hipster-gui-20230421.iso
https://dlc.openindiana.org/isos/hipster/20230421/OI-hipster-text-20230421.iso
https://dlc.openindiana.org/isos/hipster/20230421/OI-hipster-minimal-20230421.iso
https://download.opensuse.org/distribution/leap/15.0/iso/openSUSE-Leap-15.0-DVD-x86_64.iso
https://download.opensuse.org/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso
https://download.opensuse.org/distribution/leap/15.2/iso/openSUSE-Leap-15.2-DVD-x86_64-Current.iso
https://download.opensuse.org/distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-x86_64-Current.iso
https://download.opensuse.org/distribution/leap/15.4/iso/openSUSE-Leap-15.4-DVD-x86_64-Current.iso
https://download.opensuse.org/tumbleweed/iso/openSUSE-MicroOS-DVD-x86_64-Current.iso
https://download.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-DVD-x86_64-Current.iso
https://yum.oracle.com/ISOS/OracleLinux/OL7/u7/x86_64//OracleLinux-R7-U7-Server-x86_64-dvd.iso
https://yum.oracle.com/ISOS/OracleLinux/OL7/u8/x86_64//OracleLinux-R7-U8-Server-x86_64-dvd.iso
https://yum.oracle.com/ISOS/OracleLinux/OL7/u9/x86_64//OracleLinux-R7-U9-Server-x86_64-dvd.iso
https://yum.oracle.com/ISOS/OracleLinux/OL8/u4/x86_64//OracleLinux-R8-U4-x86_64-dvd.iso
https://yum.oracle.com/ISOS/OracleLinux/OL8/u5/x86_64//OracleLinux-R8-U5-x86_64-dvd.iso
https://yum.oracle.com/ISOS/OracleLinux/OL8/u6/x86_64//OracleLinux-R8-U6-x86_64-dvd.iso
https://yum.oracle.com/ISOS/OracleLinux/OL9/u0/x86_64//OracleLinux-R9-U0-x86_64-dvd.iso


https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0
https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0
https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0
https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0
https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0
https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0
https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0
https://mirrors.dotsrc.org/porteus/x86_64/Porteus-v5.0
/
/
https://downloads.sourceforge.net/project/reactos/ReactOS/0.4.14/ReactOS-0.4.14-release-93-g10d0e9b-iso.zip

http://dl.rockylinux.org/vault/rocky/8.3
http://dl.rockylinux.org/vault/rocky/8.3
http://dl.rockylinux.org/vault/rocky/8.3
https://mirrors.dotsrc.org/siduction/iso/Standing_on_the_Shoulders_of_Giants/kde/siduction-2023.1.1-Standing_on_the_Shoulders_of_Giants-kde-amd64-202309091853.iso
https://mirrors.dotsrc.org/siduction/iso/Standing_on_the_Shoulders_of_Giants/lxqt/siduction-2023.1.1-Standing_on_the_Shoulders_of_Giants-lxqt-amd64-202309091910.iso
https://mirrors.dotsrc.org/siduction/iso/Standing_on_the_Shoulders_of_Giants/nox/siduction-2023.1.1-Standing_on_the_Shoulders_of_Giants-nox-amd64-202309091923.iso
https://mirrors.dotsrc.org/siduction/iso/Standing_on_the_Shoulders_of_Giants/xfce/siduction-2023.1.1-Standing_on_the_Shoulders_of_Giants-xfce-amd64-202309091902.iso
https://mirrors.dotsrc.org/siduction/iso/Standing_on_the_Shoulders_of_Giants/xorg/siduction-2023.1.1-Standing_on_the_Shoulders_of_Giants-xorg-amd64-202309091916.iso
https://slackware.nl/slackware/slackware-iso/slackware64-14.2-iso/slackware64-14.2-install-dvd.iso
https://slackware.nl/slackware/slackware-iso/slackware64-15.0-iso/slackware64-15.0-install-dvd.iso
https://slax.org/download-slax.php?a=64bit&b=Debian/slax-64bit-11.6.0.iso
https://slax.org/download-slax.php?a=64bit&b=Slackware/slax-64bit-15.0.1.iso
http://mirror.slitaz.org/iso/rolling/slitaz-rolling.iso
http://mirror.slitaz.org/iso/rolling/slitaz-rolling-core.iso
http://mirror.slitaz.org/iso/rolling/slitaz-rolling-core64.iso
http://mirror.slitaz.org/iso/rolling/slitaz-rolling-loram.iso
http://mirror.slitaz.org/iso/rolling/slitaz-rolling-core-5in1.iso
http://mirror.slitaz.org/iso/rolling/slitaz-rolling-preinit.iso
https://mirrors.rit.edu/solus/images/4.3/Solus-4.3-Budgie.iso
https://mirrors.rit.edu/solus/images/4.3/Solus-4.3-GNOME.iso
https://mirrors.rit.edu/solus/images/4.3/Solus-4.3-MATE.iso
https://mirrors.rit.edu/solus/images/4.3/Solus-4.3-Plasma.iso
https://sourceforge.net/projects/spirallinux/files/12.231005/SpiralLinux_Plasma_12.231005_x86-64.iso
https://sourceforge.net/projects/spirallinux/files/12.231005/SpiralLinux_XFCE_12.231005_x86-64.iso
https://sourceforge.net/projects/spirallinux/files/12.231005/SpiralLinux_Mate_12.231005_x86-64.iso
https://sourceforge.net/projects/spirallinux/files/12.231005/SpiralLinux_LXQt_12.231005_x86-64.iso
https://sourceforge.net/projects/spirallinux/files/12.231005/SpiralLinux_Gnome_12.231005_x86-64.iso
https://sourceforge.net/projects/spirallinux/files/12.231005/SpiralLinux_Budgie_12.231005_x86-64.iso
https://sourceforge.net/projects/spirallinux/files/12.231005/SpiralLinux_Cinnamon_12.231005_x86-64.iso
https://sourceforge.net/projects/spirallinux/files/12.231005/SpiralLinux_Builder_12.231005_x86-64.iso
https://download.tails.net/tails/stable/tails-amd64-5.18/tails-amd64-5.18.iso
http://www.tinycorelinux.net/14.x/x86/release/Core-14.0.iso
http://www.tinycorelinux.net/14.x/x86/release/TinyCore-14.0.iso
http://www.tinycorelinux.net/14.x/x86/release/CorePlus-14.0.iso
http://www.tinycorelinux.net/14.x/x86_64/release/CorePure64-14.0.iso
http://www.tinycorelinux.net/14.x/x86_64/release/TinyCorePure64-14.0.iso
https://mirrors.ocf.berkeley.edu/trisquel-images/trisquel_10.0.1
https://mirrors.ocf.berkeley.edu/trisquel-images/trisquel-mini_10.0.1
https://mirrors.ocf.berkeley.edu/trisquel-images/triskel_10.0.1
https://mirrors.ocf.berkeley.edu/trisquel-images/trisquel-sugar_10.0.1

https://download-core.sys.truenas.net/13.0/STABLE/U5.3/x64/TrueNAS-13.0-U5.3.iso

https://download.sys.truenas.net/TrueNAS-SCALE-Bluefin/22.12.4.1/TrueNAS-SCALE-22.12.4.1.iso
https://os.tuxedocomputers.com//TUXEDO-OS-2-202309111354.iso
https://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso
https://releases.ubuntu.com/16.04/ubuntu-16.04.7-desktop-amd64.iso
https://releases.ubuntu.com/18.04/ubuntu-18.04.6-desktop-amd64.iso
https://releases.ubuntu.com/20.04/ubuntu-20.04.6-desktop-amd64.iso
https://releases.ubuntu.com/22.04/ubuntu-22.04.3-desktop-amd64.iso
https://releases.ubuntu.com/23.04/ubuntu-23.04-desktop-amd64.iso
ERROR! Failed to download http://cdimage.ubuntu.com/ubuntu/jammy/daily-live/current/.zsync
ERROR! Failed to download http://cdimage.ubuntu.com/ubuntu/daily-live/current/.zsync
ERROR! Failed to download http://cdimage.ubuntu.com/ubuntu/daily-canary/current/.zsync
https://cdimage.ubuntu.com/ubuntu-budgie/releases/20.04/release/ubuntu-budgie-20.04.6-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntu-budgie/releases/22.04/release/ubuntu-budgie-22.04.3-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntu-budgie/releases/23.04/release/ubuntu-budgie-23.04-desktop-amd64.iso
ERROR! Failed to download http://cdimage.ubuntu.com/ubuntu-budgie/daily-live/current/.zsync
ERROR! Failed to download http://cdimage.ubuntu.com/ubuntu-budgie/daily-live/current/.zsync
ERROR! Failed to download http://cdimage.ubuntu.com/ubuntu-budgie/daily-live/current/.zsync
https://cdimage.ubuntu.com/ubuntucinnamon/releases/23.04/release/ubuntucinnamon-23.04-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntukylin/releases/16.04/release/ubuntukylin-16.04.7-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntukylin/releases/18.04/release/ubuntukylin-18.04.5-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntukylin/releases/20.04/release/ubuntukylin-20.04.6-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntukylin/releases/22.04/release/ubuntukylin-22.04.3-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntukylin/releases/23.04/release/ubuntukylin-23.04-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntu-mate/releases/16.04/release/ubuntu-mate-16.04.6-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntu-mate/releases/18.04/release/ubuntu-mate-18.04.5-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntu-mate/releases/20.04/release/ubuntu-mate-20.04.6-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntu-mate/releases/22.04/release/ubuntu-mate-22.04.3-desktop-amd64.iso
https://cdimage.ubuntu.com/ubuntu-mate/releases/23.04/release/ubuntu-mate-23.04-desktop-amd64.iso
https://releases.ubuntu.com/18.04/ubuntu-18.04.6-live-server-amd64.iso
https://releases.ubuntu.com/20.04/ubuntu-20.04.6-live-server-amd64.iso
https://releases.ubuntu.com/22.04/ubuntu-22.04.3-live-server-amd64.iso
https://releases.ubuntu.com/23.04/ubuntu-23.04-live-server-amd64.iso
https://cdimage.ubuntu.com/ubuntustudio/releases/16.04/release/ubuntustudio-16.04.5-dvd-amd64.iso
https://cdimage.ubuntu.com/ubuntustudio/releases/18.04/release/ubuntustudio-18.04-dvd-amd64.iso
https://cdimage.ubuntu.com/ubuntustudio/releases/20.04/release/ubuntustudio-20.04.5-dvd-amd64.iso
https://cdimage.ubuntu.com/ubuntustudio/releases/22.04/release/ubuntustudio-22.04.3-dvd-amd64.iso
https://cdimage.ubuntu.com/ubuntustudio/releases/23.04/release/ubuntustudio-23.04-dvd-amd64.iso
https://cdimage.ubuntu.com/ubuntu-unity/releases/23.04/release/ubuntu-unity-23.04-desktop-amd64.iso
https://cdn.vanillaos.org/assets/ISO/22.10-r8/VanillaOS-22.10-all.20230226.iso
https://github.com/ventoy/Ventoy/releases/download/v1.0.95/ventoy-1.0.95-livecd.iso
https://alpha.de.repo.voidlinux.org/live/current/void-live-x86_64-20230628-base.iso
https://alpha.de.repo.voidlinux.org/live/current/void-live-x86_64-musl-20230628-base.iso
https://alpha.de.repo.voidlinux.org/live/current/void-live-x86_64-20230628-xfce.iso
https://alpha.de.repo.voidlinux.org/live/current/void-live-x86_64-musl-20230628-xfce.iso
https://downloads.sourceforge.net/project/vpup/VoidPup64/VoidPup64-22.02-230701.iso
https://github.com/VX-Linux/main/releases/download/6.1.5/vx-6.1.5.iso
https://github.com/VX-Linux/main/releases/download/6.0/vx-6.0.iso
https://github.com/VX-Linux/main/releases/download/5.5/vx-5.5.iso
https://github.com/VX-Linux/main/releases/download/5.4/vx-5.4.iso
https://github.com/VX-Linux/main/releases/download/5.3/vx-5.3.iso
https://github.com/VX-Linux/main/releases/download/5.2/vx-5.2.iso
https://github.com/VX-Linux/main/releases/download/5.1/vx-5.1.iso
https://github.com/VX-Linux/main/releases/download/5.0/vx-5.0.iso
Downloading Windows 10 22H2...
https://www.itechtics.com/?dl_id=173
Downloading Windows 11 22H2...
https://www.itechtics.com/?dl_id=168
https://sourceforge.net/projects/xerolinux/files/Releases/xerolinux-2022.12-x86_64.iso
https://cdimage.ubuntu.com/xubuntu/releases/16.04/release/xubuntu-16.04.6-desktop-amd64.iso
https://cdimage.ubuntu.com/xubuntu/releases/18.04/release/xubuntu-18.04.5-desktop-amd64.iso
https://cdimage.ubuntu.com/xubuntu/releases/20.04/release/xubuntu-20.04.6-desktop-amd64.iso
https://cdimage.ubuntu.com/xubuntu/releases/22.04/release/xubuntu-22.04.3-desktop-amd64.iso
https://cdimage.ubuntu.com/xubuntu/releases/23.04/release/xubuntu-23.04-desktop-amd64.iso
https://free.download.zorinos.com/16/Zorin-OS-16.3-Core-64-bit.iso
https://free.download.zorinos.com/16/Zorin-OS-16.3-Lite-64-bit.iso
https://free.download.zorinos.com/16/Zorin-OS-16.3-Education-64-bit.iso
https://free.download.zorinos.com/16/Zorin-OS-16.3-Education-Lite-64-bit.iso
`

</details>

closes #783
