### PR TITLE
Update batocera version in quickget

### DIFF
--- a/quickget
+++ b/quickget
@@ -398,7 +398,7 @@ function releases_fedora() {
 }
 
 function releases_batocera() {
-  echo 32 33 34
+  echo latest
 }
 
 function editions_fedora() {


### PR DESCRIPTION
As the quickget download the latest Batocera version only it's more convenient to use "latest" instead of old versions