### PR TITLE
Add spice-gtk-tools to Fedora packages in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Debian (and direct derivatives such as MX Linux):
 
 Fedora:
 
-    sudo dnf install qemu bash coreutils edk2-tools grep jq lsb procps python3 genisoimage usbutils util-linux sed spice-gtk-tools swtpm wget xdg-user-dirs xrandr unzip
+    sudo dnf install qemu bash coreutils edk2-tools grep jq lsb procps python3 genisoimage usbutils util-linux sed spice-gtk-tools swtpm wget xdg-user-dirs xrandr unzip spice-gtk-tools
 
 MacOS:
 


### PR DESCRIPTION
On Fedora, the spice-gtk-tools provides the spicy command.

Without it, quickemu with default config fails with the following message:

```
ERROR! Requested 'spicy' as viewer, but 'spicy' is not installed.
```