### PR TITLE
Add socat to Fedora dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Debian (and direct derivatives such as MX Linux):
 
 Fedora:
 
-    sudo dnf install qemu bash coreutils edk2-tools grep jq lsb procps python3 genisoimage usbutils util-linux sed spice-gtk-tools swtpm wget xdg-user-dirs xrandr unzip
+    sudo dnf install qemu bash coreutils edk2-tools grep jq lsb procps python3 genisoimage usbutils util-linux sed spice-gtk-tools swtpm wget xdg-user-dirs xrandr unzip socat
 
 MacOS:
 


### PR DESCRIPTION
`socat` is a missing dependency.