### PR TITLE
Use only latest blendos release

### DIFF
--- a/quickget
+++ b/quickget
@@ -524,13 +524,15 @@ function releases_biglinux() {
 }
 
 function releases_blendos() {
-    # Pull the rss feed
+    echo latest
+}
+
+function editions_blendos() {
     wget -q https://sourceforge.net/projects/blendos/rss?path=/ISOs/ -O- | grep -E -o 'https://.*blendOS\.iso.*</media:hash' >/tmp/blendos-isos.rss
 
-    local RLIST
-    RLIST=$(grep -E -o 'https://.*blendOS\.iso.*</media:hash' /tmp/blendos-isos.rss | cut -d/ -f 8-9 | sort -r -t/  --key=2 |grep -e '16878' -e '168[8-9]'| tr '\r\n' ' ')
-    echo "${RLIST}"
-
+    local BLENDOS_EDITIONS
+    BLENDOS_EDITIONS="$(grep -E -o 'https://.*blendOS\.iso.*</media:hash' /tmp/blendos-isos.rss | cut -d '/' -f 8 | sort | uniq | tr '\n' ' ')"
+    echo "${BLENDOS_EDITIONS}"
 }
 
 function releases_bunsenlabs() {
@@ -859,7 +861,7 @@ function editions_primtux() {
 }
 
 function releases_pureos() {
-    wget -q -O- "https://www.pureos.net/download/" | grep -m 1 "downloads.puri" | cut -d '"' -f 2 | cut -d '-' -f 4 
+    wget -q -O- "https://www.pureos.net/download/" | grep -m 1 "downloads.puri" | cut -d '"' -f 2 | cut -d '-' -f 4
 }
 function editions_pureos() {
     echo gnome plasma
@@ -1561,23 +1563,15 @@ function get_biglinux() {
 }
 
 function get_blendos() {
-
     local HASH=""
     local URL=""
+    local latest_blendos_release
 
-    # BlendOS has more editions and releases but there's a tracker indirect and other issues
-    # so easier to use the rss feed
-    #
-    # We have to provide edition/release as RELEASE or have a major refactor
-    # But this works for now ... or does it ....
-    URL=$(grep ${RELEASE} /tmp/blendos-isos.rss | grep -E -o 'https://.*blendOS\.iso')
-    HASH=$(grep ${RELEASE} /tmp/blendos-isos.rss | grep -E -o '[[:alnum:]]{32}')
-    # ## fix up variables for path naming
-      EDITION=${RELEASE%%/*}
-      RELEASE=${RELEASE##*/}
-      # For UX maybe show the date of the release
-      #echo ${RELEASE##*/} "(" $(date -d @${RELEASE##*/}) ")"
-      # maybe $(date -d @${RELEASE##*/} '+%Y%m%d')
+    latest_blendos_release="$(grep "${EDITION}" /tmp/blendos-isos.rss | cut -d '/' -f 9 | sort -nr | head -n 1)"
+
+    URL=$(grep "${EDITION}/${latest_blendos_release}" /tmp/blendos-isos.rss | grep -E -o 'https://.*blendOS\.iso')
+    HASH=$(grep "${EDITION}/${latest_blendos_release}" /tmp/blendos-isos.rss | grep -E -o '[[:alnum:]]{32}')
+
       echo "${URL} ${HASH}"
 }
 
@@ -2407,7 +2401,7 @@ function get_pureos() {
     local IsoTrimmed=
     IsoTrimmed="${ISO%.*}"
     HASH="$(wget -q -O- "${URL}/${IsoTrimmed}.checksums_sha256.txt" | grep -m 1 '.iso' | cut -d '.' -f 1)"
-    echo "${URL}/${ISO} ${HASH}" 
+    echo "${URL}/${ISO} ${HASH}"
 }
 
 


### PR DESCRIPTION
Currently, quickget determines the blendos release/edition combinations using its RSS feed, and then prints them all out as releases. For example, you'll see output like this: `plasma/1688424625 gnome/1688424211 deepin/1688423865 lxqt/1688423615 mate/1688423313 xfce/1688423053 cinnamon/1688422684 plasma/168787346`.
This also causes significant issues, such as directory names including slashes, as seen in #995.

This PR proposes replacing this mess with just offering the user the latest release, and listing out the available editions instead. The latest release is determined by numerically sorting through every available release within the selected edition. The releases & editions cannot be listed separately, since each edition has different releases (which are based on epoch time). Therefore, I think this is the best available solution.

Closes #995