### PR TITLE
Improve the code used to determine host RAM amount.

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -313,9 +313,8 @@ function vm_boot() {
     local RAM_VM="2G"
     if [ -z "${ram}" ]; then
         local RAM_HOST=""
-        RAM_HOST=$(free --mega -h | grep Mem | cut -d':' -f2 | cut -d'G' -f1 | sed 's/ //g')
-        #Round up - https://github.com/wimpysworld/quickemu/issues/11
-        RAM_HOST=$(printf '%.*f\n' 0 "${RAM_HOST}")
+        # Determine the number of gigabytes of RAM in the host by extracting the first numerical value from the output.
+        RAM_HOST=$(free --giga | tr ' ' '\n' | grep -m 1 [0-9])
         if [ "${RAM_HOST}" -ge 128 ]; then
             RAM_VM="32G"
         elif [ "${RAM_HOST}" -ge 64 ]; then


### PR DESCRIPTION
Fixes #899 

Current RAM check is not very versatile. It functions by printing out text following the colon, preceding the first instance of the character 'G', excluding spaces. This will throw an error on systems with under 1GB or over 1000GB of memory, since 'G' does not follow the first value, and it's not possible to round (or use the greater than/equal to operator) on strings. This resolves that issue, as well as removing the need for rounding in the first place, since free --giga does not print out floating point values.