### PR TITLE
Implement simple custom_config

### DIFF
--- a/quickget
+++ b/quickget
@@ -353,20 +353,48 @@ function list_csv() {
 }
 
 function create_config() {
-    local OS="${1}"
-    local DESTINATION="${2}"
-    local USE
+    local VM_PATH="${1}"
+    local INPUT="${2}"
+    OS="custom"
 
-    if [[ "${DESTINATION}" == "http://"* ]] || [[ "${DESTINATION}" == "https://"* ]]; then
-        web_get "${DESTINATION}" "${OS}"
-        echo "#TODO: create config!"
-    elif [[ "${DESTINATION}" == "/"* ]]; then
-        cp "${OS}" "${DESTINATION}"/
-        echo "#TODO: create config!"
-    else
-        echo "You forget write full path?" && exit 1
+    if ! mkdir "${VM_PATH}" 2>/dev/null; then
+        echo "ERROR! Could not create directory: ${VM_PATH}. Please verify that it does not already exist"
+        exit 1
     fi
-    exit 0
+
+    if [[ "${INPUT}" == "http://"* ]] || [[ "${INPUT}" == "https://"* ]]; then
+        INPUT="$(web_redirect "${INPUT}")"
+        if [[ "${INPUT}" == *".iso" ]] || [[ "${INPUT}" == *".img" ]]; then
+            web_get "${INPUT}" "${VM_PATH}"
+            INPUT="${VM_PATH}/${INPUT##*/}"
+        else
+            echo "ERROR! Only ISO and IMG file types are supported for --create-config"
+            exit 1
+        fi
+    fi
+
+    if [[ "${INPUT}" == *".iso" ]]; then
+        CUSTOM_IMAGE_TYPE="iso"
+    elif [[ "${INPUT}" == *".img" ]]; then
+        CUSTOM_IMAGE_TYPE="img"
+    else
+        echo "ERROR! Only ISO and IMG file types are supported for --create-config"
+        exit 1
+    fi
+
+    echo "Creating custom VM config for ${INPUT##*/}."
+    case "${INPUT,,}" in
+        *windows-server*) CUSTOM_OS="windows-server";;
+        *windows*) CUSTOM_OS="windows";;
+        *freebsd*) CUSTOM_OS="freebsd";;
+        *kolibrios*) CUSTOM_OS="kolibrios";;
+        *reactos*) CUSTOM_OS="reactos";;
+        *) CUSTOM_OS="linux";;
+    esac
+
+    echo "Selecting OS: ${CUSTOM_OS}. If this is incorrect, please modify the config file to include the correct OS."
+    echo
+    make_vm_config "${INPUT}"
 }
 
 function list_supported() {
@@ -463,7 +491,7 @@ function list_check_all() {
     else
         FUNC="${OS}"
     fi
- 
+
     for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
         if [[ $(type -t "editions_${OS}") == function ]]; then
             for OPTION in $(editions_"${OS}"); do
@@ -1387,10 +1415,15 @@ function make_vm_config() {
     fi
     IMAGE_FILE="${1}"
     ISO_FILE="${2}"
+    IMAGE_PATH="${VM_PATH}/"
     case "${OS}" in
       batocera)
         GUEST="batocera"
         IMAGE_TYPE="img";;
+      custom)
+        GUEST="${CUSTOM_OS}"
+        IMAGE_TYPE="${CUSTOM_IMAGE_TYPE}"
+        IMAGE_PATH="";;
       dragonflybsd)
         GUEST="dragonflybsd"
         IMAGE_TYPE="iso";;
@@ -1457,7 +1490,7 @@ function make_vm_config() {
 #!$(which quickemu) --vm
 guest_os="${GUEST}"
 disk_img="${VM_PATH}/disk.qcow2"
-${IMAGE_TYPE}="${VM_PATH}/${IMAGE_FILE}"
+${IMAGE_TYPE}="${IMAGE_PATH}${IMAGE_FILE}"
 EOF
         echo "Setting ${CONF_FILE} executable"
         chmod u+x "${CONF_FILE}"
@@ -1549,7 +1582,7 @@ EOF
         fi
     fi
     echo -e "\nTo start your $(pretty_name "${OS}") virtual machine run:"
-    if [ ${OS} == "slint" ]; then
+    if [ "${OS}" == "slint" ]; then
         echo -e "    quickemu --vm ${CONF_FILE}\nTo start Slint with braille support run:\n    quickemu --vm --braille --display sdl ${CONF_FILE}"
     else
         echo "    quickemu --vm ${CONF_FILE}"
@@ -3525,9 +3558,7 @@ case "${1}" in
     shift
     ;;
   '--create-config'|'-cc')
-    just="config"
-    shift
-    create_config "${@}"
+    create_config "${2}" "${3}"
     ;;
   '--open-homepage'|'-o')
     if [ -z "$(os_info "${2}")" ]; then


### PR DESCRIPTION
Only image types img & iso are supported by quickemu, so throw an error if the file/url doesn't end in one of those. Quickget shouldn't require the user to specify the OS, so instead attempt to determine it from the file (vast majority will be Linux-based anyways). make_vm_config had to be slightly modified to allow for the possibility of full paths to image files.