### PR TITLE
quickemu: fix version

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1540,7 +1540,7 @@ SOUND_CARD=""
 # shellcheck disable=SC2155
 readonly LAUNCHER=$(basename "${0}")
 readonly DISK_MIN_SIZE=$((197632 * 8))
-readonly VERSION="4.8"
+readonly VERSION="4.9"
 
 # TODO: Make this run the native architecture binary
 QEMU=$(command -v qemu-system-x86_64)


### PR DESCRIPTION
The latest [4.9](https://github.com/quickemu-project/quickemu/releases/tag/4.9) missed update on the version variable in quickemu.
Could there be a bugfix 4.9.1 release?