### PR TITLE
Add additional "--access" parameter to allow remote access to spice session

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ Usage
   quickemu --vm ubuntu.conf
 
 You can also pass optional parameters
+  --access                          : Enable remote spice access support. 'local' (default), 'remote', 'clientipaddress'
   --braille                         : Enable braille support. Requires SDL.
   --delete-disk                     : Delete the disk image and EFI variables
   --delete-vm                       : Delete the entire VM and it's configuration

--- a/docs/quickemu.1.md
+++ b/docs/quickemu.1.md
@@ -27,6 +27,9 @@ machines for Linux, macOS and Windows
 
 You can also pass optional parameters
 
+**--access**
+:   Enable remote spice access support. 'local' (default), 'remote', 'clientipaddress'
+
 **--braille**
 :   Enable braille support. Requires SDL.
 
@@ -552,6 +555,7 @@ Here are the usage instructions:
       quickemu --vm ubuntu.conf
 
     You can also pass optional parameters
+      --access                          : Enable remote spice access support. 'local' (default), 'remote', 'clientipaddress'
       --braille                         : Enable braille support. Requires SDL.
       --delete-disk                     : Delete the disk image and EFI variables
       --delete-vm                       : Delete the entire VM and it's configuration

--- a/quickemu
+++ b/quickemu
@@ -848,6 +848,19 @@ function vm_boot() {
       SPICE_PORT=$(get_port 5930 9)
     fi
 
+    # ALLOW REMOTE ACCESS TO SPICE OVER LAN RATHER THAN JUST LOCALHOST
+    if [ -z "${ACCESS}" ]; then
+      SPICE_ADDR="127.0.0.1"
+    else
+      if [ "${ACCESS}" == "remote" ]; then
+        SPICE_ADDR=""
+      elif [ "${ACCESS}" == "local" ]; then
+        SPICE_ADDR="127.0.0.1"
+      else
+        SPICE_ADDR="${ACCESS}"
+      fi
+    fi
+
     if [ -z "${SPICE_PORT}" ]; then
       echo " - SPICE:    All SPICE ports have been exhausted."
       if [ "${OUTPUT}" == "none" ] || [ "${OUTPUT}" == "spice" ] || [ "${OUTPUT}" == "spice-app" ]; then
@@ -864,7 +877,7 @@ function vm_boot() {
           echo -n " --spice-shared-dir ${PUBLIC}"
         fi
         echo "${FULLSPICY}"
-        SPICE="${SPICE},port=${SPICE_PORT},addr=127.0.0.1"
+        SPICE="${SPICE},port=${SPICE_PORT},addr=${SPICE_ADDR}"
       fi
     fi
   fi
@@ -1231,7 +1244,6 @@ function vm_boot() {
     exit 1
   fi
 
-
   if [ -z "${EXTRA_ARGS}" ]; then
     EXTRA_ARGS="${extra_args}"
   fi
@@ -1326,6 +1338,7 @@ function usage() {
   echo "  ${LAUNCHER} --vm ubuntu.conf"
   echo
   echo "You can also pass optional parameters"
+  echo "  --access                          : Select whether to enable remote spice access. 'local' (default), 'remote' 'clientipaddress'"
   echo "  --braille                         : Enable braille support. Requires SDL."
   echo "  --delete-disk                     : Delete the disk image and EFI variables"
   echo "  --delete-vm                       : Delete the entire VM and it's configuration"
@@ -1498,6 +1511,7 @@ mouse="tablet"
 # options: intel-hda, ac97, es1370, sb16, none
 sound_card="intel-hda"
 
+ACCESS=""
 BRAILLE=""
 DELETE_DISK=0
 DELETE_VM=0
@@ -1564,6 +1578,10 @@ if [ $# -lt 1 ]; then
 else
     while [ $# -gt 0 ]; do
         case "${1}" in
+          -access|--access)
+            ACCESS="${2}"
+            shift
+            shift;;
           -braille|--braille)
             BRAILLE="on"
             shift;;


### PR DESCRIPTION
**Issue:** 
Using remote-viewer locally on the host (ex: spice://localhost:5930) works, however using it remotely (ex: spice://192.168.0.10:5930) will not connect.
[See issue](https://github.com/quickemu-project/quickemu/issues/833)

**Code Changes:**
The following code changes add an additional parameter (--access). 

If this parameter is excluded the status quo remains and spice sessions can only connect from 127.0.0.1. The same outcome occurs if the "local" option is used (ex: --access local). 

If the "remote" option (ex: --access remote) is used then no IP restrictions are imposed and the spice IP address section is left blank, allowing access from any machine that your firewall would otherwise allow.

A third custom option is also permitted (ex: --access 192.168.0.52) which allows defining a custom IP for spice access