### PR TITLE
Fix error on invalid OS selection

### DIFF
--- a/quickget
+++ b/quickget
@@ -172,7 +172,7 @@ function error_specify_os() {
 
 os_supported() {
     if [[ ! " $(os_support) " =~ " ${OS} " ]]; then
-        os_not_supported
+        error_not_supported_os
     fi
 }
 


### PR DESCRIPTION
#999 renamed the 'os_not_supported' function without changing the os_supported function to point to the correct one. 