### PR TITLE
Fix -s/-t flags still downloading isos

### DIFF
--- a/quickget
+++ b/quickget
@@ -952,25 +952,23 @@ function web_get() {
       exit 1
     fi
 
-    if command -v aria2c &>/dev/null; then
+	# Test mode for ISO (yet wget only)
+	if [ "${show_iso_url}" == 'on' ]; then
+	    echo "${URL}"
+	    exit 0
+    elif [ "${test_iso_url}" == 'on' ]; then
+	    wget --spider "${URL}"
+	    exit 0
+    elif command -v aria2c &>/dev/null; then
         if ! aria2c --stderr -x16 --continue=true --summary-interval=0 --download-result=hide --console-log-level=error "${URL}" --dir "${DIR}" -o "${FILE}"; then
           echo #Necessary as aria2c in suppressed mode does not have new lines
           echo "ERROR! Failed to download ${URL} with aria2c. Try running 'quickget' again."
           exit 1
         fi
         echo #Necessary as aria2c in suppressed mode does not have new lines
-    # Test mode for ISO (yet wget only)
-    elif [ "${show_iso_url}" == 'on' ]; then
-          echo "${URL}"
-          exit 0
-    elif [ "${test_iso_url}" == 'on' ]; then
-          wget --spider "${URL}"
-          exit 0
-    else
-        if ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
-          echo "ERROR! Failed to download ${URL} with wget. Try running 'quickget' again."
-          exit 1
-        fi
+    elif ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
+        echo "ERROR! Failed to download ${URL} with wget. Try running 'quickget' again."
+        exit 1
     fi
 }
 
@@ -980,7 +978,14 @@ function zsync_get() {
     local OUT=""
     local URL="${1}"
 
-    if command -v zsync &>/dev/null; then
+	# Test mode for ISO (yet wget only)
+	if [ "${show_iso_url}" == 'on' ]; then
+	    echo "${URL}"
+	    exit 0
+    elif [ "${test_iso_url}" == 'on' ]; then
+	    wget --spider "${URL}"
+	    exit 0
+    elif command -v zsync &>/dev/null; then
         if [ -n "${3}" ]; then
             OUT="${3}"
         else

--- a/quickget
+++ b/quickget
@@ -952,7 +952,7 @@ function web_get() {
       exit 1
     fi
 
-	# Test mode for ISO (yet wget only)
+	# Test mode for ISO
 	if [ "${show_iso_url}" == 'on' ]; then
 	    echo "${URL}"
 	    exit 0
@@ -978,7 +978,7 @@ function zsync_get() {
     local OUT=""
     local URL="${1}"
 
-	# Test mode for ISO (yet wget only)
+	# Test mode for IS
 	if [ "${show_iso_url}" == 'on' ]; then
 	    echo "${URL}"
 	    exit 0

--- a/quickget
+++ b/quickget
@@ -978,7 +978,7 @@ function zsync_get() {
     local OUT=""
     local URL="${1}"
 
-	# Test mode for IS
+	# Test mode for ISO
 	if [ "${show_iso_url}" == 'on' ]; then
 	    echo "${URL}"
 	    exit 0


### PR DESCRIPTION
This should fix iso download commencing when using new `-s/-t` flags

Fixes #845 

@philclifford Can you test this?