### PR TITLE
quickemu: Support $disk_format var for $disk_img

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1145,7 +1145,7 @@ function vm_boot() {
     else
         # shellcheck disable=SC2054,SC2206
         args+=(-device virtio-blk-pci,drive=SystemDisk
-            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+            -drive id=SystemDisk,if=none,format=${disk_format:-qcow2},file="${disk_img}" ${STATUS_QUO})
     fi
 
     # https://wiki.qemu.org/Documentation/9psetup
@@ -1473,6 +1473,7 @@ function monitor_send_cmd {
 boot="efi"
 cpu_cores=""
 disk_img=""
+disk_format=""
 disk_size=""
 display=""
 extra_args=""

--- a/quickemu
+++ b/quickemu
@@ -1750,7 +1750,7 @@ if [ -n "${VM}" ] && [ -e "${VM}" ]; then
 
     # Set the default disk_format if not provided by user
     if [ -z "${disk_format}" ]; then
-        disk_format=$(${QEMU_IMG} info "${disk_img}" | gawk '/^file format: / {print $NF}')
+        disk_format=$(${QEMU_IMG} info "${disk_img}" | grep 'file format' | cut -d ':' -f 2 | tr -cd '[:graph:]')
     fi
 
     if [ -n "${display}" ]; then

--- a/quickemu
+++ b/quickemu
@@ -1748,6 +1748,11 @@ if [ -n "${VM}" ] && [ -e "${VM}" ]; then
         disk_size="${disk}"
     fi
 
+    # Set the default disk_format if not provided by user
+    if [ -z "${disk_format}" ]; then
+        disk_format=$(${QEMU_IMG} info "${disk_img}" | gawk '/^file format: / {print $NF}')
+    fi
+
     if [ -n "${display}" ]; then
         OUTPUT="${display}"
     fi


### PR DESCRIPTION
This adds disk_format=${disk_format:-qcow2} variable that defaults to qcow2 format, so the vm.conf files can use $disk_format to specify the format of the $disk_img when this is different from the default qcow2.