### PR TITLE
Fix regression in the case of a missing release

### DIFF
--- a/quickget
+++ b/quickget
@@ -3872,12 +3872,11 @@ os_error_release() {
         "languages_${OS}" && echo "${LANGS[@]}"
         ;;
       *)
+        echo -n " - Releases: "
+        "releases_${OS}" | fold -s -w "$(tput cols)"
         if [[ $(type -t "editions_${OS}") == function ]]; then
             echo -n ' - Editions: '
             "editions_${OS}"
-        else
-            echo -n " - Releases: "
-            "releases_${OS}" | fold -s -w "$(tput cols)"
         fi
         ;;
     esac


### PR DESCRIPTION
The os_error_release function only prints the releases if an editions function does not exist. This fixes the error. 