### PR TITLE
#874 - Fix failing to launch VMs from outside directory

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1736,7 +1736,10 @@ if [ -n "${VM}" ] && [ -e "${VM}" ]; then
     VMPATH=$(realpath "$(dirname "${VM}")")
     VM_MONITOR_SOCKETPATH="${VMDIR}/${VMNAME}-monitor.socket"
     VM_SERIAL_SOCKETPATH="${VMDIR}/${VMNAME}-serial.socket"
-
+    if [ ! -f "${disk_img}" ]; then
+        cd "${VMPATH}"
+    fi
+    
     # Backwards compatibility for ${driver_iso}
     if [ -n "${driver_iso}" ] && [ -z "${fixed_iso}" ]; then
         fixed_iso="${driver_iso}"


### PR DESCRIPTION
The args array doesn't work properly when quotes are used, so the other fix I thought of (appending VM Path to every variable) wouldn't work if there's a space in the path. Changing directory isn't the best solution, but I can't think of any issues it would cause in this specific case.