### PR TITLE
chore: disable reviewdog for PRs

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -3,7 +3,6 @@ name: 'Run shellcheck with reviewdog'
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This generate too much noise in pull-requests making it is impossible to review changes. Will re-enalble when quickemu and quickget have zero sheelcheck issues
