### PR TITLE
fix: make revised batocera actually find the latest file

### DIFF
--- a/quickget
+++ b/quickget
@@ -1320,22 +1320,7 @@ function get_batocera() {
     local HASH=""
     local URL="https://mirrors.o2switch.fr/batocera/x86_64/stable/last"
     local ISO="$(curl -sl ${URL}/ | grep -e 'batocera.*img.gz'|cut -d\" -f2)"
-    local CURRENT_RELEASE=$(echo "${ISO}"| cut -d\- -f3)
-
-
-    case ${RELEASE} in
-      ${CURRENT_RELEASE})  #Current release
-         URL+=""
-         ;;
-      *)
-         URL+="/archives/${RELEASE}"
-         ISO="$(curl -sl ${URL}/ | grep -e 'batocera.*img.gz'|cut -d\" -f2)"
-         ;; # non-current are here
-
-    esac
-
-
-    echo "${URL}/${ISO} ${HASH}"
+     echo "${URL}/${ISO} ${HASH}"
 }
 
 function get_bodhi() {


### PR DESCRIPTION
Without also removing the old case comparing the last release with the requested etc the new code always generated a non-existant URL.
This seems to get the latest file again.