### PR TITLE
change Board_id for ventura image

### DIFF
--- a/quickget
+++ b/quickget
@@ -1587,8 +1587,7 @@ function get_macos() {
         monterey)       #12
             BOARD_ID="Mac-E43C1C25D4880AD6";;
         ventura)        #13
-            BOARD_ID="Mac-7BA5B2D9E42DDD94"
-            OS_TYPE="latest";;
+            BOARD_ID="Mac-BE088AF8C5EB4FA2";;
         *) echo "ERROR! Unknown release: ${RELEASE}"
            releases_macos
            exit 1;;


### PR DESCRIPTION
after a week, macos servers change default mac os recovery image for old board id
this pull request retrieve new board id from [this project](https://github.com/acidanthera/OpenCorePkg/blob/master/Utilities/macrecovery/boards.json)