### PR TITLE
Make curl based web handlers and update all ISO downloaders

### DIFF
--- a/quickget
+++ b/quickget
@@ -1448,8 +1448,7 @@ function web_pipe() {
 
 # Download a file from the web
 function web_get() {
-    local URL=""
-    URL=$(web_redirect "${1}")
+    local URL="${1}"
     local DIR="${2}"
     local FILE=""
     local USER_AGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
@@ -1459,6 +1458,9 @@ function web_get() {
     else
         FILE="${URL##*/}"
     fi
+
+    # Process any URL redirections after the file name has been extracted
+    URL=$(web_redirect "${URL}")
 
     while (( "$#" )); do
         if [[ $1 == --header ]]; then

--- a/quickget
+++ b/quickget
@@ -809,7 +809,7 @@ function editions_artixlinux() {
 }
 
 function releases_athenaos() {
-    web_pipe "https://api.github.com/repos/Athena-OS/athena/releases" | grep 'download_url' | grep rolling | cut -d'/' -f8 | uniq | tr '\n' ' '
+    echo $(web_pipe "https://api.github.com/repos/Athena-OS/athena/releases" | grep 'download_url' | grep rolling | cut -d'/' -f8 | uniq | tr '\n' ' ')
 }
 
 function releases_batocera() {

--- a/quickget
+++ b/quickget
@@ -946,7 +946,7 @@ function releases_elementary() {
 }
 
 function releases_endeavouros() {
-    local ENDEAVOUR_RELEASES="$(curl -s https://mirror.alpix.eu/endeavouros/iso/ | LC_ALL="en_US.UTF-8" sort -Mr | grep -o -P '(?<=<a href=").*(?=.iso">)' | grep -v 'x86_64' | cut -c 13- | tr '\n' ' ')"
+    local ENDEAVOUR_RELEASES="$(web_pipe "https://mirror.alpix.eu/endeavouros/iso/" | LC_ALL="en_US.UTF-8" sort -Mr | grep -o -P '(?<=<a href=").*(?=.iso">)' | grep -v 'x86_64' | cut -c 13- | head -n 5 | tr '\n' ' ')"
     echo "${ENDEAVOUR_RELEASES,,}"
 }
 

--- a/quickget
+++ b/quickget
@@ -1147,11 +1147,11 @@ function releases_oraclelinux() {
 }
 
 function releases_parrotsec() {
-    echo 6.0 5.3 4.11.3
+    echo 6.0 5.3
 }
 
 function editions_parrotsec() {
-    echo architect home htb security
+    echo home htb security
 }
 
 function releases_peppermint() {

--- a/quickget
+++ b/quickget
@@ -1079,7 +1079,7 @@ function releases_macos() {
 }
 
 function releases_mageia(){
-    echo 8
+    echo 9 8
 }
 
 function editions_mageia(){

--- a/quickget
+++ b/quickget
@@ -845,7 +845,7 @@ function editions_bodhi() {
 }
 
 function releases_bunsenlabs() {
-    echo latest
+    echo boron
 }
 
 function releases_cachyos() {

--- a/quickget
+++ b/quickget
@@ -857,7 +857,7 @@ function editions_cachyos() {
 }
 
 function releases_centos-stream() {
-    echo 9 8
+    echo $(web_pipe "https://linuxsoft.cern.ch/centos-stream/" | grep "\-stream" | cut -d'"' -f 6 | cut -d'-' -f 1)
 }
 
 function editions_centos-stream() {
@@ -1914,20 +1914,9 @@ function get_cachyos() {
 }
 
 function get_centos-stream() {
-    local HASH=""
-    local ISO=""
-    case ${RELEASE} in
-      8)
-        ISO="CentOS-Stream-${RELEASE}-x86_64-latest-${EDITION}.iso"
-        URL="https://mirrors.ocf.berkeley.edu/centos/8-stream/isos/x86_64"
-        HASH=$(web_pipe "${URL}/CHECKSUM" | grep "SHA256 (${ISO}" | cut -d' ' -f4)
-        ;;
-      9)
-        ISO="CentOS-Stream-${RELEASE}-latest-x86_64-${EDITION}.iso"
-        URL="https://mirrors.ocf.berkeley.edu/centos-stream/9-stream/BaseOS/x86_64/iso"
-        HASH=$(web_pipe "${URL}/${ISO}.SHA256SUM" | grep "SHA256 (${ISO}" | cut -d' ' -f4)
-        ;;
-    esac
+    local ISO="CentOS-Stream-${RELEASE}-latest-x86_64-${EDITION}.iso"
+    local URL="https://linuxsoft.cern.ch/centos-stream/${RELEASE}-stream/BaseOS/x86_64/iso"
+    local HASH=$(web_pipe "${URL}/${ISO}.SHA256SUM" | grep "SHA256 (${ISO}" | cut -d' ' -f4)
     echo "${URL}/${ISO} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -1440,13 +1440,8 @@ function check_hash() {
 }
 
 function web_pipe() {
-    # Check for URL redirections
-    # Output to nonexistent directory so the download fails fast
-    local URL="${1}"
-    local REDIRECT_URL=$(curl --silent --location --fail "${URL}" --write-out %{url_effective} --output /var/cache/${RANDOM}/${RANDOM})
-    if [ "${REDIRECT_URL}" != "${URL}" ]; then
-        URL="${REDIRECT_URL}"
-    fi
+    local URL=""
+    URL=$(web_redirect "${1}")
     curl --silent --location "${URL}"
 }
 

--- a/quickget
+++ b/quickget
@@ -1368,7 +1368,7 @@ function editions_void() {
 }
 
 function releases_vxlinux() {
-    wget -q https://github.com/VX-Linux/main/releases/latest -O- | grep -o -e 'releases/tag/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]' | head -1 | cut -d/ -f3
+    web_pipe "https://github.com/VX-Linux/main/releases/latest" | grep -o -e 'releases/tag/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]' | head -n 1 | cut -d'/' -f 3
 }
 
 function releases_windows() {

--- a/quickget
+++ b/quickget
@@ -793,8 +793,7 @@ function releases_archlinux() {
 }
 
 function releases_arcolinux() {
-    web_pipe "https://mirror.accum.se/mirror/arcolinux.info/iso/" | grep -o -E ">v[[:digit:]]{2}.[[:digit:]]{2}.[[:digit:]]{2}" | sed -e "s/>//" | sort -r | head -n 5 | tr '\n' ' '
-    echo
+    echo $(web_pipe "https://mirror.accum.se/mirror/arcolinux.info/iso/" | grep -o -E ">v[[:digit:]]{2}.[[:digit:]]{2}.[[:digit:]]{2}" | sed -e "s/>//" | sort -r | head -n 5 | tr '\n' ' ')
 }
 
 function editions_arcolinux() {

--- a/quickget
+++ b/quickget
@@ -859,8 +859,8 @@ function releases_blendos() {
 }
 
 function editions_blendos() {
-    wget -q https://sourceforge.net/projects/blendos/rss?path=/ISOs/ -O- | grep -E -o 'https://.*blendOS\.iso.*</media:hash' >/tmp/blendos-isos.rss
-    local BLENDOS_EDITIONS
+    web_pipe "https://sourceforge.net/projects/blendos/rss?path=/ISOs/" | grep -E -o 'https://.*blendOS\.iso.*</media:hash' >/tmp/blendos-isos.rss
+    local BLENDOS_EDITIONS=""
     BLENDOS_EDITIONS="$(grep -E -o 'https://.*blendOS\.iso.*</media:hash' /tmp/blendos-isos.rss | cut -d '/' -f 8 | sort | uniq | tr '\n' ' ')"
     echo "${BLENDOS_EDITIONS}"
 }

--- a/quickget
+++ b/quickget
@@ -1071,7 +1071,7 @@ function editions_lmde(){
 }
 
 function releases_lmde(){
-    echo 5
+    echo 6
 }
 
 function releases_macos() {

--- a/quickget
+++ b/quickget
@@ -1329,7 +1329,7 @@ function releases_ubuntu-server() {
 }
 
 function releases_vanillaos() {
-    echo 22.10
+    echo $(web_pipe "https://api.github.com/repos/Vanilla-OS/live-iso/releases" | grep 'download_url' | cut -d'/' -f8 | sort -ru)
 }
 
 function releases_void() {
@@ -1870,10 +1870,10 @@ function get_blendos() {
 }
 
 function get_vanillaos() {
-    # TODO: Dynamically get the latest release from GitHub
-    local HASH=$(web_pipe "https://cdn.vanillaos.org/assets/ISO/22.10-r9/VanillaOS-22.10-all.20231009.sha256.txt" | cut_1)
-    local URL="https://cdn.vanillaos.org/assets/ISO/22.10-r9/VanillaOS-22.10-all.20231009.iso"
-    echo "${URL} ${HASH}"
+    local ISO=$(web_pipe "https://api.github.com/repos/Vanilla-OS/live-iso/releases" | grep 'download_url' | grep "${RELEASE}" | head -1 | cut -d'"' -f4)
+    local HASH_URL=$(echo "${ISO}" | sed s'|\.iso|\.sha256\.txt|g')
+    local HASH=$(web_pipe "${HASH_URL}" | cut_1)
+    echo "${ISO} ${HASH}"
 }
 
 function get_batocera() {

--- a/quickget
+++ b/quickget
@@ -1644,7 +1644,7 @@ guest_os="${GUEST}"
 disk_img="${VM_PATH}/disk.qcow2"
 ${IMAGE_TYPE}="${VM_PATH}/${IMAGE_FILE}"
 EOF
-        echo "Giving user execute permissions on ${CONF_FILE},"
+        echo "Setting executable ${CONF_FILE}"
         chmod u+x "${CONF_FILE}"
         if [ -n "${ISO_FILE}" ]; then
             echo "fixed_iso=\"${VM_PATH}/${ISO_FILE}\"" >> "${CONF_FILE}"

--- a/quickget
+++ b/quickget
@@ -1808,8 +1808,8 @@ function get_archlinux() {
     local ISO=""
     local URL="https://mirror.rackspace.com/archlinux"
     ISO=$(web_pipe "https://archlinux.org/releng/releases/json/" | jq -r '.releases[0].iso_url')
-    HASH=$(web_pipe "https://archlinux.org/releng/releases/json/" | jq -r '.releases[0].sha1_sum')
-    echo "${URL}/${ISO} ${HASH}"
+    HASH=$(web_pipe "https://archlinux.org/releng/releases/json/" | jq -r '.releases[0].sha256_sum')
+    echo "${URL}${ISO} ${HASH}"
 }
 
 function get_archcraft() {

--- a/quickget
+++ b/quickget
@@ -1307,7 +1307,7 @@ function releases_tuxedo-os() {
 }
 
 function releases_ubuntu() {
-    local VERSION_DATA="$(IFS=$'\n' wget -qO- https://api.launchpad.net/devel/ubuntu/series | jq -r '.entries[]')"
+    local VERSION_DATA="$(IFS=$'\n' web_pipe https://api.launchpad.net/devel/ubuntu/series | jq -r '.entries[]')"
     local SUPPORTED_VERSIONS=($(IFS=$'\n' jq -r 'select(.status=="Supported" or .status=="Current Stable Release") | .version' <<<${VERSION_DATA} | sort))
     local EOL_VERSIONS=($(IFS=$'\n' jq -r 'select(.status=="Obsolete") | .version' <<<${VERSION_DATA} | sort))
     local LTS_SUPPORT=()
@@ -1338,7 +1338,7 @@ function releases_ubuntu() {
 }
 
 function releases_ubuntu-server() {
-    local ALL_VERSIONS=($(IFS=$'\n' wget -qO- http://releases.ubuntu.com/streams/v1/com.ubuntu.releases:ubuntu-server.json | jq -r '.products[] | select(.arch=="amd64") | .version'))
+    local ALL_VERSIONS=($(IFS=$'\n' web_pipe http://releases.ubuntu.com/streams/v1/com.ubuntu.releases:ubuntu-server.json | jq -r '.products[] | select(.arch=="amd64") | .version'))
     local LTS_SUPPORT=()
     local INTERIM_SUPPORT=()
     for i in "${!ALL_VERSIONS[@]}"; do

--- a/quickget
+++ b/quickget
@@ -829,14 +829,11 @@ function editions_biglinux() {
 }
 
 function releases_blendos() {
-    echo latest
+    echo $(web_pipe "https://mirror.ico277.xyz/blendos/gnome/" | grep "\.iso" | cut -c81- | cut -d'"' -f2 | cut -d'-' -f2)
 }
 
 function editions_blendos() {
-    web_pipe "https://sourceforge.net/projects/blendos/rss?path=/ISOs/" | grep -E -o 'https://.*blendOS\.iso.*</media:hash' >/tmp/blendos-isos.rss
-    local BLENDOS_EDITIONS=""
-    BLENDOS_EDITIONS="$(grep -E -o 'https://.*blendOS\.iso.*</media:hash' /tmp/blendos-isos.rss | cut -d '/' -f 8 | sort | uniq | tr '\n' ' ')"
-    echo "${BLENDOS_EDITIONS}"
+    echo $(web_pipe "https://mirror.ico277.xyz/blendos/" | grep "\[DIR\]" | cut -c81-90 | cut -d'/' -f1 | grep -v testing | sort -u)
 }
 
 function releases_bodhi() {
@@ -1867,12 +1864,9 @@ function get_bunsenlabs() {
 
 function get_blendos() {
     local HASH=""
-    local URL=""
-    local latest_blendos_release
-    latest_blendos_release="$(grep "${EDITION}" /tmp/blendos-isos.rss | cut -d '/' -f 9 | sort -nr | head -n 1)"
-    URL=$(grep "${EDITION}/${latest_blendos_release}" /tmp/blendos-isos.rss | grep -E -o 'https://.*blendOS\.iso')
-    HASH=$(grep "${EDITION}/${latest_blendos_release}" /tmp/blendos-isos.rss | grep -E -o '[[:alnum:]]{32}')
-    echo "${URL} ${HASH}"
+    local ISO="blendos-${RELEASE}-stable-${EDITION}.iso"
+    local URL="https://mirror.ico277.xyz/blendos/${EDITION}"
+    echo "${URL}/${ISO} ${HASH}"
 }
 
 function get_vanillaos() {

--- a/quickget
+++ b/quickget
@@ -2182,13 +2182,10 @@ function get_gentoo() {
     local ISO=""
     local URL="https://mirror.bytemark.co.uk/gentoo/releases/amd64/autobuilds/"
     case ${EDITION} in
-      minimal)
-        ISO=$(web_pipe "${URL}/${RELEASE}-iso.txt" | grep install | cut_1)
-        HASH=$(web_pipe "${URL}/${ISO}.DIGESTS" | grep -A 1 SHA512 | grep iso | grep -v CONTENTS | cut_1);;
-      livegui)
-        ISO=$(web_pipe "${URL}/${RELEASE}-iso.txt" | grep livegui | cut -d' ' -f1)
-        HASH=$(web_pipe "${URL}/${ISO}.DIGESTS" | grep -A 1 SHA512 | grep iso | grep -v CONTENTS | cut_1);;
+        minimal) ISO=$(web_pipe "${URL}/${RELEASE}-iso.txt" | grep install | cut_1);;
+        livegui) ISO=$(web_pipe "${URL}/${RELEASE}-iso.txt" | grep livegui | cut_1);;
     esac
+    HASH=$(web_pipe "${URL}/${ISO}.DIGESTS" | grep -A 1 SHA512 | grep iso | grep -v CONTENTS | cut_1)
     echo "${URL}/${ISO} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -1529,6 +1529,12 @@ function web_redirect() {
     fi
 }
 
+function web_check() {
+    local URL=""
+    URL=$(web_redirect "${1}")
+    curl --silent --location --head --output /dev/null --fail "${URL}"
+}
+
 function zsync_get() {
     local DIR="${2}"
     local FILE="${1##*/}"

--- a/quickget
+++ b/quickget
@@ -2400,7 +2400,7 @@ function get_macos() {
     elif [ "${download_iso}" == 'on' ]; then
         echo "Downloading macOS ${RELEASE} from ${downloadLink}"
         web_get "${downloadLink}" "${VM_PATH}" RecoveryImage.dmg --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${downloadSession}"
-        curl --progress-bar "${chunkListLink}" -o RecoveryImage.chunklist --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${chunkListSession}"
+        web_get "${chunkListLink}" RecoveryImage.chunklist --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${chunkListSession}"
         VM_PATH="$(pwd)"
 
     else
@@ -2414,7 +2414,7 @@ function get_macos() {
         if [ ! -e "${VM_PATH}/RecoveryImage.chunklist" ]; then
             echo "Downloading macOS ${RELEASE} from ${downloadLink}"
             web_get "${downloadLink}" "${VM_PATH}" RecoveryImage.dmg --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${downloadSession}"
-            curl --progress-bar "${chunkListLink}" -o "${VM_PATH}/RecoveryImage.chunklist" --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${chunkListSession}"
+            web_get "${chunkListLink}" "${VM_PATH}/RecoveryImage.chunklist" --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${chunkListSession}"
         fi
     fi
 

--- a/quickget
+++ b/quickget
@@ -1922,13 +1922,10 @@ function get_centos-stream() {
 
 function get_chimeralinux() {
     local EDITION="${1:-}"
-    local HASH=""
-    local DATE=""
-    local ISO=""
     local URL="https://repo.chimera-linux.org/live/${RELEASE}"
-    DATE=$(web_pipe "${URL}/sha256sums.txt" | head -n1 | cut -d'-' -f5)
-    ISO="chimera-linux-x86_64-LIVE-${DATE}-${EDITION}.iso"
-    HASH=$(web_pipe "${URL}/sha256sums.txt" | grep 'x86_64-LIVE' | grep "${EDITION}" | cut_1)
+    local DATE=$(web_pipe "${URL}/sha256sums.txt" | head -n1 | cut -d'-' -f5)
+    local ISO="chimera-linux-x86_64-LIVE-${DATE}-${EDITION}.iso"
+    local HASH=$(web_pipe "${URL}/sha256sums.txt" | grep 'x86_64-LIVE' | grep "${EDITION}" | cut_1)
     echo "${URL}/${ISO} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -813,7 +813,7 @@ function releases_athenaos() {
 }
 
 function releases_batocera() {
-    echo latest
+    echo $(web_pipe "https://mirrors.o2switch.fr/batocera/x86_64/stable/" | grep ^\<a | cut -d'"' -f2 | cut -d '/' -f1 | grep -v '\.' | sort -ru | tail +2 | head -n 5)
 }
 
 function releases_bazzite() {
@@ -1884,7 +1884,7 @@ function get_vanillaos() {
 
 function get_batocera() {
     local HASH=""
-    local URL="https://mirrors.o2switch.fr/batocera/x86_64/stable/last"
+    local URL="https://mirrors.o2switch.fr/batocera/x86_64/stable/${RELEASE}"
     local ISO="$(web_pipe "${URL}/" | grep -e 'batocera.*img.gz'| cut -d'"' -f2)"
     echo "${URL}/${ISO} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -933,10 +933,12 @@ function releases_dragonflybsd() {
 }
 
 function releases_easyos() {
-    #local RLIST
-    #RLIST=$(curl -s https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/ | grep 'href="' | tail +2 | cut -d'/' -f1 | cut -d'"' -f6)
-    #RLIST=$(wget -q -O- 'https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/' | grep 'href="' | tail +2 | cut -d'/' -f1 | cut -d'"' -f6)
-    #echo ${RLIST}
+    #local Y2023=""
+    #local Y2024=""
+    #Y2024=$(web_pipe https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2024/ | grep "tr class" | tail +2 | cut -d'"' -f6 | cut -d'/' -f1 | sort -r)
+    #Y2023=$(web_pipe https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/ | grep "tr class" | tail +2 | cut -d'"' -f6 | cut -d'/' -f1 | sort -r)
+    #echo -n ${2024}
+    #echo ${Y2023}
     # Not dynamic for now
     echo 5.7 5.6.7 5.6.6 5.6.5 5.6.4 5.6.3 5.6.2 5.6.1
 }

--- a/quickget
+++ b/quickget
@@ -1274,7 +1274,7 @@ function releases_tails() {
 }
 
 function releases_tinycore() {
-    echo 14.0
+    echo 15.0 14.0
 }
 
 function editions_tinycore() {

--- a/quickget
+++ b/quickget
@@ -853,7 +853,7 @@ function releases_cachyos() {
 }
 
 function editions_cachyos() {
-    echo kde gnome
+    echo $(web_pipe "https://mirror.cachyos.org/ISO/" | grep "title=" | grep -v testing | grep -v cli | cut -d'"' -f4 | cut -d '/' -f1 | sort)
 }
 
 function releases_centos-stream() {
@@ -1906,15 +1906,11 @@ function get_bodhi() {
 }
 
 function get_cachyos() {
-    local HASH=""
-    local ISO=""
-    local URL=""
-    local release=""
-    release=$(web_pipe "https://mirror.cachyos.org/ISO/${EDITION}/" | grep -Po '(?<=">)[0-9]+(?=/</a>)' | tail -n 1)
-    ISO="cachyos-${EDITION}-linux-${release}.iso"
-    URL="https://mirror.cachyos.org/ISO/${EDITION}/${release}"
-    HASH=$(web_pipe "${URL}/${ISO}.sha256" | cut_1)
-    echo "${URL}/${ISO} ${HASH}"
+    local URL="https://mirror.cachyos.org/ISO/${EDITION}/"
+    local REL=$(web_pipe "${URL}" | grep -Po '(?<=">)[0-9]+(?=/</a>)' | sort -ru | tail -n 1)
+    local ISO="cachyos-${EDITION}-linux-${REL}.iso"
+    local HASH=$(web_pipe "${URL}/${REL}/${ISO}.sha256" | cut_1)
+    echo "${URL}/${REL}/${ISO} ${HASH}"
 }
 
 function get_centos-stream() {

--- a/quickget
+++ b/quickget
@@ -1171,7 +1171,7 @@ function editions_popos() {
 }
 
 function releases_porteus() {
-    echo 5.01 5.0
+    echo 5.01
 }
 
 function editions_porteus() {

--- a/quickget
+++ b/quickget
@@ -928,7 +928,7 @@ function releases_devuan() {
 function releases_dragonflybsd() {
     # If you remove "".bz2" from the end of the searched URL, you will get only the current release - currently 6.4.0
     # We could add a variable so this behaviour is optional/switchable (maybe from option or env)
-    DBSD_RELEASES=$(curl -sL  http://mirror-master.dragonflybsd.org/iso-images/ | grep -E -o '"dfly-x86_64-.*_REL.iso.bz2"' | grep -o -E '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+' | tr '\n' ' ')
+    DBSD_RELEASES=$(web_pipe "http://mirror-master.dragonflybsd.org/iso-images/" | grep -E -o '"dfly-x86_64-.*_REL.iso.bz2"' | grep -o -E '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+' | tr '\n' ' ')
     echo "$DBSD_RELEASES"
 }
 

--- a/quickget
+++ b/quickget
@@ -1815,7 +1815,7 @@ function get_archlinux() {
 function get_archcraft() {
     local HASH=""
     local URL=""
-    URL="https://sourceforge.net/projects/archcraft/files/latest/download"
+    URL="https://sourceforge.net/projects/archcraft/files/${RELEASE}/download"
     echo "${URL} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -1010,7 +1010,8 @@ function editions_gentoo() {
 }
 
 function releases_ghostbsd() {
-    echo 22.01.12 21.11.24 21.10.16
+    web_pipe "https://download.ghostbsd.org/releases/amd64/" | grep "href" | cut -d'"' -f2 | cut -d'/' -f1 | sort -r | tail +3 | head -n 5 | tr '\n' ' '
+    echo
 }
 
 function editions_ghostbsd() {

--- a/quickget
+++ b/quickget
@@ -1105,7 +1105,7 @@ function releases_netboot() {
 }
 
 function releases_netbsd() {
-    local NBSD_RELEASES=$(curl -sL  http://cdn.netbsd.org/pub/NetBSD/iso/ | grep -o -E '"[[:digit:]]+\.[[:digit:]]+/"' | tr -d '"/' | sort -nr | tr '\n' ' ')
+    local NBSD_RELEASES=$(web_pipe "http://cdn.netbsd.org/pub/NetBSD/iso/" | grep -o -E '"[[:digit:]]+\.[[:digit:]]+/"' | tr -d '"/' | sort -nr | tr '\n' ' ')
     echo "${NBSD_RELEASES}"
 }
 

--- a/quickget
+++ b/quickget
@@ -851,7 +851,7 @@ function releases_bazzite() {
 }
 
 function releases_biglinux() {
-    echo kde
+    echo $(web_pipe "https://iso.biglinux.com.br/" | grep biglinux | grep iso | cut -d'_' -f2 | uniq | sort -r)
 }
 
 function releases_blendos() {

--- a/quickget
+++ b/quickget
@@ -1416,9 +1416,7 @@ function check_hash() {
 
 # Download a file from the web and pipe it to stdout
 function web_pipe() {
-    local URL=""
-    URL=$(web_redirect "${1}")
-    curl --silent --location "${URL}"
+    curl --silent --location "${1}"
 }
 
 # Download a file from the web

--- a/quickget
+++ b/quickget
@@ -1439,12 +1439,14 @@ function check_hash() {
     fi
 }
 
+# Download a file from the web and pipe it to stdout
 function web_pipe() {
     local URL=""
     URL=$(web_redirect "${1}")
     curl --silent --location "${URL}"
 }
 
+# Download a file from the web
 function web_get() {
     local URL=""
     URL=$(web_redirect "${1}")
@@ -1506,6 +1508,7 @@ function web_get() {
     fi
 }
 
+# checks if a URL needs to be redirected and returns the final URL
 function web_redirect() {
     local URL="${1}"
     # Check for URL redirections
@@ -1518,6 +1521,7 @@ function web_redirect() {
     fi
 }
 
+# checks is a URL is reachable
 function web_check() {
     local URL=""
     URL=$(web_redirect "${1}")

--- a/quickget
+++ b/quickget
@@ -1200,8 +1200,8 @@ function releases_rebornos() {
 }
 
 function get_rebornos() {
-    local ISO=$(wget -q -O- "https://meta.cdn.soulharsh007.dev/RebornOS-ISO?format=json" | jq -r ".url")
-    local HASH=$(wget -q -O- "https://meta.cdn.soulharsh007.dev/RebornOS-ISO?format=json" | jq -r ".md5")
+    local ISO=$(web_pipe "https://meta.cdn.soulharsh007.dev/RebornOS-ISO?format=json" | jq -r ".url")
+    local HASH=$(web_pipe "https://meta.cdn.soulharsh007.dev/RebornOS-ISO?format=json" | jq -r ".md5")
     echo "${ISO} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -1122,7 +1122,7 @@ function editions_nixos(){
 }
 
 function releases_openbsd(){
-    local OBSD_RELEASES=$(curl -sL https://mirror.leaseweb.com/pub/OpenBSD/ | grep -e '6\.[8-9]/' -e '[7-9]\.' | cut -d\" -f4 | tr -d '/' | tr '\n' ' ')
+    local OBSD_RELEASES=$(web_pipe "https://mirror.leaseweb.com/pub/OpenBSD/" | grep -e '6\.[8-9]/' -e '[7-9]\.' | cut -d\" -f4 | tr -d '/' | sort -r | tr '\n' ' ')
     echo "${OBSD_RELEASES}"
 }
 

--- a/quickget
+++ b/quickget
@@ -802,40 +802,11 @@ function editions_arcolinux() {
 }
 
 function releases_artixlinux() {
-    echo stable
+    web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f 4 | sort -ru | tail -1
 }
 
 function editions_artixlinux() {
-    echo base-dinit \
-    base-openrc \
-    base-runit \
-    base-s6 \
-    cinnamon-dinit \
-    cinnamon-openrc \
-    cinnamon-runit \
-    cinnamon-s6 \
-    lxde-dinit \
-    lxde-openrc \
-    lxde-runit \
-    lxde-s6 \
-    lxqt-dinit \
-    lxqt-openrc \
-    lxqt-runit \
-    lxqt-s6 \
-    mate-dinit \
-    mate-openrc \
-    mate-runit \
-    mate-s6 \
-    plasma-dinit \
-    plasma-openrc \
-    plasma-runit \
-    plasma-s6 \
-    xfce-dinit \
-    xfce-openrc \
-    xfce-runit \
-    xfce-s6 \
-    community-gtk-openrc \
-    community-qt-openrc
+    web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f2-3 | sort -u | tr '\n' ' '
 }
 
 function releases_athenaos() {
@@ -1864,8 +1835,7 @@ function get_artixlinux() {
     local HASH=""
     local ISO=""
     local URL="https://iso.artixlinux.org/iso"
-    DATE=$(web_pipe "${URL}/sha256sums" | cut -d'-' -f4 | head -1)
-    ISO="artix-${EDITION}-${DATE}-x86_64.iso"
+    ISO="artix-${EDITION}-${RELEASE}-x86_64.iso"
     HASH=$(web_pipe "${URL}/sha256sums" | grep "${ISO}")
     echo "${URL}/${ISO} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -765,7 +765,7 @@ function editions_alma() {
 }
 
 function releases_alpine() {
-    echo latest 3.18 3.17 3.16 3.15 3.14 3.13 3.12
+    echo latest 3.19 3.18 3.17 3.16 3.15 3.14 3.13 3.12
 }
 
 function releases_android() {

--- a/quickget
+++ b/quickget
@@ -839,7 +839,7 @@ function editions_artixlinux() {
 }
 
 function releases_athenaos() {
-    wget -q -O- 'https://sourceforge.net/projects/athena-iso/rss?path=/' | grep '.iso/download"' | cut -d'=' -f5 | cut -d'"' -f2 | cut -d'/' -f7 | cut -d'v' -f2 | sed ':a;N;$!ba;s/\n/ /g'
+    web_pipe "https://api.github.com/repos/Athena-OS/athena/releases" | grep 'download_url' | grep rolling | cut -d'/' -f8 | uniq | tr '\n' ' '
 }
 
 function releases_batocera() {
@@ -1854,17 +1854,9 @@ function get_artixlinux() {
 
 function get_athenaos() {
     local HASH=""
-    local URL=""
-    local ISO=""
-    case ${RELEASE} in
-      rolling)
-        ISO="athena-rolling-x86_64.iso"
-        URL="https://sourceforge.net/projects/athena-iso/files/rolling"
-        ;;
-      *)
-        ISO="athena-20${RELEASE}-x86_64.iso"
-        URL="https://sourceforge.net/projects/athena-iso/files/v${RELEASE}"
-    esac
+    local URL="https://github.com/Athena-OS/athena/releases/download/${RELEASE}"
+    local ISO="athena-rolling-x86_64.iso"
+    HASH=$(web_pipe "${URL}/${ISO}.sha256" | cut_1)
     echo "${URL}/${ISO} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -847,7 +847,7 @@ function releases_batocera() {
 }
 
 function releases_bazzite() {
-    echo $(wget -q -O- "https://api.github.com/repos/ublue-os/bazzite/releases" | grep 'download_url' | grep 'sum' | cut -d '/' -f8 | cut -d'v' -f2 | tr '\n' ' ')
+    echo $(web_pipe "https://api.github.com/repos/ublue-os/bazzite/releases" | grep 'download_url' | grep 'sum' | cut -d '/' -f8 | cut -d'v' -f2 | tr '\n' ' ')
 }
 
 function releases_biglinux() {

--- a/quickget
+++ b/quickget
@@ -822,7 +822,11 @@ function releases_bazzite() {
 }
 
 function releases_biglinux() {
-    echo $(web_pipe "https://iso.biglinux.com.br/" | grep biglinux | grep iso | cut -d'_' -f2 | uniq | sort -r)
+    echo $(web_pipe "https://iso.biglinux.com.br" | grep -Eo 'biglinux_[0-9]{4}(-[0-9]{2}){2}_k[0-9]{2,3}.iso' | cut -d'_' -f2 | sort -ru)
+}
+
+function editions_biglinux() {
+    echo $(web_pipe "https://iso.biglinux.com.br" | grep -Eo 'biglinux_[0-9]{4}(-[0-9]{2}){2}_k[0-9]{2,3}.iso' | cut -d'_' -f3 | cut -d'.' -f1 | sort -ru)
 }
 
 function releases_blendos() {
@@ -1850,9 +1854,8 @@ function get_athenaos() {
 
 function get_biglinux() {
     local HASH=""
-    local ISO=""
+    local ISO="biglinux_${RELEASE}_${EDITION}.iso"
     local URL="https://iso.biglinux.com.br"
-    ISO=$(grep -Eo 'biglinux_[0-9]{4}(-[0-9]{2}){2}_k[0-9]{2,3}.iso' <(web_pipe "${URL}") | sort -u | tail -n2 | head -n1)
     HASH=$(web_pipe "${URL}/${ISO}.md5" | grep -Eo '[[:alnum:]]{32}')
     echo "${URL}/${ISO} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -1136,7 +1136,8 @@ function editions_openindiana(){
 }
 
 function releases_opensuse(){
-    echo 15.4 15.3 15.2 15.1 15.0 microos tumbleweed
+    web_pipe "https://download.opensuse.org/distribution/leap/" | grep 'class="name"' | cut -d '/' -f2 | grep -v 42 | sort -r | tr '\n' ' '
+    echo microos tumbleweed
 }
 
 function releases_oraclelinux() {

--- a/quickget
+++ b/quickget
@@ -1517,6 +1517,18 @@ function web_get() {
     fi
 }
 
+function web_redirect() {
+    local URL="${1}"
+    # Check for URL redirections
+    # Output to nonexistent directory so the download fails fast
+    local REDIRECT_URL=$(curl --silent --location --fail --write-out %{url_effective} --output /var/cache/${RANDOM}/${RANDOM} "${URL}")
+    if [ "${REDIRECT_URL}" != "${URL}" ]; then
+        echo "${REDIRECT_URL}"
+    else
+        echo "${URL}"
+    fi
+}
+
 function zsync_get() {
     local DIR="${2}"
     local FILE="${1##*/}"

--- a/quickget
+++ b/quickget
@@ -1095,7 +1095,7 @@ function releases_manjaro() {
 }
 
 function releases_mxlinux(){
-    echo 21.3
+    echo 23.2
 }
 
 function editions_mxlinux(){

--- a/quickget
+++ b/quickget
@@ -918,7 +918,7 @@ function editions_debian() {
 }
 
 function releases_deepin() {
-    echo 20.7 20.6 20.5 20.4 20.3 20.2.4 20.2.3 20.2.2 20.2.1 20.2 20.1 20
+    web_pipe "https://cdimage.deepin.com/releases/" | grep "href=" | cut -d'"' -f2 | grep -v "\.\." | grep -v nightly | grep -v preview | sed 's|/||g' | sort -r | tr '\n' ' '
 }
 
 function releases_devuan() {

--- a/quickget
+++ b/quickget
@@ -957,7 +957,7 @@ function releases_endless() {
 }
 
 function editions_endless() {
-  echo base en fr pt_BR es
+    echo base en fr pt_BR es
 }
 
 function releases_fedora() {
@@ -965,21 +965,21 @@ function releases_fedora() {
 }
 
 function editions_fedora() {
-  echo Workstation \
-  Budgie \
-  Cinnamon \
-  i3 \
-  KDE \
-  LXDE \
-  LXQt \
-  Mate \
-  Xfce \
-  Silverblue \
-  Sericea \
-  Kinoite \
-  Sway \
-  Server \
-  Onyx
+    echo Workstation \
+    Budgie \
+    Cinnamon \
+    i3 \
+    KDE \
+    LXDE \
+    LXQt \
+    Mate \
+    Xfce \
+    Silverblue \
+    Sericea \
+    Kinoite \
+    Sway \
+    Server \
+    Onyx
 }
 
 function releases_freebsd(){
@@ -1522,13 +1522,13 @@ function zsync_get() {
     local FILE="${1##*/}"
     local OUT=""
     local URL="${1}"
-	# Test mode for ISO
-	if [ "${show_iso_url}" == 'on' ]; then
-	    echo "${URL}"
-	    exit 0
+    # Test mode for ISO
+    if [ "${show_iso_url}" == 'on' ]; then
+        echo "${URL}"
+        exit 0
     elif [ "${test_iso_url}" == 'on' ]; then
-	    wget --spider "${URL}"
-	    exit 0
+        wget --spider "${URL}"
+        exit 0
     elif command -v zsync &>/dev/null; then
         if [ -n "${3}" ]; then
             OUT="${3}"
@@ -2072,10 +2072,8 @@ function get_easyos() {
     local YEAR=""
     ISO="easy-${RELEASE}-amd64.img"
     case ${RELEASE} in
-      5.6.5|5.6.4|5.6.3|5.6.2|5.6.1|5.5.5|5.5.4)
-        YEAR="2023";;
-      5.7|5.6.7|5.6.6)
-        YEAR="2024";;
+        5.6.5|5.6.4|5.6.3|5.6.2|5.6.1) YEAR="2023";;
+        5.7|5.6.7|5.6.6)               YEAR="2024";;
     esac
     URL="https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/${YEAR}/${RELEASE}"
     HASH=$(web_pipe "${URL}/md5.sum.txt" | cut_1)
@@ -2132,8 +2130,8 @@ function get_fedora() {
     local URL=""
     local VARIANT=""
     case ${EDITION} in
-      Server|Kinoite|Onyx|Silverblue|Sericea|Workstation) VARIANT="${EDITION}";;
-      *) VARIANT="Spins";;
+        Server|Kinoite|Onyx|Silverblue|Sericea|Workstation) VARIANT="${EDITION}";;
+        *) VARIANT="Spins";;
     esac
     JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select(.variant=="'${VARIANT}'" and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'")')
     URL=$(echo "${JSON}" | jq -r '.link' | head -n1)
@@ -2195,8 +2193,8 @@ function get_ghostbsd() {
     local URL="https://download.ghostbsd.org/releases/amd64/${RELEASE}"
     local HASH=""
     case ${EDITION} in
-      mate) ISO="GhostBSD-${RELEASE}.iso";;
-      xfce) ISO="GhostBSD-${RELEASE}-XFCE.iso";;
+        mate) ISO="GhostBSD-${RELEASE}.iso";;
+        xfce) ISO="GhostBSD-${RELEASE}-XFCE.iso";;
     esac
     HASH=$(web_pipe "${URL}/${ISO}.sha256" | grep "${ISO}" | cut -d' ' -f4)
     echo "${URL}/${ISO} ${HASH}"

--- a/quickget
+++ b/quickget
@@ -3683,6 +3683,118 @@ fi
 
 LANGS=()
 
+os_supported_release() {
+    if [[ ! " ${RELEASES[*]} " =~ " ${RELEASE} " ]]; then
+        echo -e "ERROR! ${DISPLAY_NAME} ${RELEASE} is not a supported release."
+        echo -n 'Supported releases: '
+        "releases_${OS}"
+        exit 1
+    fi
+}
+
+os_supported_edition() {
+    if [[ ! " ${EDITIONS[*]} " =~ " ${EDITION} " ]]; then
+        echo -e "ERROR! ${EDITION} is not a supported $(pretty_name "${OS}") edition\n"
+        echo -n ' - Editions: '
+        for EDITION in "${EDITIONS[@]}"; do
+            echo -n "${EDITION} "
+        done
+        echo ""
+        exit 1
+    fi
+}
+
+os_error_edition() {
+    echo -en "ERROR! You must specify an edition.\n - Editions: "
+    #TODO ERROR here
+    "editions_${OS}"
+    exit 1
+}
+
+os_supported_lang() {
+    echo -e "ERROR! ${LANG} is not a supported $(pretty_name "${OS}") language\n"
+    echo -n ' - Editions: '
+    for LANG in "${LANGS[@]}"; do
+        echo -n "${LANG} "
+    done
+    exit 1
+}
+
+handle_missing() {
+    # Handle odd missing Fedora combinations
+    if [[ $OS == fedora ]] ; then
+        if [[ ${RELEASE} = "33" && ${EDITION} = "i3" ]] || [[ ${RELEASE} = "34" && ${EDITION} = "Cinnamon" ]] || [[ "${RELEASE}" < "39" && ${EDITION} = "Onyx" ]]; then
+            echo "ERROR! Unsupported combination"
+            echo "       Fedora ${RELEASE} ${EDITION} is not available, please choose another Release or Edition"
+            exit 1;
+        fi
+    fi
+    # Handle missing Manjaro Sway minimal
+    if [[ $OS == manjaro ]] ; then
+        if [[ ${RELEASE} == "sway" && ${EDITION} == "minimal" ]] ; then
+            echo "ERROR! Unsupported combination"
+            echo "       Manjaro Sway does not have a minimal edition"
+            exit 1;
+        fi
+    fi
+}
+
+os_error() {
+    echo 'ERROR! You must specify an operating system.'
+    echo '- Supported Operating Systems:'
+    os_support | fold -s -w "$(tput cols)"
+    echo -e "\nTo see all possible arguments, use:\n   quickget -h  or  quickget --help"
+    exit 1
+}
+
+os_not_supported() {
+    echo -e "ERROR! ${OS} is not a supported OS.\n"
+    os_support | fold -s -w "$(tput cols)"
+    exit 1
+}
+
+os_path_error() {
+    echo 'ERROR! You must specify path.'
+    os_error
+    exit 1
+}
+
+os_error_release() {
+    echo 'ERROR! You must specify a release.'
+    case ${OS} in
+      *ubuntu-server*)
+        echo -n ' - Releases: '
+        releases_ubuntu-server | sed -Ee 's/eol-\S+//g' # hide eol releases
+        ;;
+      *ubuntu*)
+        echo -n ' - Releases: '
+        releases_ubuntu | sed -Ee 's/eol-\S+//g' # hide eol releases
+        ;;
+      *windows*)
+        echo -n ' - Releases: '
+        "releases_${OS}"
+        echo -n ' - Languages: '
+        "languages_${OS}" && echo "${LANGS[@]}"
+        ;;
+      *)
+        echo -n ' - Releases: '
+        "releases_${OS}" | fold -s -w "$(tput cols)"
+        if [[ $(type -t "editions_${OS}") == function ]]; then
+            echo -n ' - Editions: '
+            "editions_${OS}" | fold -s -w "$(tput cols)"
+        fi
+        ;;
+    esac
+    exit 1
+}
+
+CURL=$(command -v curl)
+if [ ! -e "${CURL}" ]; then
+    echo "ERROR! curl not found. Please make install curl"
+    exit 1
+fi
+CURL_VERSION=$("${CURL}" --version | head -1 | cut -d' ' -f2)
+
 if [ -n "${1}" ]; then
     OS="${1,,}"
     if [ "${OS}" == "list" ] || [ "${OS}" == "list_csv" ]; then

--- a/quickget
+++ b/quickget
@@ -953,7 +953,7 @@ function releases_endeavouros() {
 }
 
 function releases_endless() {
-  echo 5.0.0
+    echo 5.1.1
 }
 
 function editions_endless() {
@@ -2113,16 +2113,11 @@ function get_endless() {
     # Endless edition names are "base" for the small minimal one or the Language for the large full release
     # The isos are stamped as they are finished so ....
     case ${EDITION} in
-        base)
-          FILE_TS="230127-211122";;
-        fr)
-          FILE_TS="230127-213415";;
-        en)
-          FILE_TS="230127-212436";;
-        es)
-          FILE_TS="230127-212646";;
-        pt_BR)
-          FILE_TS="230127-220328";;
+        base)  FILE_TS="240103-025438";;
+        en)    FILE_TS="240103-025437";;
+        es)    FILE_TS="240103-025438";;
+        fr)    FILE_TS="240103-025438";;
+        pt_BR) FILE_TS="240103-030103";;
     esac
     URL="https://images-dl.endlessm.com/release/${RELEASE}/eos-amd64-amd64/${EDITION}"
     ISO="eos-eos${RELEASE:0:3}-amd64-amd64.${FILE_TS}.${EDITION}.iso"

--- a/quickget
+++ b/quickget
@@ -1832,8 +1832,7 @@ function get_archlinux() {
 function get_archcraft() {
     local HASH=""
     local URL=""
-    # Check where the URL redirects using curl. Output to a nonexistent directory so it's not possible to successfully download the image
-    URL=$(curl -Lfs "https://sourceforge.net/projects/archcraft/files/latest/download" -w %{url_effective} -o /this/is/a/nonexistent/directory/$RANDOM/$RANDOM)
+    URL="https://sourceforge.net/projects/archcraft/files/latest/download"
     echo "${URL} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -981,7 +981,7 @@ function editions_fedora() {
 }
 
 function releases_freebsd(){
-    local FBSD_RELEASES=$(curl -sL https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/|grep -e 'class="link"' |grep -v '\.\.'|cut -d\" -f4|tr -d '/' | tr '\n' ' ')
+    local FBSD_RELEASES=$(web_pipe "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/" |grep -e 'class="link"' |grep -v '\.\.'|cut -d\" -f4|tr -d '/' | sort -r | tr '\n' ' ')
     echo "${FBSD_RELEASES}"
 }
 

--- a/quickget
+++ b/quickget
@@ -1037,7 +1037,7 @@ function editions_haiku() {
 }
 
 function releases_holoiso() {
-    wget -q https://github.com/HoloISO/releases/releases/latest -O- | grep -o -e 'releases/tag/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]' | head -1 | cut -d/ -f3
+    web_pipe "https://github.com/HoloISO/releases/releases/latest" | grep -o -e 'releases/tag/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]' | head -n 1 | cut -d'/' -f 3
 }
 
 function releases_kali() {

--- a/quickget
+++ b/quickget
@@ -907,9 +907,9 @@ function releases_crunchbang++() {
 
 function releases_debian() {
     local DEBOLD
-    DEBCURRENT=$(wget -q https://cdimage.debian.org/debian-cd/ -O- | grep '\.[0-9]/' | cut -d\> -f9 | cut -d\/ -f1)
-    DEBOLD=$(wget -q https://cdimage.debian.org/cdimage/archive/ -O- | grep -e '>[1-9][0-9]\.' | grep -v 'live' | cut -d\> -f9 | cut -d'/' -f1 | tac)
-    echo -n "${DEBCURRENT}"
+    DEBCURRENT=$(web_pipe "https://cdimage.debian.org/debian-cd/" | grep '\.[0-9]/' | cut -d'>' -f 9 | cut -d'/' -f 1)
+    DEBOLD=$(web_pipe "https://cdimage.debian.org/cdimage/archive/" | grep -e '>[1-9][0-9]\.' | grep -v 'live' | grep -v NEVER | cut -d'>' -f 9 | cut -d'/' -f 1 | tac)
+    echo -n "${DEBCURRENT} "
     echo ${DEBOLD}
 }
 

--- a/quickget
+++ b/quickget
@@ -922,7 +922,7 @@ function releases_deepin() {
 }
 
 function releases_devuan() {
-    echo beowulf chimaera daedalus
+    echo daedalus chimaera beowulf
 }
 
 function releases_dragonflybsd() {

--- a/quickget
+++ b/quickget
@@ -1250,11 +1250,13 @@ function editions_solus() {
 }
 
 function releases_sparkylinux() {
-    echo 7.3
+    web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f3 | sort -ru | tr '\n' ' '
+    echo
 }
 
 function editions_sparkylinux() {
-    echo lxqt mate xfce kde minimalgui minimalcli gameover multimedia rescue
+    web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f5 | cut -d'.' -f 1 | sort -u | tr '\n' ' '
+    echo
 }
 
 function releases_spirallinux() {

--- a/quickget
+++ b/quickget
@@ -1775,31 +1775,26 @@ function get_android() {
 function get_antix() {
     local EDITION="${1:-}"
     local HASH=""
-    local ISO=""
+    local ISO="antiX-${RELEASE}"
+    local README="README"
     local URL="https://sourceforge.net/projects/antix-linux/files/Final/antiX-${RELEASE}"
-    case ${RELEASE} in
-      21) URL_runit="${URL}/runit-bullseye";;
-      *) URL_runit="${URL}/runit-antiX-${RELEASE}";;
-    esac
+
+    # antiX uses a different URL and ISO naming for runit editions
+    if [[ "${EDITION}" == *"runit"* ]];then
+        ISO+="-runit"
+        README="README2"
+        case ${RELEASE} in
+            21) URL+="/runit-bullseye";;
+            *)  URL+="/runit-antiX-${RELEASE}";;
+        esac
+    fi
     case ${EDITION} in
-      net-sysv)  ISO="antiX-${RELEASE}-net_x64-net.iso";;
-      core-sysv) ISO="antiX-${RELEASE}_x64-core.iso";;
-      base-sysv) ISO="antiX-${RELEASE}_x64-base.iso";;
-      full-sysv) ISO="antiX-${RELEASE}_x64-full.iso";;
-      net-runit)  ISO="antiX-${RELEASE}-runit-net_x64-net.iso"
-                  URL="${URL_runit}"
-      ;;
-      core-runit) ISO="antiX-${RELEASE}-runit_x64-core.iso"
-                  URL="${URL_runit}"
-      ;;
-      base-runit) ISO="antiX-${RELEASE}-runit_x64-base.iso"
-                  URL="${URL_runit}"
-      ;;
-      full-runit) ISO="antiX-${RELEASE}-runit_x64-full.iso"
-                  URL="${URL_runit}"
-      ;;
+        base-*) ISO+="_x64-base.iso";;
+        core-*) ISO+="_x64-core.iso";;
+        full-*) ISO+="_x64-full.iso";;
+        net-*)  ISO+="-net_x64-net.iso";;
     esac
-    HASH=$(web_pipe "${URL}/README.txt" | grep "${ISO}" | cut -d' ' -f1 | head -1)
+    HASH=$(web_pipe "${URL}/${README}.txt" | grep "${ISO}" | cut_1 | head -1)
     echo "${URL}/${ISO} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -801,11 +801,11 @@ function editions_arcolinux() {
 }
 
 function releases_artixlinux() {
-    web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f 4 | sort -ru | tail -1
+    echo $(web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f 4 | sort -ru | tail -1)
 }
 
 function editions_artixlinux() {
-    web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f2-3 | sort -u | tr '\n' ' '
+    echo $(web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f2-3 | sort -u | tr '\n' ' ')
 }
 
 function releases_athenaos() {

--- a/quickget
+++ b/quickget
@@ -1185,7 +1185,7 @@ function editions_primtux() {
 }
 
 function releases_pureos() {
-    wget -q -O- "https://www.pureos.net/download/" | grep -m 1 "downloads.puri" | cut -d '"' -f 2 | cut -d '-' -f 4
+    web_pipe "https://www.pureos.net/download/" | grep -m 1 "downloads.puri" | cut -d '"' -f 2 | cut -d '-' -f 4
 }
 function editions_pureos() {
     echo gnome plasma

--- a/quickget
+++ b/quickget
@@ -1020,7 +1020,7 @@ function editions_ghostbsd() {
 
 function releases_gnomeos() {
     local GNOMEOS_RELEASES=""
-    GNOMEOS_RELEASES="$(curl -s https://download.gnome.org/gnomeos/ | grep -o -P '(?<=<a href=").*(?=/" title=")' | sort -nr | tr '\n' ' ')"
+    GNOMEOS_RELEASES="$(web_pipe "https://download.gnome.org/gnomeos/" | grep -o -P '(?<=<a href=").*(?=/" title=")' | sort -nr | tr '\n' ' ')"
     echo nightly "${GNOMEOS_RELEASES}"
 }
 

--- a/quickget
+++ b/quickget
@@ -2083,14 +2083,10 @@ function get_easyos() {
 function get_elementary() {
     local HASH=""
     case ${RELEASE} in
-      7.0)
-        local ISO="elementaryos-${RELEASE}-stable.20230129rc.iso"
-        ;;
-      7.1)
-        local ISO="elementaryos-${RELEASE}-stable.20230926rc.iso"
-        HASH="5c7f6b388e5787c366587985301ea05ab16e4cc0de3be2b3d6a559ce81a2f102"
-        ;;
+        7.0) STAMP="20230129rc";;
+        7.1) STAMP="20230926rc";;
     esac
+    local ISO="elementaryos-${RELEASE}-stable.${STAMP}.iso"
     local URL="https://ams3.dl.elementary.io/download"
     echo "${URL}/$(date +%s | base64)/${ISO} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -1446,9 +1446,10 @@ function web_pipe() {
 }
 
 function web_get() {
+    local URL=""
+    URL=$(web_redirect "${1}")
     local DIR="${2}"
     local FILE=""
-    local URL="${1}"
     local USER_AGENT="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
 
     if [ -n "${3}" ]; then
@@ -1487,13 +1488,6 @@ function web_get() {
     fi
 
     if command -v curl &>/dev/null; then
-        # Check for URL redirections
-        # Output to nonexistent directory so the download fails fast
-        local REDIRECT_URL=$(curl --silent --location --fail "${URL}" --write-out %{url_effective} --output /var/cache/${RANDOM}/${RANDOM})
-        if [ "${REDIRECT_URL}" != "${URL}" ]; then
-            echo "- Redirected: ${REDIRECT_URL}"
-            URL="${REDIRECT_URL}"
-        fi
         if ! curl --progress-bar --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}"; then
             echo "ERROR! Failed to download ${URL} with curl."
             echo "       Try deleting '${DIR}/${FILE}' running 'quickget' again."

--- a/quickget
+++ b/quickget
@@ -1127,7 +1127,8 @@ function releases_openbsd(){
 }
 
 function releases_openindiana(){
-    echo 20230421
+    web_pipe "https://dlc.openindiana.org/isos/hipster/" | grep link | cut -d'/' -f 1 | cut -d '"' -f4 | sort -r | tail +2 | head -n 5 | tr '\n' ' '
+    echo
 }
 
 function editions_openindiana(){

--- a/quickget
+++ b/quickget
@@ -1489,22 +1489,21 @@ function web_get() {
         echo "- URL: ${URL}"
     fi
 
-    if command -v curl &>/dev/null; then
-        if ! curl --progress-bar --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}"; then
-            echo "ERROR! Failed to download ${URL} with curl."
+    if ! curl --progress-bar --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}"; then
+        echo "ERROR! Failed to download ${URL} with curl."
+        echo "       Will try again with wget."
+        rm -f "${DIR}/${FILE}"
+        if command -v wget2 &>/dev/null; then
+            if ! wget2 --quiet --continue --tries=3 --read-timeout=10 --force-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" "${HEADERS[@]}"; then
+                echo "ERROR! Failed to download ${URL} with wget2."
+                echo "       Try deleting '${DIR}/${FILE}' running 'quickget' again."
+                exit 1
+            fi
+        elif ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" "${HEADERS[@]}"; then
+            echo "ERROR! Failed to download ${URL} with wget."
             echo "       Try deleting '${DIR}/${FILE}' running 'quickget' again."
             exit 1
         fi
-    elif command -v wget2 &>/dev/null; then
-        if ! wget2 --quiet --continue --tries=3 --read-timeout=10 --force-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" "${HEADERS[@]}"; then
-            echo "ERROR! Failed to download ${URL} with wget2."
-            echo "       Try deleting '${DIR}/${FILE}' running 'quickget' again."
-            exit 1
-        fi
-    elif ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" "${HEADERS[@]}"; then
-        echo "ERROR! Failed to download ${URL} with wget."
-        echo "       Try deleting '${DIR}/${FILE}' running 'quickget' again."
-        exit 1
     fi
 }
 

--- a/quickget
+++ b/quickget
@@ -938,7 +938,7 @@ function releases_easyos() {
     #RLIST=$(wget -q -O- 'https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/' | grep 'href="' | tail +2 | cut -d'/' -f1 | cut -d'"' -f6)
     #echo ${RLIST}
     # Not dynamic for now
-    echo 5.7 5.6.7 5.6.6 5.6.5 5.6.4 5.6.3 5.6.2 5.6.1 5.5.5 5.5.4
+    echo 5.7 5.6.7 5.6.6 5.6.5 5.6.4 5.6.3 5.6.2 5.6.1
 }
 
 function releases_elementary() {

--- a/quickget
+++ b/quickget
@@ -1244,7 +1244,7 @@ function releases_slitaz() {
 }
 
 function releases_solus() {
-    echo 4.3
+    echo 4.5
 }
 
 function editions_solus() {

--- a/quickget
+++ b/quickget
@@ -777,7 +777,7 @@ function editions_android() {
 }
 
 function releases_antix() {
-    echo 23 22 21
+    echo 23.1 23 22 21
 }
 
 function editions_antix() {

--- a/quickget
+++ b/quickget
@@ -1520,7 +1520,7 @@ function web_redirect() {
     fi
 }
 
-# checks is a URL is reachable
+# checks if a URL is reachable
 function web_check() {
     local URL=""
     URL=$(web_redirect "${1}")


### PR DESCRIPTION
This pull request adds some new web handlers that use `curl` by default:

- `web_pipe()`: Download a file from the web and pipe it to stdout
- `web_check()`: Checks if a URL is reachable; an alternative to `wget --spider`
- `web_redirect()`: Checks if a URL needs to be redirected and returns the final URL
- `web_get()`: Already existed to download a file from the web, but now uses `curl` by default

## Notes

- `web_get()` will fallback to `wget2` and `wget` if `curl` fails. 
- Most ad-hoc calls to `wget` have been replaced with calls to the appropriate `web_*()` handlers.
  - A separate pull request will be submitted that replaces `wget --spider` with `web_check()`.
- Downloads have been manually tested and releases/editions updated where appropriate.
- Several `releases_*()` and `editions_*()` scripts have been made dynamic.
- URL redirection is consistently handled now, making downloads much more reliable; particularly from Sourceforge, dynamic views of S3 buckets (NixOS), GitHub and anything using [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition).

## Rationale

- `aria2c` behaves inconsistently across distributions depending on how it was compiled.
- Some distributions are starting to symlink `wget2` to `wget`, but they do not behave the same way.
- `curl` has stable interfaces, so create functions in `quickget` to establish common ways to fetch/download content from the web.
- `curl` can present a consistent download progress bar.
- `curl` has been used throughout `quickget` in an ad-hoc manner, but was not a documented requirement and is not installed by default in the `quickget` packages for a number of distros.
- Creating some common handlers as the only way to access web content provides a smaller debug and maintenance surface.