### PR TITLE
Fix wget2 with quickget (#878)

### DIFF
--- a/quickget
+++ b/quickget
@@ -1253,7 +1253,7 @@ function get_archcraft() {
     local URL=""
     local TMPURL=""
 
-    TMPURL=$(wget -q -S -O- --max-redirect=0 "https://sourceforge.net/projects/archcraft/files/latest/download" 2>&1 | grep -i Location | cut -d' ' -f4)
+    TMPURL=$(curl -Lfs "https://sourceforge.net/projects/archcraft/files/latest/download" -w %{url_effective} -o /this/is/a/nonexistent/directory/$RANDOM/$RANDOM)
     URL=${TMPURL%\?*}
     echo "${URL} ${HASH}"
 }
@@ -1916,7 +1916,7 @@ function get_reactos() {
     local URL=""
     local TMPURL=""
 
-    TMPURL=$(wget -q -S -O- --max-redirect=0 "https://sourceforge.net/projects/reactos/files/latest/download" 2>&1 | grep -i Location | cut -d' ' -f4)
+    TMPURL=$(curl -Lfs "https://sourceforge.net/projects/reactos/files/latest/download"-w %{url_effective} -o /this/is/a/nonexistent/directory/$RANDOM/$RANDOM)
     URL=${TMPURL%\?*}
     echo "${URL} ${HASH}"
 }
@@ -2187,7 +2187,7 @@ function get_zorin() {
     local URL=""
 
     # Parse out the iso URL from the redirector
-    URL=$(wget -q -S -O- --max-redirect=0 "https://zrn.co/${RELEASE}${EDITION}" 2>&1 | grep Location | cut -d' ' -f4)
+    URL=$(curl -Lfs "https://zrn.co/${RELEASE}${EDITION}" -w %{url_effective} -o /this/is/a/nonexistent/directory/$RANDOM/$RANDOM)
     echo "${URL} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -1916,7 +1916,7 @@ function get_reactos() {
     local URL=""
     local TMPURL=""
 
-    TMPURL=$(curl -Lfs "https://sourceforge.net/projects/reactos/files/latest/download"-w %{url_effective} -o /this/is/a/nonexistent/directory/$RANDOM/$RANDOM)
+    TMPURL=$(curl -Lfs "https://sourceforge.net/projects/reactos/files/latest/download" -w %{url_effective} -o /this/is/a/nonexistent/directory/$RANDOM/$RANDOM)
     URL=${TMPURL%\?*}
     echo "${URL} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -939,6 +939,12 @@ function web_get() {
       exit 1
     fi
 
+    if command -v wget2 &>/dev/null; then
+        local WGET_PROGRESS="--force-progress"
+    else   
+        local WGET_PROGRESS="--show-progress"
+    fi
+
     if command -v aria2c &>/dev/null; then
         if ! aria2c --stderr -x16 --continue=true --summary-interval=0 --download-result=hide --console-log-level=error "${URL}" --dir "${DIR}" -o "${FILE}"; then
           echo #Necessary as aria2c in suppressed mode does not have new lines
@@ -946,7 +952,7 @@ function web_get() {
           exit 1
         fi
         echo #Necessary as aria2c in suppressed mode does not have new lines
-    elif ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
+    elif ! wget --quiet --continue --tries=3 --read-timeout=10 "${WGET_PROGRESS}" --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
         echo "ERROR! Failed to download ${URL} with wget. Try running 'quickget' again."
         exit 1
     fi

--- a/quickget
+++ b/quickget
@@ -939,12 +939,6 @@ function web_get() {
       exit 1
     fi
 
-    if wget --help | grep -q Wget2; then
-        local WGET_PROGRESS="--force-progress"
-    else   
-        local WGET_PROGRESS="--show-progress"
-    fi
-
     if command -v aria2c &>/dev/null; then
         if ! aria2c --stderr -x16 --continue=true --summary-interval=0 --download-result=hide --console-log-level=error "${URL}" --dir "${DIR}" -o "${FILE}"; then
           echo #Necessary as aria2c in suppressed mode does not have new lines
@@ -952,7 +946,12 @@ function web_get() {
           exit 1
         fi
         echo #Necessary as aria2c in suppressed mode does not have new lines
-    elif ! wget --quiet --continue --tries=3 --read-timeout=10 "${WGET_PROGRESS}" --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
+    elif command -v wget2 &>/dev/null; then
+        if ! wget2 --quiet --continue --tries=3 --read-timeout=10 --force-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
+            echo "ERROR! Failed to download ${URL} with wget2. Try running 'quickget' again."
+            exit 1
+        fi
+    elif ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}"; then
         echo "ERROR! Failed to download ${URL} with wget. Try running 'quickget' again."
         exit 1
     fi

--- a/quickget
+++ b/quickget
@@ -939,7 +939,7 @@ function web_get() {
       exit 1
     fi
 
-    if command -v wget2 &>/dev/null; then
+    if wget --help | grep -q Wget2; then
         local WGET_PROGRESS="--force-progress"
     else   
         local WGET_PROGRESS="--show-progress"


### PR DESCRIPTION
Wget2 renames "show-progress" to "force-progress". This fixes the command when wget2 is installed. 
Fixes #878 