### PR TITLE
Add options to directly specify VM width and height on cmdline or config

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -770,7 +770,11 @@ function vm_boot() {
 
   # Try and coerce the display resolution for Linux guests only.
   if [ "${guest_os}" == "linux" ]; then
-    VIDEO="${VIDEO},xres=${X_RES},yres=${Y_RES}"
+    if [ -n "${WIDTH}" ] && [ -n "${HEIGHT}" ]; then
+      VIDEO="${VIDEO},xres=${WIDTH},yres=${HEIGHT}"
+    else
+      VIDEO="${VIDEO},xres=${X_RES},yres=${Y_RES}"
+    fi
   fi
 
   # Allocate VRAM to VGA devices
@@ -1354,6 +1358,8 @@ function usage() {
   echo "  --snapshot info                   : Show disk/snapshot info."
   echo "  --status-quo                      : Do not commit any changes to disk/snapshot."
   echo "  --viewer <viewer>                 : Choose an alternative viewer. @Options: 'spicy' (default), 'remote-viewer', 'none'"
+  echo "  --width <width>                   : Set VM screen width. Does nothing without --height"
+  echo "  --height <height>                 : Set VM screen height. Does nothing without --width"
   echo "  --ssh-port <port>                 : Set ssh-port manually"
   echo "  --spice-port <port>               : Set spice-port manually"
   echo "  --public-dir <path>               : Expose share directory. @Options: '' (default: xdg-user-dir PUBLICSHARE), '<directory>', 'none'"
@@ -1491,6 +1497,8 @@ secureboot="off"
 tpm="off"
 usb_devices=()
 viewer="spicy"
+width=""
+height=""
 ssh_port=""
 spice_port=""
 public_dir=""
@@ -1533,6 +1541,8 @@ VMDIR=""
 VMNAME=""
 VMPATH=""
 VIEWER=""
+WIDTH=""
+HEIGHT=""
 SSH_PORT=""
 SPICE_PORT=""
 MONITOR=""
@@ -1651,6 +1661,14 @@ else
             VIEWER="${2}"
             shift
             shift;;
+          -width|--width)
+            WIDTH="${2}"
+            shift;
+            shift;;
+          -height|--height)
+            HEIGHT="${2}"
+            shift;
+            shift;;
           -ssh-port|--ssh-port)
             SSH_PORT="${2}"
             shift;
@@ -1766,6 +1784,11 @@ if [ -n "${VM}" ] && [ -e "${VM}" ]; then
     VIEWER="${viewer}"
   fi
   viewer_param_check
+
+  if [ -z "${WIDTH}" ] || [ -z "${HEIGHT}" ] ; then
+    WIDTH="${width}"
+    HEIGHT="${height}"
+  fi
 
   # Set the default 3D acceleration.
   if [ -z "${gl}" ]; then


### PR DESCRIPTION
This PR adds `--width` and `--height` arguments, as well as `width` and `height` config options, overriding hardcoded resolutions when specified.

It looks like this may only apply to Linux VMs, but it may prove useful in the event that automatically resizing fails.