### PR TITLE
Have wget retry when download stalls for 10 seconds

### DIFF
--- a/quickget
+++ b/quickget
@@ -846,7 +846,7 @@ function web_get() {
         fi
         echo #Necessary as aria2c in suppressed mode does not have new lines
     else
-        if ! wget --quiet --continue --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
+        if ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
           echo "ERROR! Failed to download ${URL} with wget. Try running 'quickget' again."
           exit 1
         fi


### PR DESCRIPTION
When I download files greater than 2GB in size the download always fails around the 2GB mark.
So I have to resume the download. If the size is greater than 4GB the download stalls again. etc. etc...

Without the proposed changes the download just hangs.
The if statement never completes and thus quickget sees no error.
A rerun does the trick. So this is essentially trying to save the user from doing a rerun. If all tries fail, a rerun is required anyway.

I set --tries to 3, so that I can download up to 6 GB without have to rerun. I am not sure how large the different images are. The Ubuntu Desktop image is 4.7 GB and I believe the Windows image is around 5.5 GB. So 3 tries seemed reasonable.

The 10 seconds are chosen arbitrarily. It has to be something to trigger a retry.

Aria seems to overcome my quirky internet limitations with it's current options, so no changes needed there.
I have not tried zsync as I have having issues finding available options.

---
\# edit

With the help of the discord forums I was able to test quickgui with my modifications.
As such my modifications have no effect on quickgui if the download succeeds. There are no changes.
Quickgui just has issues with failed downloads.
Whenever a download fails/succeeds Quickgui just says 'Download finished'
Before my changes the download just hanged and consequently Quickgui stopped receiving updates.
Now wget fails after X amount of tries and Quick then says 'Download finished'

---

A demonstration of my issue.

![Screenshot from 2023-11-05 21-33-46](https://github.com/quickemu-project/quickemu/assets/36673513/b1d7a26b-951c-4622-a796-32a3d88bc0f0)

The first download had stalled for 20-30 minutes when I cancelled it.
I then delete the partially downloaded file to fully demonstrate the effects of my changes