### PR TITLE
feat: OS distribution rss feed

### DIFF
--- a/.github/workflows/rss.yml
+++ b/.github/workflows/rss.yml
@@ -1,0 +1,27 @@
+--- # RSS feed
+name: Monitor new OS versions
+
+on:
+  schedule:
+    # Run this Action every day at 7:37am UTC
+    - cron: "37 7 * * *"
+  push:
+    branches: '**' #'!master' # excludes master
+    paths-ignore: [ '**/README.md' ]
+  pull_request:
+    branches: '**' # matches every branch
+    paths-ignore: [ '**/README.md' ]
+  workflow_dispatch:
+jobs:
+  distrowatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: git-for-windows/rss-to-issues@v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          feed: https://distrowatch.com/news/dwd.xml
+          prefix: "[OS]"
+          character-limit: 255
+          dry-run: false
+          max-age: 48h
+          labels: distrowatch

--- a/.github/workflows/rss.yml
+++ b/.github/workflows/rss.yml
@@ -1,16 +1,10 @@
 --- # RSS feed
-name: Monitor new OS versions
+name: Monitor new OS versions (distrowatch)
 
 on:
   schedule:
     # Run this Action every day at 7:37am UTC
-    - cron: "37 7 * * *"
-  push:
-    branches: '**' #'!master' # excludes master
-    paths-ignore: [ '**/README.md' ]
-  pull_request:
-    branches: '**' # matches every branch
-    paths-ignore: [ '**/README.md' ]
+    - cron: '0 18 * * *'
   workflow_dispatch:
 jobs:
   distrowatch:


### PR DESCRIPTION
For now DistroWatch only for testing. Could be any number of RSS feeds

Should I work more on this?
usecase: Get actual new release info into github action, test and apply to quickget without intervention.

see [issues](https://github.com/oSoWoSo/quickemu/issues)
and
[actions](https://github.com/oSoWoSo/quickemu/actions/workflows/rss.yml)