### PR TITLE
Update pack 1

### DIFF
--- a/quickget
+++ b/quickget
@@ -383,7 +383,7 @@ function list_supported() {
     exit 0
 }
 
-function list_isos() {
+function list_url_all() {
     local DIR="/dev/null"
     local URL
     local FUNC
@@ -396,35 +396,33 @@ function list_isos() {
     else
         FUNC="${OS}"
     fi
-    for OS in ${FUNC}; do
-        for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
-            if [[ $(type -t "editions_${OS}") == function ]]; then
-                for OPTION in $(editions_"${OS}"); do
-                    validate_release releases_"${OS}"
-                    get_"${OS}" "${OPTION}" | cut_1 || echo "ERROR! - ${OS} ${RELEASE} ${OPTION}"
-                done
-            elif [[ "${OS}" == "windows"* ]]; then
-                "languages_${OS}"
-                for OPTION in "${LANGS[@]}"; do
-                    echo "skipped: ${OS} ${RELEASE} ${OPTION}"
-                    #validate_release releases_${OS}
-                    #get_${OS} ${OPTION} | cut_1
-                done
-            #TODO NEEDED?
-            elif [[ "${OS}" == "macos" ]]; then
+    for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
+        if [[ $(type -t "editions_${OS}") == function ]]; then
+            for OPTION in $(editions_"${OS}"); do
                 validate_release releases_"${OS}"
-                get_macos || echo "ERROR! - ${OS} ${RELEASE} ${OPTION}"
-            elif [[ "${OS}" == *ubuntu-server* ]]; then
-                validate_release releases_ubuntu
-                get_ubuntu-server || echo "ERROR! - ${OS} ${RELEASE}"
-            elif [[ "${OS}" == *ubuntu* ]]; then
-                validate_release releases_ubuntu
-                get_ubuntu || echo "ERROR! - ${OS} ${RELEASE}"
-            else
-                validate_release releases_"${OS}"
-                get_"${OS}" "${RELEASE}" | cut_1 || echo "ERROR! - ${OS} ${RELEASE}"
-            fi
-        done
+                get_"${OS}" "${OPTION}" | cut_1 || echo "ERROR! - ${OS} ${RELEASE} ${OPTION}"
+            done
+        elif [[ "${OS}" == "windows"* ]]; then
+            "languages_${OS}"
+            for OPTION in "${LANGS[@]}"; do
+                echo "skipped: ${OS} ${RELEASE} ${OPTION}"
+                #validate_release releases_${OS}
+                #get_${OS} ${OPTION} | cut_1
+            done
+        #TODO NEEDED?
+        elif [[ "${OS}" == "macos" ]]; then
+            validate_release releases_"${OS}"
+            get_macos || echo "ERROR! - ${OS} ${RELEASE} ${OPTION}"
+        elif [[ "${OS}" == *ubuntu-server* ]]; then
+            validate_release releases_ubuntu
+            get_ubuntu-server || echo "ERROR! - ${OS} ${RELEASE}"
+        elif [[ "${OS}" == *ubuntu* ]]; then
+            validate_release releases_ubuntu
+            get_ubuntu || echo "ERROR! - ${OS} ${RELEASE}"
+        else
+            validate_release releases_"${OS}"
+            get_"${OS}" "${RELEASE}" | cut_1 || echo "ERROR! - ${OS} ${RELEASE}"
+        fi
     done
     exit 0
 }
@@ -3537,7 +3535,7 @@ case "${1}" in
   '--url-all'|'-ua')
     just="show"
     shift
-    time list_isos "${1}"
+    list_url_all "${1}"
     ;;
   '--check'|'-c')
     just="test"

--- a/quickget
+++ b/quickget
@@ -352,6 +352,23 @@ function list_csv() {
     exit 0
 }
 
+function create_config() {
+    local OS="${1}"
+    local DESTINATION="${2}"
+    local USE
+
+    if [[ "${DESTINATION}" == "http://"* ]] || [[ "${DESTINATION}" == "https://"* ]]; then
+        web_get "${DESTINATION}" "${OS}"
+        echo "#TODO: create config!"
+    elif [[ "${DESTINATION}" == "/"* ]]; then
+        cp "${OS}" "${DESTINATION}"/
+        echo "#TODO: create config!"
+    else
+        echo "You forget write full path?" && exit 1
+    fi
+    exit 0
+}
+
 function list_supported() {
     # output OS RELEASE EDITION (usefull for straight testing...)
     local DL=""
@@ -3508,8 +3525,9 @@ case "${1}" in
     shift
     ;;
   '--create-config'|'-cc')
-    just="custom"
-    echo "TODO:"
+    just="config"
+    shift
+    create_config "${@}"
     ;;
   '--open-homepage'|'-o')
     if [ -z "$(os_info "${2}")" ]; then

--- a/quickget
+++ b/quickget
@@ -3471,14 +3471,12 @@ Arguments:
  --help           (-h)                : Show this help message
 -------------- For testing & development ---------------------
  --url            (-u) <os> <re> [ed] : Show download URL for an OS release/edition
- --check          (-c) <os> [re] [ed] : Check download an OS release/edition is available
  --url-all       (-ua) <os>           : Show all download URLs for an OS
+ --check          (-c) <os> [re] [ed] : Check download an OS release/edition is available
  --check-all     (-ca) <os>           : Check all downloads for an OS are available
  --list           (-l)                : List all supported systems in plain text
  --list-csv      (-lc)                : List all supported systems in csv format
  --list-json     (-lj)                : List all supported systems in json format
- --list-urls     (-lu)                : List all supported systems download URLs
- --test-urls     (-tu)                : Check all downloads for all OSs are available
 --------------------------------------------------------------
    *info: 1=Logo 2=Based of 3=Credentials 4=Homepage 5=Short info
     Can be used in any combination like -13254 or -52

--- a/quickget
+++ b/quickget
@@ -3549,11 +3549,11 @@ case "${1}" in
     just="show"
     shift
     ;;
-    #TODO: Argument list should be DEPRECATED!
-  '--list-csv'|'-lc'|'list')
+    #TODO: Argument without dashes should be DEPRECATED!
+  '--list-csv'|'-lc'|'list'|'list_csv'|'lc')
     list_csv
     ;;
-    #TODO: Argument list_json should be DEPRECATED!
+    #TODO: Argument without dashes should be DEPRECATED!
   '--list-json'|'-lj'|'list_json')
     list_json
     ;;
@@ -3572,9 +3572,6 @@ esac
 
 if [ -n "${1}" ]; then
     OS="${1,,}"
-    if [ "${OS}" == "list" ] || [ "${OS}" == "list_csv" ]; then
-        list_csv
-    fi
 else
     error_specify_os
 fi

--- a/quickget
+++ b/quickget
@@ -384,18 +384,19 @@ function list_supported() {
 }
 
 function list_isos() {
-    local showIsoUrl=on
     local DIR="/dev/null"
     local URL
     local FUNC
     local OPTION
-    local OS
-    for OS in $(os_support); do
-        case ${OS} in
-          *ubuntu-server*) FUNC="ubuntu-server";;
-          *ubuntu*) FUNC="ubuntu";;
-          *) FUNC="${OS}";;
-        esac
+    local OS="${1}"
+    if [[ "${OS}" == *ubuntu-server* ]]; then
+        FUNC="ubuntu-server"
+    elif [[ "${OS}" == *ubuntu* ]]; then
+        FUNC="ubuntu"
+    else
+        FUNC="${OS}"
+    fi
+    for OS in ${FUNC}; do
         for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
             if [[ $(type -t "editions_${OS}") == function ]]; then
                 for OPTION in $(editions_"${OS}"); do
@@ -413,12 +414,12 @@ function list_isos() {
             elif [[ "${OS}" == "macos" ]]; then
                 validate_release releases_"${OS}"
                 get_macos || echo "ERROR! - ${OS} ${RELEASE} ${OPTION}"
-            elif [[ "${OS}" == *"ubuntu"* ]]; then
-                validate_release releases_ubuntu
-                get_ubuntu || echo "ERROR! - ${OS} ${RELEASE}"
-            elif [[ "${OS}" == *"ubuntu-server"* ]]; then
+            elif [[ "${OS}" == *ubuntu-server* ]]; then
                 validate_release releases_ubuntu
                 get_ubuntu-server || echo "ERROR! - ${OS} ${RELEASE}"
+            elif [[ "${OS}" == *ubuntu* ]]; then
+                validate_release releases_ubuntu
+                get_ubuntu || echo "ERROR! - ${OS} ${RELEASE}"
             else
                 validate_release releases_"${OS}"
                 get_"${OS}" "${RELEASE}" | cut_1 || echo "ERROR! - ${OS} ${RELEASE}"

--- a/quickget
+++ b/quickget
@@ -430,11 +430,10 @@ function list_isos() {
 }
 
 function test_isos() {
-    local testIsoUrl=on
     local DIR="/dev/null"
     local FUNC
     local OPTION
-    local OS
+    local OS="${1}"
 
     check_it() {
         validate_release releases_"${OS}"
@@ -442,44 +441,41 @@ function test_isos() {
         GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
     }
 
-    for OS in $(os_support); do
-        local GOOD=""
+    if [[ "${OS}" == *ubuntu-server* ]]; then
+        FUNC="ubuntu-server"
+    elif [[ "${OS}" == *ubuntu* ]]; then
+        FUNC="ubuntu"
+    else
+        FUNC="${OS}"
+    fi
+    for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
+        if [[ $(type -t "editions_${OS}") == function ]]; then
+            for OPTION in $(editions_"${OS}"); do
+                check_it
+            done
+        elif [[ "${OS}" == "windows"* ]]; then
+            # skipping because of microsoft
+            "languages_${OS}"
+            for OPTION in "${LANGS[@]}"; do
+                GOOD='FAIL!'
+            done
+        elif [[ "${OS}" == *"ubuntu"* ]]; then
+            URL=$(get_"${OS}" )
+            GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
+        elif [[ "${OS}" == *"ubuntu-server"* ]]; then
+            URL="$(get_ubuntu-server)"
+            GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
+        else
+            validate_release releases_"${OS}"
+            URL=$(get_"${OS}" "${RELEASE}" | cut_1)
+            GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
+        fi
 
-        case "${OS}" in
-          *ubuntu-server*) FUNC="ubuntu-server";;
-          *ubuntu*) FUNC="ubuntu";;
-          *) FUNC="${OS}";;
-        esac
-
-        for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
-            if [[ $(type -t "editions_${OS}") == function ]]; then
-                for OPTION in $(editions_"${OS}"); do
-                    check_it
-                done
-            elif [[ "${OS}" == "windows"* ]]; then
-                # skipping because of microsoft
-                "languages_${OS}"
-                for OPTION in "${LANGS[@]}"; do
-                    GOOD='FAIL'
-                done
-            elif [[ "${OS}" == *"ubuntu"* ]]; then
-                URL=$(get_"${OS}" )
-                GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-            elif [[ "${OS}" == *"ubuntu-server"* ]]; then
-                URL="$(get_ubuntu-server)"
-                GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-            else
-                validate_release releases_"${OS}"
-                URL=$(get_"${OS}" "${RELEASE}" | cut_1)
-                GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-            fi
-
-            if [[ "${GOOD}" == "PASS" ]]; then
-                echo "PASS - ${OS} ${RELEASE} ${OPTION} ${URL}"
-            else
-                echo "FAIL - ${OS} ${RELEASE} ${OPTION} ${URL}"
-            fi
-        done
+        if [[ "${GOOD}" == "OK" ]]; then
+            echo "OK - ${OS} ${RELEASE} ${OPTION} ${URL}"
+        else
+            echo "ERROR - ${OS} ${RELEASE} ${OPTION} ${URL}"
+        fi
     done
     exit 0
 }

--- a/quickget
+++ b/quickget
@@ -429,7 +429,7 @@ function list_isos() {
     exit 0
 }
 
-function test_isos() {
+function list_check_all() {
     local DIR="/dev/null"
     local FUNC
     local OPTION
@@ -448,6 +448,7 @@ function test_isos() {
     else
         FUNC="${OS}"
     fi
+ 
     for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
         if [[ $(type -t "editions_${OS}") == function ]]; then
             for OPTION in $(editions_"${OS}"); do
@@ -3545,7 +3546,7 @@ case "${1}" in
   '--check-all'|'-ca')
     just="test"
     shift
-    time test_isos "${1}"
+    list_check_all "${1}"
     ;;
     #TODO: Argument without dashes should be DEPRECATED!
   '--list-csv'|'-lc'|'list'|'list_csv'|'lc')

--- a/quickget
+++ b/quickget
@@ -564,7 +564,7 @@ function os_support() {
     trisquel \
     truenas-core \
     truenas-scale \
-    tuxedo-os \
+    tuxedoos \
     ubuntu \
     ubuntu-budgie \
     ubuntucinnamon \
@@ -1082,7 +1082,7 @@ function releases_truenas-scale() {
     echo 23
 }
 
-function releases_tuxedo-os() {
+function releases_tuxedoos() {
     echo current
 }
 
@@ -2585,7 +2585,7 @@ function get_truenas-core() {
     echo "${URL} ${HASH}"
 }
 
-function get_tuxedo-os() {
+function get_tuxedoos() {
     local ISO=""
     local URL=""
     local Current=

--- a/quickget
+++ b/quickget
@@ -2288,6 +2288,7 @@ function get_openindiana(){
     HASH=$(web_pipe "${URL}/${ISO}.sha256" |cut_1)
     echo "${URL}/${ISO} ${HASH}"
 }
+
 function get_opensuse() {
     local HASH=""
     local ISO=""

--- a/quickget
+++ b/quickget
@@ -3531,14 +3531,6 @@ case "${1}" in
     help_message
     exit 0
     ;;
-  '--check'|'-c')
-    just="test"
-    shift
-    ;;
-  '--check-all'|'-ca')
-    just="test"
-    shift
-    ;;
   '--url'|'-u')
     just="show"
     shift
@@ -3546,6 +3538,16 @@ case "${1}" in
   '--url-all'|'-ua')
     just="show"
     shift
+    time list_isos "${1}"
+    ;;
+  '--check'|'-c')
+    just="test"
+    shift
+    ;;
+  '--check-all'|'-ca')
+    just="test"
+    shift
+    time test_isos "${1}"
     ;;
     #TODO: Argument without dashes should be DEPRECATED!
   '--list-csv'|'-lc'|'list'|'list_csv'|'lc')
@@ -3557,14 +3559,6 @@ case "${1}" in
     ;;
   '--list'|'-l')
     time list_supported
-    ;;
-  '--list-urls'|'-lu')
-    shift
-    time list_isos
-    ;;
-  '--test-urls'|'-tu')
-    shift
-    time test_isos
     ;;
 esac
 

--- a/quickget
+++ b/quickget
@@ -417,7 +417,7 @@ function list_url_all() {
         if [[ $(type -t "editions_${OS}") == function ]]; then
             for OPTION in $(editions_"${OS}"); do
                 validate_release releases_"${OS}"
-                get_"${OS}" "${OPTION}" | cut_1 || echo "ERROR! - ${OS} ${RELEASE} ${OPTION}"
+                get_"${OS}" "${OPTION}" | cut_1 || echo "FAIL - ${OS} ${RELEASE} ${OPTION}"
             done
         elif [[ "${OS}" == "windows"* ]]; then
             "languages_${OS}"
@@ -429,16 +429,16 @@ function list_url_all() {
         #TODO NEEDED?
         elif [[ "${OS}" == "macos" ]]; then
             validate_release releases_"${OS}"
-            get_macos || echo "ERROR! - ${OS} ${RELEASE} ${OPTION}"
+            get_macos || echo "FAIL - ${OS} ${RELEASE} ${OPTION}"
         elif [[ "${OS}" == *ubuntu-server* ]]; then
             validate_release releases_ubuntu
-            get_ubuntu-server || echo "ERROR! - ${OS} ${RELEASE}"
+            get_ubuntu-server || echo "FAIL - ${OS} ${RELEASE}"
         elif [[ "${OS}" == *ubuntu* ]]; then
             validate_release releases_ubuntu
-            get_ubuntu || echo "ERROR! - ${OS} ${RELEASE}"
+            get_ubuntu || echo "FAIL - ${OS} ${RELEASE}"
         else
             validate_release releases_"${OS}"
-            get_"${OS}" "${RELEASE}" | cut_1 || echo "ERROR! - ${OS} ${RELEASE}"
+            get_"${OS}" "${RELEASE}" | cut_1 || echo "FAIL - ${OS} ${RELEASE}"
         fi
     done
     exit 0
@@ -487,10 +487,10 @@ function list_check_all() {
             GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
         fi
 
-        if [[ "${GOOD}" == "OK" ]]; then
-            echo "OK - ${OS} ${RELEASE} ${OPTION} ${URL}"
+        if [[ "${GOOD}" == "PASS" ]]; then
+            echo "PASS - ${OS} ${RELEASE} ${OPTION} ${URL}"
         else
-            echo "ERROR - ${OS} ${RELEASE} ${OPTION} ${URL}"
+            echo "FAIL - ${OS} ${RELEASE} ${OPTION} ${URL}"
         fi
     done
     exit 0


### PR DESCRIPTION
# Update Pack 1
(for new **run** script)
To not clutter PRs to much, and make things bit easier
(why have to constantly switch between issues?)
## Update pack contains:
- Final help message (Less is More)
- Removed obsolete arguments also from run script
- feat: Rewrite list_isos function for one OS only
- feat: Rewrite test_isos function for one OS only
- Solve 'lists' in case instead in iffi
- feat: Fill empty fields in os_info with ' - '
- fix error_not_supported_os
- Rename tuxedo-os to tuxedoos
- fix: Update some names etc in os_info and added new ones

Also accepting PRs in my branch with your quickfix (Bigger changes or new feature in own PR)
So can be included in this PR and hopefully makes thing quicker and easier

# help message (Less is More)
![qhelp](https://github.com/quickemu-project/quickemu/assets/6384793/d9097889-5ab6-498c-9301-218136cb72e0)

# Current arguments for lists:
(csv,json)
## TODO: Argument without dashes should be DEPRECATED!
`  '--list-csv'|'-lc'|'list'|'list_csv'|'lc')`
## TODO: Argument without dashes should be DEPRECATED!
`  '--list-json'|'-lj'|'list_json')`

Raised issue for cooperation with quickgui team
[#124](https://github.com/quickemu-project/quickgui/issues/124)
