### PR TITLE
Refactor and updates to get most of the tests working

### DIFF
--- a/quickget
+++ b/quickget
@@ -1028,11 +1028,11 @@ function releases_slitaz() {
 }
 
 function releases_solus() {
-    echo 4.5
+    echo $(web_pipe "https://getsol.us/download/" | grep "isos" | grep Download | cut -d'-' -f 2 | sort -ru)
 }
 
 function editions_solus() {
-    echo Budgie GNOME MATE Plasma
+    echo $(web_pipe "https://getsol.us/download/" | grep "isos" | grep Download | cut -d'.' -f5 | cut -d'-' -f2- | sort -u)
 }
 
 function releases_sparkylinux() {
@@ -2418,7 +2418,7 @@ function get_slitaz() {
 function get_solus() {
     local HASH=""
     local ISO="Solus-${RELEASE}-${EDITION}.iso"
-    local URL="https://mirrors.rit.edu/solus/images/${RELEASE}"
+    local URL="https://downloads.getsol.us/isos/${RELEASE}"
     HASH=$(web_pipe "${URL}/${ISO}.sha256sum" | cut_1)
     echo "${URL}/${ISO} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -414,7 +414,6 @@ function list_url_all() {
     os_supported
 
     local CHECK=""
-    local OPTION=""
     local FUNC="${OS}"
     if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
         FUNC="ubuntu"
@@ -430,9 +429,9 @@ function list_url_all() {
             done
         elif [[ "${OS}" == "windows"* ]]; then
             "languages_${OS}"
-            for OPTION in "${LANGS[@]}"; do
+            for LANG in "${LANGS[@]}"; do
                 validate_release releases_"${OS}"
-                show_test_result SKIP "${OS}" "${RELEASE}" "${OPTION}" "${URL}"
+                show_test_result SKIP "${OS}" "${RELEASE}" "${LANG}" "${URL}"
             done
         elif [[ "${OS}" == "macos" ]]; then
             validate_release releases_macos
@@ -457,7 +456,6 @@ function list_check_all() {
     os_supported
 
     local CHECK=""
-    local OPTION=""
     local FUNC="${OS}"
     if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
         FUNC="ubuntu"
@@ -475,9 +473,9 @@ function list_check_all() {
         else
             if [[ "${OS}" == "windows"* ]]; then
                 "languages_${OS}"
-                for OPTION in "${LANGS[@]}"; do
+                for LANG in "${LANGS[@]}"; do
                     validate_release releases_"${OS}"
-                    show_test_result SKIP "${OS}" "${RELEASE}" "${OPTION}" "${URL}"
+                    show_test_result SKIP "${OS}" "${RELEASE}" "${LANG}" "${URL}"
                 done
             elif [[ "${OS}" == "macos" ]]; then
                 validate_release releases_macos

--- a/quickget
+++ b/quickget
@@ -799,8 +799,7 @@ function editions_gentoo() {
 }
 
 function releases_ghostbsd() {
-    web_pipe "https://download.ghostbsd.org/releases/amd64/" | grep "href" | cut -d'"' -f2 | cut -d'/' -f1 | sort -r | tail +3 | head -n 5 | tr '\n' ' '
-    echo
+    echo $(web_pipe "https://download.ghostbsd.org/releases/amd64/" | grep "href" | cut -d'"' -f2 | cut -d'/' -f1 | sort -r | tail +3 | head -3)
 }
 
 function editions_ghostbsd() {
@@ -808,9 +807,7 @@ function editions_ghostbsd() {
 }
 
 function releases_gnomeos() {
-    local GNOMEOS_RELEASES=""
-    GNOMEOS_RELEASES="$(web_pipe "https://download.gnome.org/gnomeos/" | grep -o -P '(?<=<a href=").*(?=/" title=")' | sort -nr | tr '\n' ' ')"
-    echo nightly "${GNOMEOS_RELEASES}"
+    echo "nightly" $(web_pipe "https://download.gnome.org/gnomeos/" | grep -o -P '(?<=<a href=").*(?=/" title=")' | sort -nr)
 }
 
 function releases_guix() {
@@ -1896,24 +1893,18 @@ function get_ghostbsd() {
 
 function get_gnomeos() {
     local HASH=""
-    local ISO=""
-    local URL=""
+    local ISO="gnome_os_installer_${RELEASE}.iso"
+    local URL="https://download.gnome.org/gnomeos/${RELEASE}"
     case ${RELEASE} in
         nightly)
-            URL="https://os.gnome.org/download/latest"
-            ISO="gnome_os_installer.iso";;
-        # The download.gnome.org mirror does not currently link to ISOs for 44.rc or 45.rc
-        44.rc|45.rc)
-            URL="https://mirror.umd.edu/gnome/gnomeos/${RELEASE}"
-            ISO="gnome_os_installer_${RELEASE}.iso";;
-        3.38*)
-            URL="https://download.gnome.org/gnomeos/${RELEASE}"
-            ISO="gnome_os_installer.iso";;
-        *)
-            URL="https://download.gnome.org/gnomeos/${RELEASE}"
-            ISO="gnome_os_installer_${RELEASE}.iso";;
+            ISO="gnome_os_installer.iso"
+            URL="https://os.gnome.org/download/latest";;
+        46.0) ISO="gnome_os_installer_46.iso";;
+        3*) ISO="gnome_os_installer.iso";;
     esac
-    echo "${URL}/${ISO} ${HASH}"
+    # Process the URL redirections; required for GNOME
+    ISO=$(web_redirect "${URL}/${ISO}")
+    echo "${ISO} ${HASH}"
 }
 
 function get_guix() {

--- a/quickget
+++ b/quickget
@@ -145,11 +145,7 @@ function os_info() {
 function show_os_info() {
      while getopts ":12345" opt; do
         case $opt in
-          1) os_info "${2}" | cut -d'|' -f1;;
-          2) os_info "${2}" | cut -d'|' -f2;;
-          3) os_info "${2}" | cut -d'|' -f3;;
-          4) os_info "${2}" | cut -d'|' -f4;;
-          5) os_info "${2}" | cut -d'|' -f5;;
+          1|2|3|4|5) os_info "${2}" | cut -d'|' -f${opt};;
           *) echo "Wrong choice!" && exit 1;;
         esac
     done

--- a/quickget
+++ b/quickget
@@ -440,13 +440,13 @@ function list_url_all() {
             for EDITION in $(editions_"${OS}"); do
                 validate_release releases_"${OS}"
                 URL=$(get_"${OS}" | cut_1 | head -1)
-                echo "${URL}"
+                show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
             done
         elif [[ "${OS}" == "windows"* ]]; then
             "languages_${OS}"
             for LANG in "${LANGS[@]}"; do
                 validate_release releases_"${OS}"
-                show_test_result SKIP "${OS}" "${RELEASE}" "${LANG}" "${URL}"
+                show_url_result "${OS}" "${RELEASE}" "${LANG}" "SKIP"
             done
         elif [[ "${OS}" == "macos" ]]; then
             validate_release releases_macos
@@ -460,7 +460,7 @@ function list_url_all() {
         else
             validate_release releases_"${OS}"
             URL=$(get_"${OS}" | cut_1 | head -1)
-            echo "${URL}"
+            show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
         fi
     done
     exit 0
@@ -1254,7 +1254,7 @@ function web_get() {
 
     # Test mode for ISO
     if [ "${just}" == 'show' ]; then
-        echo "${URL}"
+        show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
         exit 0
     elif [ "${just}" == 'test' ]; then
         CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
@@ -2094,7 +2094,7 @@ function get_macos() {
     local chunkListSession=$(echo "$info" | grep 'expires' | grep 'chunklist')
 
     if [ "${just}" == 'show' ]; then
-        echo -e "Recovery URL (inaccessible through normal browser):\n${downloadLink}\nChunklist (used for verifying the Recovery Image):\n${chunkListLink}\nFirmware URLs:\n${OpenCore_qcow2}\n${OVMF_CODE}\n${OVMF_VARS}"
+        show_url_result "${OS}" "${RELEASE}" "" "${downloadLink}"
         exit 0
     elif [ "${just}" == 'test' ]; then
         local CHECK=$(web_check "${downloadLink}" --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${downloadSession}" && echo 'PASS' || echo 'FAIL')

--- a/quickget
+++ b/quickget
@@ -651,7 +651,7 @@ function releases_archlinux() {
 }
 
 function releases_arcolinux() {
-    echo $(web_pipe "https://mirror.accum.se/mirror/arcolinux.info/iso/" | grep -o -E ">v[[:digit:]]{2}.[[:digit:]]{2}.[[:digit:]]{2}" | sed -e "s/>//" | sort -r | head -n 5 | tr '\n' ' ')
+    echo $(web_pipe "https://mirror.accum.se/mirror/arcolinux.info/iso/" | grep -o -E ">v[[:digit:]]{2}.[[:digit:]]{2}.[[:digit:]]{2}" | sed -e "s/>//" | sort -r | head -n 5)
 }
 
 function editions_arcolinux() {

--- a/quickget
+++ b/quickget
@@ -742,8 +742,7 @@ function releases_devuan() {
 function releases_dragonflybsd() {
     # If you remove "".bz2" from the end of the searched URL, you will get only the current release - currently 6.4.0
     # We could add a variable so this behaviour is optional/switchable (maybe from option or env)
-    DBSD_RELEASES=$(web_pipe "http://mirror-master.dragonflybsd.org/iso-images/" | grep -E -o '"dfly-x86_64-.*_REL.iso.bz2"' | grep -o -E '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+' | tr '\n' ' ')
-    echo "$DBSD_RELEASES"
+    echo $(web_pipe "http://mirror-master.dragonflybsd.org/iso-images/" | grep -E -o '"dfly-x86_64-.*_REL.iso.bz2"' | grep -o -E '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+')
 }
 
 function releases_easyos() {

--- a/quickget
+++ b/quickget
@@ -1190,7 +1190,7 @@ function check_hash() {
     local iso=""
     local hash=""
     local hash_algo=""
-    if [ "${just}" == 'download' ]; then
+    if [ "${OPERATION}" == "download" ]; then
         iso="${1}"
     else
         iso="${VM_PATH}/${1}"
@@ -1249,14 +1249,14 @@ function web_get() {
     done
 
     # Test mode for ISO
-    if [ "${just}" == 'show' ]; then
+    if [ "${OPERATION}" == "show" ]; then
         show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
         exit 0
-    elif [ "${just}" == 'test' ]; then
+    elif [ "${OPERATION}" == "test" ]; then
         CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
         show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
         exit 0
-    elif [ "${just}" == 'download' ]; then
+    elif [ "${OPERATION}" == "download" ]; then
         DIR="$(pwd)"
     fi
 
@@ -1323,10 +1323,10 @@ function zsync_get() {
     local OUT=""
     local URL="${1}"
     # Test mode for ISO
-    if [ "${just}" == 'show' ]; then
+    if [ "${OPERATION}" == "show" ]; then
         echo "${URL}"
         exit 0
-    elif [ "${just}" == 'test' ]; then
+    elif [ "${OPERATION}" == "test" ]; then
         web_check "${URL}"
         exit 0
     elif command -v zsync &>/dev/null; then
@@ -1367,7 +1367,7 @@ function make_vm_config() {
     local IMAGE_TYPE=""
     local GUEST=""
     local SEC_BOOT=""
-    if [ "${just}" == 'download' ]; then
+    if [ "${OPERATION}" == "download" ]; then
         exit 0
     fi
     IMAGE_FILE="${1}"
@@ -2089,14 +2089,14 @@ function get_macos() {
     local chunkListLink=$(echo "$info" | grep 'oscdn' | grep 'chunklist')
     local chunkListSession=$(echo "$info" | grep 'expires' | grep 'chunklist')
 
-    if [ "${just}" == 'show' ]; then
+    if [ "${OPERATION}" == "show" ]; then
         show_url_result "${OS}" "${RELEASE}" "" "${downloadLink}"
         exit 0
-    elif [ "${just}" == 'test' ]; then
+    elif [ "${OPERATION}" == "test" ]; then
         local CHECK=$(web_check "${downloadLink}" --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${downloadSession}" && echo 'PASS' || echo 'FAIL')
         show_test_result ${CHECK} "${OS}" "${RELEASE}" "" "${downloadLink}"
         exit 0
-    elif [ "${just}" == 'download' ]; then
+    elif [ "${OPERATION}" == "download" ]; then
         echo "Downloading macOS ${RELEASE} from ${downloadLink}"
         web_get "${downloadLink}" "${VM_PATH}" RecoveryImage.dmg --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${downloadSession}"
         web_get "${chunkListLink}" "${VM_PATH}" RecoveryImage.chunklist --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${chunkListSession}"
@@ -3273,7 +3273,7 @@ function get_windows() {
         download_windows_workstation "${RELEASE}"
     fi
 
-    if [ "${just}" == 'download' ]; then
+    if [ "${OPERATION}" == "download" ]; then
         exit 0
     fi
 
@@ -3404,7 +3404,7 @@ if ((BASH_VERSINFO[0] < 4)); then
 fi
 
 LANGS=()
-
+OPERATION=""
 CURL=$(command -v curl)
 if [ ! -e "${CURL}" ]; then
     echo "ERROR! curl not found. Please make install curl"
@@ -3418,11 +3418,11 @@ case "${1}" in
     exit 0
     ;;
   '--download'|'-d')
-    just="download"
+    OPERATION="download"
     shift
     ;;
   '--create-config'|'-cc')
-    just="config"
+    OPERATION="config"
     shift
     create_config "${@}"
     ;;
@@ -3444,11 +3444,11 @@ case "${1}" in
     exit 0
     ;;
   '--url'|'-u')
-    just="show"
+    OPERATION="show"
     shift
     ;;
   '--url-all'|'-ua')
-    just="show"
+    OPERATION="show"
     shift
     # if no OS is specified, list all URLs for all supported OSes
     if [ -z "${1}" ]; then
@@ -3460,11 +3460,11 @@ case "${1}" in
     fi
     ;;
   '--check'|'-c')
-    just="test"
+    OPERATION="test"
     shift
     ;;
   '--check-all'|'-ca')
-    just="test"
+    OPERATION="test"
     shift
     # if no OS is specified, check all URLs for all supported OSes
     if [ -z "${1}" ]; then

--- a/quickget
+++ b/quickget
@@ -480,7 +480,7 @@ function list_check_all() {
                 validate_release releases_"${OS}"
                 URL=$(get_"${OS}" | cut_1 | head -1)
                 CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-                show_test_result ${CHECK} "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+                show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
             done
         else
             if [[ "${OS}" == "windows"* ]]; then
@@ -502,7 +502,7 @@ function list_check_all() {
                 validate_release releases_"${OS}"
                 URL=$(get_"${OS}" | cut_1 | head -1)
                 CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-                show_test_result ${CHECK} "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+                show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
             fi
         fi
     done
@@ -2094,7 +2094,7 @@ function get_macos() {
         exit 0
     elif [ "${OPERATION}" == "test" ]; then
         local CHECK=$(web_check "${downloadLink}" --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${downloadSession}" && echo 'PASS' || echo 'FAIL')
-        show_test_result ${CHECK} "${OS}" "${RELEASE}" "" "${downloadLink}"
+        show_test_result "${CHECK}" "${OS}" "${RELEASE}" "" "${downloadLink}"
         exit 0
     elif [ "${OPERATION}" == "download" ]; then
         echo "Downloading macOS ${RELEASE} from ${downloadLink}"

--- a/quickget
+++ b/quickget
@@ -715,7 +715,7 @@ function editions_chimeralinux() {
 }
 
 function releases_crunchbang++() {
-    echo 12 11 10 9 8
+    echo $(web_pipe "https://api.github.com/repos/CBPP/cbpp/releases" | grep 'download_url' | cut -d'-' -f2 | grep '^[0-9]' | sort -gru)
 }
 
 function releases_debian() {
@@ -1721,35 +1721,8 @@ function get_chimeralinux() {
 
 function get_crunchbang++() {
     local HASH=""
-    local ISO=""
-    local URL=""
-    local URLPART=""
-    local URLPART2=""
-    URLPART="https://github.com/CBPP/cbpp"
-    case ${RELEASE} in
-      8)
-        URLPART2="releases/download/v1.0-amd64"
-        ISO="cbpp-1.0-amd64-20150428.iso"
-        ;;
-      9)
-        URLPART2="9-amd64/releases/download/v9.0"
-        ISO="cbpp-9.0-amd64-20170621.iso"
-        ;;
-      10)
-        URLPART2="releases/download/v10"
-        ISO="cbpp-10.1-amd64-20190713.iso"
-        ;;
-      11)
-        URLPART2="releases/download/v11.2"
-        ISO="cbpp-11.2-amd64-20230514.iso"
-        ;;
-      12)
-        URLPART2="releases/download/v12.0"
-        ISO="cbpp-12.0-amd64-20230611.iso"
-        ;;
-    esac
-    URL="${URLPART}/${URLPART2}"
-    echo "${URL}/${ISO} ${HASH}"
+    local ISO=$(web_pipe "https://api.github.com/repos/CBPP/cbpp/releases" | grep 'download_url' | grep amd64 | grep "${RELEASE}" | cut -d'"' -f4)
+    echo "${ISO} ${HASH}"
 }
 
 function get_debian() {

--- a/quickget
+++ b/quickget
@@ -789,11 +789,11 @@ function editions_endless() {
 }
 
 function releases_fedora() {
-    echo 40 39
+    echo $(web_pipe "https://getfedora.org/releases.json" | jq -r 'map(.version) | unique | .[]' | sort -r)
 }
 
 function editions_fedora() {
-    echo Workstation Budgie Cinnamon i3 KDE LXDE LXQt Mate Xfce Silverblue Sericea Kinoite Sway Server Onyx
+    echo $(web_pipe "https://getfedora.org/releases.json" | jq -r 'map(select(.arch=="x86_64" and .variant!="Labs" and .variant!="IoT" and .variant!="Container" and .variant!="Cloud" and .variant!="Everything"  and .subvariant!="Security" and .subvariant!="Server_KVM" and .subvariant!="SoaS")) | map(.subvariant) | unique | .[]' | sort)
 }
 
 function releases_freebsd(){

--- a/quickget
+++ b/quickget
@@ -364,26 +364,23 @@ function create_config() {
 
 function list_supported() {
     # output OS RELEASE EDITION (usefull for straight testing...)
-    local DL=""
-    local FUNC
-    local OPTION
-    local OS
+    local FUNC=""
+    local OS=""
     for OS in $(os_support); do
-        case ${OS} in
-          *ubuntu-server*) FUNC="ubuntu-server";;
-          *ubuntu*) FUNC="ubuntu";;
-          *) FUNC="${OS}";;
-        esac
+        FUNC="${OS}"
+        if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
+            FUNC="ubuntu"
+        fi
         for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
             # If the OS has an editions_() function, use it.
             if [[ $(type -t "editions_${OS}") == function ]]; then
-                for OPTION in $(editions_"${OS}"); do
-                    echo "${OS} ${RELEASE} ${OPTION}"
+                for EDITION in $(editions_"${OS}"); do
+                    echo "${OS} ${RELEASE} ${EDITION}"
                 done
             elif [[ "${OS}" == "windows"* ]]; then
                 "languages_${OS}"
-                for OPTION in "${LANGS[@]}"; do
-                    echo "${OS} ${RELEASE} ${OPTION}"
+                for LANG in "${LANGS[@]}"; do
+                    echo "${OS} ${RELEASE} ${LANG}"
                 done
             else
                 echo "${OS} ${RELEASE}"

--- a/quickget
+++ b/quickget
@@ -460,7 +460,6 @@ function list_url_all() {
             show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
         fi
     done
-    exit 0
 }
 
 function list_check_all() {
@@ -506,7 +505,6 @@ function list_check_all() {
             fi
         fi
     done
-    exit 0
 }
 
 function os_support() {
@@ -3458,6 +3456,7 @@ case "${1}" in
     else
         list_url_all "${1}"
     fi
+    exit 0
     ;;
   '--check'|'-c')
     OPERATION="test"
@@ -3474,6 +3473,7 @@ case "${1}" in
     else
         list_check_all "${1}"
     fi
+    exit 0
     ;;
     #TODO: Argument without dashes should be DEPRECATED!
   '--list-csv'|'-lc'|'list'|'list_csv'|'lc')

--- a/quickget
+++ b/quickget
@@ -1020,7 +1020,8 @@ function editions_slax() {
 }
 
 function releases_slint() {
-    echo 15.0 14.2.1
+    # 15.0.1 returns a 404 so is excluded
+    echo $(web_pipe "https://slackware.uk/slint/x86_64/" | grep "slint-" | cut -d'>' -f2 | cut -d'-' -f2 | tr -d "/\"" | grep -v "15.0.1" | sort -ru)
 }
 
 function releases_slitaz() {
@@ -2393,10 +2394,8 @@ function get_slax() {
 function get_slint() {
     local HASH=""
     local ISO=""
-    local URL=""
-    # Change to latest if needed
-    ISO="slint64-15.0-5.iso"
-    URL="https://slackware.uk/slint/x86_64/slint-${RELEASE}/iso"
+    local URL="https://slackware.uk/slint/x86_64/slint-${RELEASE}/iso"
+    ISO=$(web_pipe "${URL}" | grep "slint64-" | cut -d'>' -f2 | cut -d'"' -f2 | head -n1)
     HASH=$(web_pipe "${URL}/${ISO}.sha256" | cut -d' ' -f4)
     echo "${URL}/${ISO}" "${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -747,7 +747,7 @@ function editions_debian() {
 }
 
 function releases_deepin() {
-    echo $(web_pipe "https://cdimage.deepin.com/releases/" | grep "href=" | cut -d'"' -f2 | grep -v "\.\." | grep -v nightly | grep -v preview | sed 's|/||g' | sort -r | tr '\n' ' ')
+    echo $(web_pipe "https://cdimage.deepin.com/releases/" | grep "href=" | cut -d'"' -f2 | grep -v "\.\." | grep -v nightly | grep -v preview | sed 's|/||g' | sort -r)
 }
 
 function releases_devuan() {
@@ -934,11 +934,11 @@ function editions_nixos(){
 }
 
 function releases_openbsd(){
-    echo $(web_pipe "https://mirror.leaseweb.com/pub/OpenBSD/" | grep -e '6\.[8-9]/' -e '[7-9]\.' | cut -d\" -f4 | tr -d '/' | sort -r | tr '\n' ' ')
+    echo $(web_pipe "https://mirror.leaseweb.com/pub/OpenBSD/" | grep -e '6\.[8-9]/' -e '[7-9]\.' | cut -d\" -f4 | tr -d '/' | sort -r)
 }
 
 function releases_openindiana(){
-    echo $(web_pipe "https://dlc.openindiana.org/isos/hipster/" | grep link | cut -d'/' -f 1 | cut -d '"' -f4 | sort -r | tail +2 | head -n 5 | tr '\n' ' ')
+    echo $(web_pipe "https://dlc.openindiana.org/isos/hipster/" | grep link | cut -d'/' -f 1 | cut -d '"' -f4 | sort -r | tail +2 | head -n 5)
 }
 
 function editions_openindiana(){
@@ -946,8 +946,7 @@ function editions_openindiana(){
 }
 
 function releases_opensuse(){
-    web_pipe "https://download.opensuse.org/distribution/leap/" | grep 'class="name"' | cut -d '/' -f2 | grep -v 42 | sort -r | tr '\n' ' '
-    echo microos tumbleweed
+    echo $(web_pipe "https://download.opensuse.org/distribution/leap/" | grep 'class="name"' | cut -d '/' -f2 | grep -v 42 | sort -r) microos tumbleweed
 }
 
 function releases_oraclelinux() {
@@ -1056,11 +1055,11 @@ function editions_solus() {
 }
 
 function releases_sparkylinux() {
-    echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f3 | sort -ru | tr '\n' ' ')
+    echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f3 | sort -ru)
 }
 
 function editions_sparkylinux() {
-    echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f5 | cut -d'.' -f 1 | sort -u | tr '\n' ' ')
+    echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f5 | cut -d'.' -f 1 | sort -u)
 }
 
 function releases_spirallinux() {

--- a/quickget
+++ b/quickget
@@ -2216,7 +2216,7 @@ function get_netboot() {
 function get_netbsd() {
     local HASH=""
     local ISO="NetBSD-${RELEASE}-amd64.iso"
-    local URL="https://cdn.netbsd.org/pub/NetBSD/NetBSD-${RELEASE}/images/"
+    local URL="https://cdn.netbsd.org/pub/NetBSD/NetBSD-${RELEASE}/images"
     HASH=$(web_pipe "${URL}/MD5" | grep "${ISO}" | cut -d' ' -f4)
     echo "${URL}/${ISO} ${HASH}"
 }
@@ -2285,7 +2285,7 @@ function get_oraclelinux() {
     local ISO=""
     local VER_MAJ=${RELEASE::1}
     local VER_MIN=${RELEASE:2:1}
-    local URL="https://yum.oracle.com/ISOS/OracleLinux/OL${VER_MAJ}/u${VER_MIN}/x86_64/"
+    local URL="https://yum.oracle.com/ISOS/OracleLinux/OL${VER_MAJ}/u${VER_MIN}/x86_64"
     case ${VER_MAJ} in
       7) ISO="OracleLinux-R${VER_MAJ}-U${VER_MIN}-Server-x86_64-dvd.iso";;
       *) ISO="OracleLinux-R${VER_MAJ}-U${VER_MIN}-x86_64-dvd.iso";;

--- a/quickget
+++ b/quickget
@@ -3215,9 +3215,6 @@ function download_windows_workstation() {
 
     if echo "$iso_download_link_html" | grep -q "We are unable to complete your request at this time."; then
         echo " - Microsoft blocked the automated download request based on your IP address."
-        if [ "${just}" == 'show' ] || [ "${just}" == 'test' ]; then
-            exit 1
-        fi
         failed=1
     fi
 
@@ -3238,14 +3235,6 @@ function download_windows_workstation() {
         # This should only happen if there's been some change to the download endpoint web address
         echo " - Microsoft servers gave us no download link to our request for an automated download. Please manually download this ISO in a web browser: $url"
         return 1
-    fi
-
-    if [ "${just}" == 'show' ]; then
-        echo -e "   Windows ${RELEASE} Download (valid for 24 hours):\n${iso_download_link}"
-        exit 0
-    elif [ "${just}" == 'test' ]; then
-        web_check "${iso_download_link}"
-        exit 0
     fi
 
     echo "Downloading Windows ${RELEASE} (${LANG}): $iso_download_link"

--- a/quickget
+++ b/quickget
@@ -394,13 +394,14 @@ function list_supported() {
 }
 
 function list_url_all() {
-    local URL
-    local OPTION
+    local CHECK=""
+    local OPTION=""
     local OS="${1}"
     local FUNC="${OS}"
     if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
         FUNC="ubuntu"
     fi
+    local URL=""
 
     for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
         if [[ $(type -t "editions_${OS}") == function ]]; then
@@ -434,21 +435,22 @@ function list_url_all() {
 }
 
 function list_check_all() {
-    local URL
-    local OPTION
+    local CHECK=""
+    local OPTION=""
     local OS="${1}"
     local FUNC="${OS}"
     if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
         FUNC="ubuntu"
     fi
+    local URL=""
 
     for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
         if [[ $(type -t "editions_${OS}") == function ]]; then
             for EDITION in $(editions_"${OS}"); do
                 validate_release releases_"${OS}"
                 URL=$(get_"${OS}" | cut_1 | head -1)
-                GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-                echo -e "${GOOD}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
+                CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
+                echo -e "${CHECK}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
             done
         else
             if [[ "${OS}" == "windows"* ]]; then
@@ -469,8 +471,8 @@ function list_check_all() {
             else
                 validate_release releases_"${OS}"
                 URL=$(get_"${OS}" | cut_1 | head -1)
-                GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-                echo -e "${GOOD}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
+                CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
+                echo -e "${CHECK}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
             fi
         fi
     done
@@ -1195,6 +1197,7 @@ function web_pipe() {
 
 # Download a file from the web
 function web_get() {
+    local CHECK=""
     local HEADERS=()
     local URL="${1}"
     local DIR="${2}"
@@ -1225,8 +1228,8 @@ function web_get() {
         echo "${URL}"
         exit 0
     elif [ "${just}" == 'test' ]; then
-        GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-        echo -e "${GOOD}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
+        CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
+        echo -e "${CHECK}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
         exit 0
     elif [ "${just}" == 'download' ]; then
         DIR="$(pwd)"

--- a/quickget
+++ b/quickget
@@ -1008,7 +1008,7 @@ function editions_siduction() {
 }
 
 function releases_slackware() {
-    echo 15.0 14.2
+    echo $(web_pipe "https://slackware.nl/slackware/slackware-iso/" | grep "slackware-" | cut -d'<' -f7 | cut -d'-' -f2 | sort -ru | head -5)
 }
 
 function releases_slax() {

--- a/quickget
+++ b/quickget
@@ -1747,11 +1747,13 @@ function get_devuan() {
     local HASH=""
     local ISO=""
     local URL="https://files.devuan.org/devuan_${RELEASE}/desktop-live"
+    local VER=""
     case ${RELEASE} in
-      beowulf) ISO="devuan_${RELEASE}_3.1.1_amd64_desktop-live.iso";;
-      chimaera) ISO="devuan_${RELEASE}_4.0.2_amd64_desktop-live.iso";;
-      daedalus) ISO="devuan_${RELEASE}_5.0.0_amd64_desktop-live.iso";;
+      beowulf)  VER="3.1.1";;
+      chimaera) VER="4.0.3";;
+      daedalus) VER="5.0.0";;
     esac
+    ISO="devuan_${RELEASE}_${VER}_amd64_desktop-live.iso"
     HASH=$(web_pipe "${URL}/SHASUMS.txt" | grep "${ISO}" | cut_1)
     echo "${URL}/${ISO} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -747,7 +747,7 @@ function releases_fedora() {
 }
 
 function editions_fedora() {
-    echo $(web_pipe "https://getfedora.org/releases.json" | jq -r 'map(select(.arch=="x86_64" and .variant!="Labs" and .variant!="IoT" and .variant!="Container" and .variant!="Cloud" and .variant!="Everything"  and .subvariant!="Security" and .subvariant!="Server_KVM" and .subvariant!="SoaS")) | map(.subvariant) | unique | .[]' | sort)
+    echo $(web_pipe "https://getfedora.org/releases.json" | jq -r 'map(select(.arch=="x86_64" and .variant!="Labs" and .variant!="IoT" and .variant!="Container" and .variant!="Cloud" and .variant!="Everything"  and .subvariant!="Security" and .subvariant!="Server_KVM" and .subvariant!="SoaS")) | map(.subvariant) | unique | .[]')
 }
 
 function releases_freebsd(){

--- a/quickget
+++ b/quickget
@@ -712,9 +712,8 @@ function releases_debian() {
     local NEW=""
     local OLD=""
     NEW=$(web_pipe "https://cdimage.debian.org/debian-cd/" | grep '\.[0-9]/' | cut -d'>' -f 9 | cut -d'/' -f 1)
-    OLD=$(web_pipe "https://cdimage.debian.org/cdimage/archive/" | grep -e '>[1-9][0-9]\.' | grep -v 'live' | grep -v NEVER | cut -d'>' -f 9 | cut -d'/' -f 1 | tac)
-    echo -n "${NEW} "
-    echo ${OLD}
+    OLD=$(web_pipe "https://cdimage.debian.org/cdimage/archive/" | grep -e '>[1-9][0-9]\.' | grep -v 'live' | grep -v NEVER | cut -d'>' -f 9 | cut -d'/' -f 1 | tac | head -20)
+    echo ${NEW} ${OLD}
 }
 
 function editions_debian() {

--- a/quickget
+++ b/quickget
@@ -1158,7 +1158,7 @@ function releases_zorin() {
 }
 
 function editions_zorin() {
-    echo core64 lite64 education64 edulite64
+    echo core64 lite64 education64
 }
 
 function check_hash() {
@@ -2612,7 +2612,8 @@ function get_zorin() {
     local HASH=""
     local ISO=""
     local URL=""
-    URL="https://zrn.co/${RELEASE}${EDITION}"
+    # Process the URL redirections; required for Zorin
+    URL=$(web_redirect "https://zrn.co/${RELEASE}${EDITION}")
     echo "${URL} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -647,7 +647,7 @@ function releases_artixlinux() {
 }
 
 function editions_artixlinux() {
-    echo $(web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f2-3 | sort -u | tr '\n' ' ')
+    echo $(web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f2-3 | sort -u)
 }
 
 function releases_athenaos() {

--- a/quickget
+++ b/quickget
@@ -761,7 +761,7 @@ function releases_elementary() {
 }
 
 function releases_endeavouros() {
-    local ENDEAVOUR_RELEASES="$(web_pipe "https://mirror.alpix.eu/endeavouros/iso/" | LC_ALL="en_US.UTF-8" sort -Mr | grep -o -P '(?<=<a href=").*(?=.iso">)' | grep -v 'x86_64' | cut -c 13- | head -n 5 | tr '\n' ' ')"
+    local ENDEAVOUR_RELEASES="$(web_pipe "https://mirror.alpix.eu/endeavouros/iso/" | sort -Mr | grep -o -P '(?<=<a href=").*(?=.iso">)' | grep -v 'x86_64' | cut -c 13- | head -n 5 | tr '\n' ' ')"
     echo "${ENDEAVOUR_RELEASES,,}"
 }
 

--- a/quickget
+++ b/quickget
@@ -1036,13 +1036,11 @@ function editions_solus() {
 }
 
 function releases_sparkylinux() {
-    web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f3 | sort -ru | tr '\n' ' '
-    echo
+    echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f3 | sort -ru | tr '\n' ' ')
 }
 
 function editions_sparkylinux() {
-    web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f5 | cut -d'.' -f 1 | sort -u | tr '\n' ' '
-    echo
+    echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f5 | cut -d'.' -f 1 | sort -u | tr '\n' ' ')
 }
 
 function releases_spirallinux() {

--- a/quickget
+++ b/quickget
@@ -1546,12 +1546,8 @@ function get_alma() {
 function get_alpine() {
     local HASH=""
     local ISO=""
-    local URL=""
+    local URL="https://dl-cdn.alpinelinux.org/alpine/${RELEASE}/releases/x86_64"
     local VERSION=""
-    case ${RELEASE} in
-      latest) URL="https://dl-cdn.alpinelinux.org/alpine/latest-stable/releases/x86_64";;
-      *) URL="https://dl-cdn.alpinelinux.org/alpine/v${RELEASE}/releases/x86_64";;
-    esac
     VERSION=$(web_pipe "${URL}/latest-releases.yaml" | awk '/"Xen"/{found=0} {if(found) print} /"Virtual"/{found=1}' | grep 'version:' | awk '{print $2}')
     ISO="alpine-virt-${VERSION}-x86_64.iso"
     HASH=$(web_pipe "${URL}/latest-releases.yaml" | awk '/"Xen"/{found=0} {if(found) print} /"Virtual"/{found=1}' | grep 'sha256:' | awk '{print $2}')

--- a/quickget
+++ b/quickget
@@ -719,11 +719,12 @@ function releases_crunchbang++() {
 }
 
 function releases_debian() {
-    local DEBOLD
-    DEBCURRENT=$(web_pipe "https://cdimage.debian.org/debian-cd/" | grep '\.[0-9]/' | cut -d'>' -f 9 | cut -d'/' -f 1)
-    DEBOLD=$(web_pipe "https://cdimage.debian.org/cdimage/archive/" | grep -e '>[1-9][0-9]\.' | grep -v 'live' | grep -v NEVER | cut -d'>' -f 9 | cut -d'/' -f 1 | tac)
-    echo -n "${DEBCURRENT} "
-    echo ${DEBOLD}
+    local NEW=""
+    local OLD=""
+    NEW=$(web_pipe "https://cdimage.debian.org/debian-cd/" | grep '\.[0-9]/' | cut -d'>' -f 9 | cut -d'/' -f 1)
+    OLD=$(web_pipe "https://cdimage.debian.org/cdimage/archive/" | grep -e '>[1-9][0-9]\.' | grep -v 'live' | grep -v NEVER | cut -d'>' -f 9 | cut -d'/' -f 1 | tac)
+    echo -n "${NEW} "
+    echo ${OLD}
 }
 
 function editions_debian() {
@@ -1728,18 +1729,17 @@ function get_crunchbang++() {
 function get_debian() {
     local HASH=""
     local ISO="debian-live-${RELEASE}-amd64-${EDITION}.iso"
-    local URL=""
-    DEBCURRENT=$(web_pipe "https://cdimage.debian.org/debian-cd/" |grep '\.[0-9]/'|cut -d\> -f9|cut -d\/ -f1)
-    case ${RELEASE} in
+    local URL="https://cdimage.debian.org/cdimage/archive/${RELEASE}-live/amd64/iso-hybrid"
+    local DEBCURRENT=$(web_pipe "https://cdimage.debian.org/debian-cd/" | grep '\.[0-9]/' | cut -d'>' -f 9 | cut -d'/' -f 1)
+    case "${RELEASE}" in
       "${DEBCURRENT}") URL="https://cdimage.debian.org/debian-cd/${RELEASE}-live/amd64/iso-hybrid";;
-      *) URL="https://cdimage.debian.org/cdimage/archive/${RELEASE}-live/amd64/iso-hybrid/";;
     esac
     if [ "${EDITION}" == "netinst" ]; then
         URL="${URL/-live/}"
         URL="${URL/hybrid/cd}"
         ISO="${ISO/-live/}"
     fi
-    HASH=$(web_pipe "${URL}/SHA512SUMS" | grep "${ISO}" | cut_1)
+    HASH=$(web_pipe "${URL}/SHA512SUMS" | grep "${ISO}" | cut_1 | head -1)
     echo "${URL}/${ISO} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -774,7 +774,7 @@ function editions_endless() {
 }
 
 function releases_fedora() {
-    echo 39 38
+    echo 40 39
 }
 
 function editions_fedora() {

--- a/quickget
+++ b/quickget
@@ -267,13 +267,6 @@ function handle_missing() {
         fi
     fi
     # Handle missing Manjaro Sway minimal
-    if [[ $OS == manjaro ]] ; then
-        if [[ ${RELEASE} == "sway" && ${EDITION} == "minimal" ]] ; then
-            echo "ERROR! Unsupported combination"
-            echo "       Manjaro Sway does not have a minimal edition"
-            exit 1;
-        fi
-    fi
 }
 
 function validate_release() {
@@ -889,7 +882,7 @@ function editions_manjaro(){
 }
 
 function releases_manjaro() {
-    echo xfce gnome plasma budgie cinnamon i3 mate sway
+    echo xfce gnome plasma cinnamon i3 sway
 }
 
 function releases_mxlinux(){

--- a/quickget
+++ b/quickget
@@ -898,8 +898,8 @@ function releases_netboot() {
 }
 
 function releases_netbsd() {
-    local NBSD_RELEASES=$(web_pipe "http://cdn.netbsd.org/pub/NetBSD/iso/" | grep -o -E '"[[:digit:]]+\.[[:digit:]]+/"' | tr -d '"/' | sort -nr | tr '\n' ' ')
-    echo "${NBSD_RELEASES}"
+    # V8 is EOL so filter it out
+    echo $(web_pipe "http://cdn.netbsd.org/pub/NetBSD/iso/" | grep -o -E '"[[:digit:]]+\.[[:digit:]]+/"' | tr -d '"/' | grep -v ^8 | sort -nr)
 }
 
 function releases_nitrux() {

--- a/quickget
+++ b/quickget
@@ -1106,49 +1106,24 @@ function releases_ubuntu() {
     local VERSION_DATA="$(IFS=$'\n' web_pipe https://api.launchpad.net/devel/ubuntu/series | jq -r '.entries[]')"
     local SUPPORTED_VERSIONS=($(IFS=$'\n' jq -r 'select(.status=="Supported" or .status=="Current Stable Release") | .version' <<<${VERSION_DATA} | sort))
     local EOL_VERSIONS=($(IFS=$'\n' jq -r 'select(.status=="Obsolete") | .version' <<<${VERSION_DATA} | sort))
-    local LTS_SUPPORT=()
-    local INTERIM_SUPPORT=()
-    for i in "${SUPPORTED_VERSIONS[@]}"; do
-        if [[ $(expr ${i%.*} % 2) == 0 && ${i#*.} == "04" ]]; then
-            LTS_SUPPORT+=($i)
-        else
-            INTERIM_SUPPORT+=($i)
-        fi
-    done
     case "${OS}" in
-      edubuntu|ubuntu-unity|ubuntucinnamon)
-        echo ${INTERIM_SUPPORT[@]} daily-live
-        ;;
-      kubuntu|lubuntu|ubuntukylin|ubuntu-mate|ubuntustudio|xubuntu)
-        ## after 14.04
-        echo ${LTS_SUPPORT[@]:1} ${INTERIM_SUPPORT[@]} daily-live jammy-daily ${EOL_VERSIONS[@]/#/eol-}
-        ;;
-      ubuntu-budgie)
-        #after 16.04
-        echo ${LTS_SUPPORT[@]:2} ${INTERIM_SUPPORT[@]} daily-live jammy-daily ${EOL_VERSIONS[@]/#/eol-}
-        ;;
-      ubuntu)
-        echo ${LTS_SUPPORT[@]} ${INTERIM_SUPPORT[@]} daily-live ${EOL_VERSIONS[@]/#/eol-}
-        ;;
+        ubuntu)
+            echo ${SUPPORTED_VERSIONS[@]} daily-live ${EOL_VERSIONS[@]/#/eol-};;
+        kubuntu|lubuntu|ubuntukylin|ubuntu-mate|ubuntustudio|xubuntu)
+            # after 16.04
+            echo ${SUPPORTED_VERSIONS[@]:1} daily-live ${EOL_VERSIONS[@]/#/eol-};;
+        ubuntu-budgie)
+            # after 18.04
+            echo ${SUPPORTED_VERSIONS[@]:2} daily-live ${EOL_VERSIONS[@]/#/eol-};;
+        edubuntu|ubuntu-unity|ubuntucinnamon)
+            # after 23.10
+            echo ${SUPPORTED_VERSIONS[@]:5} daily-live ${EOL_VERSIONS[@]/#/eol-};;
     esac
 }
 
 function releases_ubuntu-server() {
-    local ALL_VERSIONS=($(IFS=$'\n' web_pipe http://releases.ubuntu.com/streams/v1/com.ubuntu.releases:ubuntu-server.json | jq -r '.products[] | select(.arch=="amd64") | .version'))
-    local LTS_SUPPORT=()
-    local INTERIM_SUPPORT=()
-    for i in "${!ALL_VERSIONS[@]}"; do
-        if [[ $i == 0 || ${ALL_VERSIONS[$i]} > ${ALL_VERSIONS[$(expr $i - 1)]} ]]; then
-            if [[ $(expr ${ALL_VERSIONS[${i}]%.*} % 2) == 0 && ${ALL_VERSIONS[${i}]#*.} == "04" ]]; then
-                LTS_SUPPORT+=(${ALL_VERSIONS[$i]})
-            else
-                INTERIM_SUPPORT+=(${ALL_VERSIONS[$i]})
-            fi
-        else
-            break
-        fi
-    done
-    echo ${LTS_SUPPORT[@]} ${INTERIM_SUPPORT[@]} daily-live
+    local ALL_VERSIONS=($(IFS=$'\n' web_pipe http://releases.ubuntu.com/streams/v1/com.ubuntu.releases:ubuntu-server.json | jq -r '.products[] | select(.arch=="amd64") | .version' | sort -rV))
+    echo ${ALL_VERSIONS[@]}
 }
 
 function releases_vanillaos() {

--- a/quickget
+++ b/quickget
@@ -1025,7 +1025,7 @@ function releases_slint() {
 }
 
 function releases_slitaz() {
-    echo preferred core core64 loram core-5in1 preinit
+    echo $(web_pipe "http://mirror.slitaz.org/iso/rolling/" | grep "class='iso'" | cut -d"'" -f4 | cut -d'-' -f3- | grep iso | cut -d'.' -f1 | sort -u)
 }
 
 function releases_solus() {
@@ -2404,10 +2404,6 @@ function get_slitaz() {
     local HASH=""
     local ISO="slitaz-rolling-${RELEASE}"
     local URL="http://mirror.slitaz.org/iso/rolling"
-    case ${RELEASE} in
-      preferred) ISO="slitaz-rolling";;
-      *) ISO="slitaz-rolling-${RELEASE}";;
-    esac
     HASH=$(web_pipe "${URL}/${ISO}.md5" | cut_1)
     echo "${URL}/${ISO}.iso ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -1870,7 +1870,7 @@ function get_garuda() {
 function get_gentoo() {
     local HASH=""
     local ISO=""
-    local URL="https://mirror.bytemark.co.uk/gentoo/releases/amd64/autobuilds/"
+    local URL="https://mirror.bytemark.co.uk/gentoo/releases/amd64/autobuilds"
     case ${EDITION} in
         minimal) ISO=$(web_pipe "${URL}/${RELEASE}-iso.txt" | grep install | cut_1);;
         livegui) ISO=$(web_pipe "${URL}/${RELEASE}-iso.txt" | grep livegui | cut_1);;

--- a/quickget
+++ b/quickget
@@ -675,7 +675,7 @@ function releases_batocera() {
 }
 
 function releases_bazzite() {
-    echo $(web_pipe "https://api.github.com/repos/ublue-os/bazzite/releases" | grep 'download_url' | grep 'sum' | cut -d '/' -f8 | cut -d'v' -f2 | tr '\n' ' ')
+    echo $(web_pipe "https://api.github.com/repos/ublue-os/bazzite/releases" | grep 'download_url' | grep 'sum' | cut -d '/' -f8 | cut -d'v' -f2 | head -n 5)
 }
 
 function releases_biglinux() {

--- a/quickget
+++ b/quickget
@@ -730,7 +730,7 @@ function releases_elementary() {
 }
 
 function releases_endeavouros() {
-    local ENDEAVOUR_RELEASES="$(web_pipe "https://mirror.alpix.eu/endeavouros/iso/" | sort -Mr | grep -o -P '(?<=<a href=").*(?=.iso">)' | grep -v 'x86_64' | cut -c 13- | head -n 5 | tr '\n' ' ')"
+    local ENDEAVOUR_RELEASES="$(web_pipe "https://mirror.alpix.eu/endeavouros/iso/" | LC_ALL="en_US.UTF-8" sort -Mr | grep -o -P '(?<=<a href=").*(?=.iso">)' | grep -v 'x86_64' | cut -c 13- | head -n 5 | tr '\n' ' ')"
     echo "${ENDEAVOUR_RELEASES,,}"
 }
 

--- a/quickget
+++ b/quickget
@@ -731,7 +731,7 @@ function editions_debian() {
 }
 
 function releases_deepin() {
-    web_pipe "https://cdimage.deepin.com/releases/" | grep "href=" | cut -d'"' -f2 | grep -v "\.\." | grep -v nightly | grep -v preview | sed 's|/||g' | sort -r | tr '\n' ' '
+    echo $(web_pipe "https://cdimage.deepin.com/releases/" | grep "href=" | cut -d'"' -f2 | grep -v "\.\." | grep -v nightly | grep -v preview | sed 's|/||g' | sort -r | tr '\n' ' ')
 }
 
 function releases_devuan() {
@@ -1798,23 +1798,18 @@ function get_debian() {
 
 function get_deepin() {
     local HASH=""
-    local EDITION=""
-    local ISO="deepin-desktop-community-${RELEASE}-amd64.iso"
+    local REV=${RELEASE}
     # deepin-desktop-community-20.3-amd64.iso
     local URL="https://cdimage.deepin.com/releases/"${RELEASE}
     # fix iso name
     if [[ "${RELEASE}" == *"20" ]] ; then
-        EDITION="1003"
-        ISO="deepin-desktop-community-${EDITION}-amd64.iso"
+        REV="1003"
     elif [[ "${RELEASE}" == *"20.1" ]]; then
-        EDITION="1010"
-        ISO="deepin-desktop-community-${EDITION}-amd64.iso"
+        REV="1010"
     fi
+    local ISO="deepin-desktop-community-${REV}-amd64.iso"
     HASH=$(web_pipe "${URL}/SHA256SUMS" | grep "${ISO}" | cut_1)
-    #echo "${URL}/${ISO} ${HASH}"
-    web_get "${URL}/${ISO}" "${VM_PATH}"
-    check_hash "${ISO}" "${HASH}"
-    make_vm_config "${ISO}"
+    echo "${URL}/${ISO} ${HASH}"
 }
 
 function get_devuan() {
@@ -3587,10 +3582,6 @@ if [ -n "${2}" ]; then
         # Ubuntu doesn't use create_vm()
         validate_release releases_ubuntu
         get_ubuntu
-    elif [[ "${OS}" == *"deepin"* ]]; then
-        # deepin doesn't use create_vm()
-        validate_release releases_deepin
-        get_deepin
     elif [[ "${OS}" == "windows"* ]]; then
         LANG="English International"
         "languages_${OS}"

--- a/quickget
+++ b/quickget
@@ -2164,8 +2164,8 @@ function get_mxlinux() {
 }
 
 function get_netboot() {
-    local ISO="netboot.xyz.iso"
     local HASH=""
+    local ISO="netboot.xyz.iso"
     local URL="https://boot.netboot.xyz/ipxe"
     HASH=$(web_pipe "${URL}/netboot.xyz-sha256-checksums.txt" | grep "${ISO}" | cut_1)
     echo "${URL}/${ISO} ${HASH}"

--- a/quickget
+++ b/quickget
@@ -3540,7 +3540,7 @@ case "${1}" in
     list_json
     ;;
   '--list'|'-l')
-    time list_supported
+    list_supported
     ;;
 esac
 

--- a/quickget
+++ b/quickget
@@ -915,8 +915,7 @@ function editions_nixos(){
 }
 
 function releases_openbsd(){
-    local OBSD_RELEASES=$(web_pipe "https://mirror.leaseweb.com/pub/OpenBSD/" | grep -e '6\.[8-9]/' -e '[7-9]\.' | cut -d\" -f4 | tr -d '/' | sort -r | tr '\n' ' ')
-    echo "${OBSD_RELEASES}"
+    echo $(web_pipe "https://mirror.leaseweb.com/pub/OpenBSD/" | grep -e '6\.[8-9]/' -e '[7-9]\.' | cut -d\" -f4 | tr -d '/' | sort -r | tr '\n' ' ')
 }
 
 function releases_openindiana(){

--- a/quickget
+++ b/quickget
@@ -259,14 +259,14 @@ function error_not_supported_lang() {
 
 function handle_missing() {
     # Handle odd missing Fedora combinations
-    if [[ $OS == fedora ]] ; then
-        if [[ ${RELEASE} = "33" && ${EDITION} = "i3" ]] || [[ ${RELEASE} = "34" && ${EDITION} = "Cinnamon" ]] || [[ "${RELEASE}" < "39" && ${EDITION} = "Onyx" ]]; then
-            echo "ERROR! Unsupported combination"
-            echo "       Fedora ${RELEASE} ${EDITION} is not available, please choose another Release or Edition"
-            exit 1;
-        fi
-    fi
-    # Handle missing Manjaro Sway minimal
+    case "${OS}" in
+        fedora)
+            if [[ "${RELEASE}" -lt 40 && "${EDITION}" == "Onyx" ]] || [[ "${RELEASE}" -lt 40 && "${EDITION}" == "Sericea" ]]; then
+                echo "ERROR! Unsupported combination"
+                echo "       Fedora ${RELEASE} ${EDITION} is not available, please choose another Release or Edition"
+                exit 1
+            fi;;
+    esac
 }
 
 function validate_release() {

--- a/quickget
+++ b/quickget
@@ -1056,7 +1056,7 @@ function releases_tails() {
 }
 
 function releases_tinycore() {
-    echo 15.0 14.0
+    echo 15 14
 }
 
 function editions_tinycore() {
@@ -2454,14 +2454,13 @@ function get_tails() {
 }
 
 function get_tinycore() {
+    local ARCH="x86"
     local HASH=""
-    local ISO="${EDITION}-${RELEASE}.iso"
-    local URL=""
-    if [ "${EDITION}" == "Core" ] || [ "${EDITION}" == "TinyCore" ] || [ "${EDITION}" == "CorePlus" ]; then
-        URL="http://www.tinycorelinux.net/14.x/x86/release"
-    elif [ "${EDITION}" == "CorePure64" ] || [ "${EDITION}" == "TinyCorePure64" ]; then
-        URL="http://www.tinycorelinux.net/14.x/x86_64/release"
-    fi
+    local ISO="${EDITION}-${RELEASE}.0.iso"
+    case "${EDITION}" in
+        *Pure*) ARCH+="_64";;
+    esac
+    local URL="http://www.tinycorelinux.net/${RELEASE}.x/${ARCH}/release"
     HASH=$(web_pipe "${URL}/${ISO}.md5.txt" | cut_1)
     echo "${URL}/${ISO} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -435,8 +435,8 @@ function list_url_all() {
                 show_test_result SKIP "${OS}" "${RELEASE}" "${OPTION}" "${URL}"
             done
         elif [[ "${OS}" == "macos" ]]; then
-            validate_release releases_"${OS}"
-            echo -e "SKIP:\t${OS}\t${RELEASE}"
+            validate_release releases_macos
+            (get_macos)
         elif [ "${OS}" == "ubuntu-server" ]; then
             validate_release releases_ubuntu-server
             (get_ubuntu-server)
@@ -480,8 +480,8 @@ function list_check_all() {
                     show_test_result SKIP "${OS}" "${RELEASE}" "${OPTION}" "${URL}"
                 done
             elif [[ "${OS}" == "macos" ]]; then
-                validate_release releases_"${OS}"
-                echo -e "SKIP:\t${OS}\t${RELEASE}"
+                validate_release releases_macos
+                (get_macos)
             elif [ "${OS}" == "ubuntu-server" ]; then
                 validate_release releases_ubuntu-server
                 (get_ubuntu-server)
@@ -2084,8 +2084,8 @@ function get_macos() {
         echo -e "Recovery URL (inaccessible through normal browser):\n${downloadLink}\nChunklist (used for verifying the Recovery Image):\n${chunkListLink}\nFirmware URLs:\n${OpenCore_qcow2}\n${OVMF_CODE}\n${OVMF_VARS}"
         exit 0
     elif [ "${just}" == 'test' ]; then
-        web_check "${downloadLink}" --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${downloadSession}"
-        web_check "${chunkListLink}" --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${chunkListSession}"
+        local CHECK=$(web_check "${downloadLink}" --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${downloadSession}" && echo 'PASS' || echo 'FAIL')
+        show_test_result ${CHECK} "${OS}" "${RELEASE}" "" "${downloadLink}"
         exit 0
     elif [ "${just}" == 'download' ]; then
         echo "Downloading macOS ${RELEASE} from ${downloadLink}"

--- a/quickget
+++ b/quickget
@@ -992,7 +992,7 @@ function releases_rebornos() {
 }
 
 function releases_rockylinux() {
-    echo 9.3 9.2 9.1 9.0 8.9 8.8 8.7 8.6 8.5 8.4 8.3
+    echo $(web_pipe "http://dl.rockylinux.org/vault/rocky/" | grep "^<a href" | grep -v full | grep -v RC | grep -v ISO | cut -d'"' -f2 | tr -d / | sort -ru)
 }
 
 function editions_rockylinux() {

--- a/quickget
+++ b/quickget
@@ -393,6 +393,22 @@ function list_supported() {
     exit 0
 }
 
+function show_test_result() {
+    local RESULT="${1}"
+    local OS="${2}"
+    local RELEASE="${3}"
+    local EDITION="${4:-}"
+    local URL="${5:-}"
+    if [ -n "${EDITION}" ]; then
+        OS="${OS}-${RELEASE}-${EDITION}"
+    else
+        OS="${OS}-${RELEASE}"
+    fi
+    # Pad the OS string to 32 characters
+    OS=$(printf "%-35s" "${OS}")
+    echo -e "${RESULT}: ${OS} ${URL}"
+}
+
 function list_url_all() {
     OS="${1}"
     os_supported

--- a/quickget
+++ b/quickget
@@ -919,8 +919,7 @@ function releases_openbsd(){
 }
 
 function releases_openindiana(){
-    web_pipe "https://dlc.openindiana.org/isos/hipster/" | grep link | cut -d'/' -f 1 | cut -d '"' -f4 | sort -r | tail +2 | head -n 5 | tr '\n' ' '
-    echo
+    echo $(web_pipe "https://dlc.openindiana.org/isos/hipster/" | grep link | cut -d'/' -f 1 | cut -d '"' -f4 | sort -r | tail +2 | head -n 5 | tr '\n' ' ')
 }
 
 function editions_openindiana(){

--- a/quickget
+++ b/quickget
@@ -1270,8 +1270,8 @@ function web_get() {
         echo "${URL}"
         exit 0
     elif [ "${just}" == 'test' ]; then
-        echo -n "Testing if $(echo "${URL}" | rev | cut -d'/' -f1 | rev) is available... "
-        web_check "${URL}" && echo 'PASS' || echo 'FAIL'
+        GOOD=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
+        echo -e "${GOOD}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
         exit 0
     elif [ "${just}" == 'download' ]; then
         DIR="$(pwd)"

--- a/quickget
+++ b/quickget
@@ -421,7 +421,7 @@ function show_url_result() {
     echo -e "${OS} ${URL}"
 }
 
-function list_url_all() {
+function test_all() {
     OS="${1}"
     os_supported
 
@@ -437,13 +437,22 @@ function list_url_all() {
             for EDITION in $(editions_"${OS}"); do
                 validate_release releases_"${OS}"
                 URL=$(get_"${OS}" | cut_1 | head -1)
-                show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+                if [ "${OPERATION}" == "show" ]; then
+                    show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+                elif [ "${OPERATION}" == "test" ]; then
+                    CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
+                    show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+                fi
             done
         elif [[ "${OS}" == "windows"* ]]; then
             "languages_${OS}"
             for LANG in "${LANGS[@]}"; do
                 validate_release releases_"${OS}"
-                show_url_result "${OS}" "${RELEASE}" "${LANG}" "SKIP"
+                if [ "${OPERATION}" == "show" ]; then
+                    show_url_result "${OS}" "${RELEASE}" "${LANG}" "SKIP"
+                elif [ "${OPERATION}" == "test" ]; then
+                    show_test_result SKIP "${OS}" "${RELEASE}" "${LANG}" "${URL}"
+                fi
             done
         elif [[ "${OS}" == "macos" ]]; then
             validate_release releases_macos
@@ -457,49 +466,9 @@ function list_url_all() {
         else
             validate_release releases_"${OS}"
             URL=$(get_"${OS}" | cut_1 | head -1)
-            show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
-        fi
-    done
-}
-
-function list_check_all() {
-    OS="${1}"
-    os_supported
-
-    local CHECK=""
-    local FUNC="${OS}"
-    if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
-        FUNC="ubuntu"
-    fi
-    local URL=""
-
-    for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
-        if [[ $(type -t "editions_${OS}") == function ]]; then
-            for EDITION in $(editions_"${OS}"); do
-                validate_release releases_"${OS}"
-                URL=$(get_"${OS}" | cut_1 | head -1)
-                CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-                show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
-            done
-        else
-            if [[ "${OS}" == "windows"* ]]; then
-                "languages_${OS}"
-                for LANG in "${LANGS[@]}"; do
-                    validate_release releases_"${OS}"
-                    show_test_result SKIP "${OS}" "${RELEASE}" "${LANG}" "${URL}"
-                done
-            elif [[ "${OS}" == "macos" ]]; then
-                validate_release releases_macos
-                (get_macos)
-            elif [ "${OS}" == "ubuntu-server" ]; then
-                validate_release releases_ubuntu-server
-                (get_ubuntu-server)
-            elif [[ "${OS}" == *ubuntu* ]]; then
-                validate_release releases_ubuntu
-                (get_ubuntu)
-            else
-                validate_release releases_"${OS}"
-                URL=$(get_"${OS}" | cut_1 | head -1)
+            if [ "${OPERATION}" == "show" ]; then
+                show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+            elif [ "${OPERATION}" == "test" ]; then
                 CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
                 show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
             fi
@@ -3451,10 +3420,10 @@ case "${1}" in
     # if no OS is specified, list all URLs for all supported OSes
     if [ -z "${1}" ]; then
         for OS in $(os_support); do
-            (list_url_all "${OS}")
+            (test_all "${OS}")
         done
     else
-        list_url_all "${1}"
+        test_all "${1}"
     fi
     exit 0
     ;;
@@ -3468,10 +3437,10 @@ case "${1}" in
     # if no OS is specified, check all URLs for all supported OSes
     if [ -z "${1}" ]; then
         for OS in $(os_support); do
-            (list_check_all "${OS}")
+            (test_all "${OS}")
         done
     else
-        list_check_all "${1}"
+        test_all "${1}"
     fi
     exit 0
     ;;

--- a/quickget
+++ b/quickget
@@ -679,11 +679,11 @@ function releases_bazzite() {
 }
 
 function releases_biglinux() {
-    echo $(web_pipe "https://iso.biglinux.com.br" | grep -Eo 'biglinux_[0-9]{4}(-[0-9]{2}){2}_k[0-9]{2,3}.iso' | cut -d'_' -f2 | sort -ru)
+    echo $(web_pipe "https://iso.biglinux.com.br" | grep -Eo 'biglinux_[0-9]{4}(-[0-9]{2}){2}_k[0-9]{2,3}.iso' | cut -d'_' -f2 | sort -ru | head -1)
 }
 
 function editions_biglinux() {
-    echo $(web_pipe "https://iso.biglinux.com.br" | grep -Eo 'biglinux_[0-9]{4}(-[0-9]{2}){2}_k[0-9]{2,3}.iso' | cut -d'_' -f3 | cut -d'.' -f1 | sort -ru)
+    echo $(web_pipe "https://iso.biglinux.com.br" | grep -Eo "biglinux_$(releases_biglinux)_k[0-9]{2,3}.iso" | cut -d'_' -f3 | cut -d'.' -f1 | sort -Vru)
 }
 
 function releases_blendos() {

--- a/quickget
+++ b/quickget
@@ -1119,7 +1119,7 @@ function releases_vanillaos() {
 }
 
 function releases_void() {
-    echo current
+    echo $(web_pipe "https://repo-default.voidlinux.org/live/" | grep "^<a href=\"2" | cut -d'"' -f2 | tr -d '/' | sort -ru)
 }
 
 function editions_void() {
@@ -2604,16 +2604,15 @@ function get_void() {
     local DATE=""
     local HASH=""
     local ISO=""
-    local URL="https://repo-default.voidlinux.org/live/current"
-    DATE=$(web_pipe "${URL}/sha256sum.txt" | head -n1 | cut -d'.' -f1 | cut -d'-' -f4)
+    local URL="https://repo-default.voidlinux.org/live"
     case ${EDITION} in
-      glibc) ISO="void-live-x86_64-${DATE}-base.iso";;
-      musl) ISO="void-live-x86_64-musl-${DATE}-base.iso";;
-      xfce-glibc) ISO="void-live-x86_64-${DATE}-xfce.iso";;
-      xfce-musl) ISO="void-live-x86_64-musl-${DATE}-xfce.iso";;
+      glibc) ISO="void-live-x86_64-${RELEASE}-base.iso";;
+      musl) ISO="void-live-x86_64-musl-${RELEASE}-base.iso";;
+      xfce-glibc) ISO="void-live-x86_64-${RELEASE}-xfce.iso";;
+      xfce-musl) ISO="void-live-x86_64-musl-${RELEASE}-xfce.iso";;
     esac
     HASH="$(web_pipe "${URL}/sha256sum.txt" | grep "${ISO}" | cut -d' ' -f4)"
-    echo "${URL}/${ISO} ${HASH}"
+    echo "${URL}/${RELEASE}/${ISO} ${HASH}"
 }
 
 function get_vxlinux() {

--- a/quickget
+++ b/quickget
@@ -3467,7 +3467,14 @@ case "${1}" in
   '--check-all'|'-ca')
     just="test"
     shift
-    list_check_all "${1}"
+    # if no OS is specified, check all URLs for all supported OSes
+    if [ -z "${1}" ]; then
+        for OS in $(os_support); do
+            (list_check_all "${OS}")
+        done
+    else
+        list_check_all "${1}"
+    fi
     ;;
     #TODO: Argument without dashes should be DEPRECATED!
   '--list-csv'|'-lc'|'list'|'list_csv'|'lc')

--- a/quickget
+++ b/quickget
@@ -601,7 +601,13 @@ function editions_alma() {
 }
 
 function releases_alpine() {
-    echo latest 3.19 3.18 3.17 3.16 3.15 3.14 3.13 3.12
+    local REL=""
+    local RELS=$(web_pipe "https://dl-cdn.alpinelinux.org/alpine/" | grep '"v' | cut -d'"' -f2 | tr -d / | sort -Vr | head -n 10)
+    for REL in ${RELS}; do
+        if web_check "https://dl-cdn.alpinelinux.org/alpine/${REL}/releases/x86_64/"; then
+            echo -n "${REL} "
+        fi
+    done
 }
 
 function releases_android() {

--- a/quickget
+++ b/quickget
@@ -394,17 +394,12 @@ function list_supported() {
 }
 
 function list_url_all() {
-    local DIR="/dev/null"
     local URL
-    local FUNC
     local OPTION
     local OS="${1}"
-    if [[ "${OS}" == *ubuntu-server* ]]; then
-        FUNC="ubuntu-server"
-    elif [[ "${OS}" == *ubuntu* ]]; then
+    local FUNC="${OS}"
+    if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
         FUNC="ubuntu"
-    else
-        FUNC="${OS}"
     fi
 
     for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
@@ -423,7 +418,7 @@ function list_url_all() {
         elif [[ "${OS}" == "macos" ]]; then
             validate_release releases_"${OS}"
             echo -e "SKIP:\t${OS}\t${RELEASE}"
-        elif [[ "${OS}" == *ubuntu-server* ]]; then
+        elif [ "${OS}" == "ubuntu-server" ]; then
             validate_release releases_ubuntu-server
             (get_ubuntu-server)
         elif [[ "${OS}" == *ubuntu* ]]; then
@@ -440,15 +435,11 @@ function list_url_all() {
 
 function list_check_all() {
     local URL
-    local FUNC
     local OPTION
     local OS="${1}"
-    if [[ "${OS}" == *ubuntu-server* ]]; then
-        FUNC="ubuntu-server"
-    elif [[ "${OS}" == *ubuntu* ]]; then
+    local FUNC="${OS}"
+    if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
         FUNC="ubuntu"
-    else
-        FUNC="${OS}"
     fi
 
     for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
@@ -469,7 +460,7 @@ function list_check_all() {
             elif [[ "${OS}" == "macos" ]]; then
                 validate_release releases_"${OS}"
                 echo -e "SKIP:\t${OS}\t${RELEASE}"
-            elif [[ "${OS}" == *ubuntu-server* ]]; then
+            elif [ "${OS}" == "ubuntu-server" ]; then
                 validate_release releases_ubuntu-server
                 (get_ubuntu-server)
             elif [[ "${OS}" == *ubuntu* ]]; then

--- a/quickget
+++ b/quickget
@@ -782,8 +782,7 @@ function editions_fedora() {
 }
 
 function releases_freebsd(){
-    local FBSD_RELEASES=$(web_pipe "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/" |grep -e 'class="link"' |grep -v '\.\.'|cut -d\" -f4|tr -d '/' | sort -r | tr '\n' ' ')
-    echo "${FBSD_RELEASES}"
+    echo $(web_pipe "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/" |grep -e 'class="link"' |grep -v '\.\.'|cut -d\" -f4|tr -d '/' | sort -r)
 }
 
 function editions_freebsd(){

--- a/quickget
+++ b/quickget
@@ -1113,7 +1113,7 @@ function releases_vanillaos() {
 }
 
 function releases_void() {
-    echo $(web_pipe "https://repo-default.voidlinux.org/live/" | grep "^<a href=\"2" | cut -d'"' -f2 | tr -d '/' | sort -ru)
+    echo $(web_pipe "https://repo-default.voidlinux.org/live/" | grep "^<a href=\"2" | cut -d'"' -f2 | tr -d '/' | sort -ru | head -3)
 }
 
 function editions_void() {

--- a/quickget
+++ b/quickget
@@ -2495,6 +2495,7 @@ function get_tuxedoos() {
 function get_ubuntu-server() {
     local HASH=""
     local ISO=""
+    local NAME="live-server"
     local URL=""
     [[ $RELEASE = daily ]] && RELEASE=daily-live
     if [[ "${RELEASE}" == "daily"* ]]; then
@@ -2502,18 +2503,19 @@ function get_ubuntu-server() {
     else
         URL="https://releases.ubuntu.com/${RELEASE}"
     fi
+
+    case "${RELEASE}" in
+      14*|16*) NAME="server";;
+    esac
+
     if web_check "${URL}/SHA256SUMS"; then
-        DATA=$(web_pipe "${URL}/SHA256SUMS" | grep 'live-server' | grep amd64 | grep iso)
+        DATA=$(web_pipe "${URL}/SHA256SUMS" | grep "${NAME}" | grep amd64 | grep iso)
         ISO=$(cut -d'*' -f2 <<<${DATA})
         HASH=$(cut_1 <<<${DATA})
     else
-        DATA=$(web_pipe "${URL}/MD5SUMS" | grep 'live-server' | grep amd64 | grep iso)
+        DATA=$(web_pipe "${URL}/MD5SUMS" | grep "${NAME}" | grep amd64 | grep iso)
         ISO=$(cut -d' ' -f3 <<<${DATA})
         HASH=$(cut_1 <<<${DATA})
-    fi
-    if [ -z $ISO ] || [ -z $HASH ]; then
-        echo "$(pretty_name $OS) ${RELEASE} is currently unavailable. Please select other OS/Release combination"
-        exit 1
     fi
     if [[ "${RELEASE}" == "daily"* ]] || [ "${RELEASE}" == "dvd" ]; then
         zsync_get "${URL}/${ISO}" "${VM_PATH}" "${OS}-devel.iso"

--- a/quickget
+++ b/quickget
@@ -409,6 +409,21 @@ function show_test_result() {
     echo -e "${RESULT}: ${OS} ${URL}"
 }
 
+function show_url_result() {
+    local OS="${1}"
+    local RELEASE="${2}"
+    local EDITION="${3:-}"
+    local URL="${4:-}"
+    if [ -n "${EDITION}" ]; then
+        OS="${OS}-${RELEASE}-${EDITION}"
+    else
+        OS="${OS}-${RELEASE}"
+    fi
+    # Pad the OS string to 32 characters
+    OS=$(printf "%-35s" "${OS}:")
+    echo -e "${OS} ${URL}"
+}
+
 function list_url_all() {
     OS="${1}"
     os_supported

--- a/quickget
+++ b/quickget
@@ -3451,7 +3451,14 @@ case "${1}" in
   '--url-all'|'-ua')
     just="show"
     shift
-    list_url_all "${1}"
+    # if no OS is specified, list all URLs for all supported OSes
+    if [ -z "${1}" ]; then
+        for OS in $(os_support); do
+            (list_url_all "${OS}")
+        done
+    else
+        list_url_all "${1}"
+    fi
     ;;
   '--check'|'-c')
     just="test"

--- a/quickget
+++ b/quickget
@@ -1296,8 +1296,7 @@ function web_redirect() {
 # checks if a URL is reachable
 function web_check() {
     local HEADERS=()
-    local URL=""
-    URL=$(web_redirect "${1}")
+    local URL="${1}"
     # Process any headers
     while (( "$#" )); do
         if [ "${1}" == "--header" ]; then

--- a/quickget
+++ b/quickget
@@ -3553,7 +3553,7 @@ fi
 os_supported
 
 if [ -n "${2}" ]; then
-    RELEASE="${2,,}"
+    RELEASE="${2}"
     VM_PATH="${OS}-${RELEASE}"
     # If the OS has an editions_() function, use it.
     if [[ $(type -t "editions_${OS}") == function ]]; then

--- a/quickget
+++ b/quickget
@@ -394,9 +394,11 @@ function list_supported() {
 }
 
 function list_url_all() {
+    OS="${1}"
+    os_supported
+
     local CHECK=""
     local OPTION=""
-    local OS="${1}"
     local FUNC="${OS}"
     if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
         FUNC="ubuntu"
@@ -435,9 +437,11 @@ function list_url_all() {
 }
 
 function list_check_all() {
+    OS="${1}"
+    os_supported
+
     local CHECK=""
     local OPTION=""
-    local OS="${1}"
     local FUNC="${OS}"
     if [[ "${OS}" == *ubuntu* && "${OS}" != "ubuntu-server" ]]; then
         FUNC="ubuntu"

--- a/quickget
+++ b/quickget
@@ -432,7 +432,7 @@ function list_url_all() {
             "languages_${OS}"
             for OPTION in "${LANGS[@]}"; do
                 validate_release releases_"${OS}"
-                echo -e "SKIP:\t${OS}\t${RELEASE}\t${OPTION}\t${URL}"
+                show_test_result SKIP "${OS}" "${RELEASE}" "${OPTION}" "${URL}"
             done
         elif [[ "${OS}" == "macos" ]]; then
             validate_release releases_"${OS}"
@@ -470,14 +470,14 @@ function list_check_all() {
                 validate_release releases_"${OS}"
                 URL=$(get_"${OS}" | cut_1 | head -1)
                 CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-                echo -e "${CHECK}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
+                show_test_result ${CHECK} "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
             done
         else
             if [[ "${OS}" == "windows"* ]]; then
                 "languages_${OS}"
                 for OPTION in "${LANGS[@]}"; do
                     validate_release releases_"${OS}"
-                    echo -e "SKIP:\t${OS}\t${RELEASE}\t${OPTION}\t${URL}"
+                    show_test_result SKIP "${OS}" "${RELEASE}" "${OPTION}" "${URL}"
                 done
             elif [[ "${OS}" == "macos" ]]; then
                 validate_release releases_"${OS}"
@@ -492,7 +492,7 @@ function list_check_all() {
                 validate_release releases_"${OS}"
                 URL=$(get_"${OS}" | cut_1 | head -1)
                 CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-                echo -e "${CHECK}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
+                show_test_result ${CHECK} "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
             fi
         fi
     done
@@ -1245,7 +1245,7 @@ function web_get() {
         exit 0
     elif [ "${just}" == 'test' ]; then
         CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-        echo -e "${CHECK}:\t${OS}\t${RELEASE}\t${EDITION}\t${URL}"
+        show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
         exit 0
     elif [ "${just}" == 'download' ]; then
         DIR="$(pwd)"

--- a/quickget
+++ b/quickget
@@ -1128,7 +1128,7 @@ function editions_void() {
 }
 
 function releases_vxlinux() {
-    web_pipe "https://github.com/VX-Linux/main/releases/latest" | grep -o -e 'releases/tag/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]' | head -n 1 | cut -d'/' -f 3
+    echo $(web_pipe "https://github.com/VX-Linux/main/releases/latest" | grep -o -e 'releases/tag/[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]' | sort -u | cut -d'/' -f 3)
 }
 
 function releases_windows() {

--- a/quickget
+++ b/quickget
@@ -651,7 +651,7 @@ function editions_artixlinux() {
 }
 
 function releases_athenaos() {
-    echo $(web_pipe "https://api.github.com/repos/Athena-OS/athena/releases" | grep 'download_url' | grep rolling | cut -d'/' -f8 | uniq | tr '\n' ' ')
+    echo $(web_pipe "https://api.github.com/repos/Athena-OS/athena/releases" | grep 'download_url' | grep rolling | cut -d'/' -f8 | sort -u)
 }
 
 function releases_batocera() {

--- a/quickget
+++ b/quickget
@@ -390,35 +390,26 @@ function list_supported() {
     exit 0
 }
 
-function show_test_result() {
-    local RESULT="${1}"
-    local OS="${2}"
-    local RELEASE="${3}"
-    local EDITION="${4:-}"
-    local URL="${5:-}"
-    if [ -n "${EDITION}" ]; then
-        OS="${OS}-${RELEASE}-${EDITION}"
-    else
-        OS="${OS}-${RELEASE}"
-    fi
-    # Pad the OS string to 32 characters
-    OS=$(printf "%-35s" "${OS}")
-    echo -e "${RESULT}: ${OS} ${URL}"
-}
-
-function show_url_result() {
+function test_result() {
     local OS="${1}"
     local RELEASE="${2}"
     local EDITION="${3:-}"
     local URL="${4:-}"
+    local RESULT="${5:-}"
     if [ -n "${EDITION}" ]; then
         OS="${OS}-${RELEASE}-${EDITION}"
     else
         OS="${OS}-${RELEASE}"
     fi
-    # Pad the OS string to 32 characters
-    OS=$(printf "%-35s" "${OS}:")
-    echo -e "${OS} ${URL}"
+
+    if [ -n "${RESULT}" ]; then
+        # Pad the OS string for consistent output
+        OS=$(printf "%-35s" "${OS}")
+        echo -e "${RESULT}: ${OS} ${URL}"
+    else
+        OS=$(printf "%-36s" "${OS}:")
+        echo -e "${OS} ${URL}"
+    fi
 }
 
 function test_all() {
@@ -438,10 +429,10 @@ function test_all() {
                 validate_release releases_"${OS}"
                 URL=$(get_"${OS}" | cut_1 | head -1)
                 if [ "${OPERATION}" == "show" ]; then
-                    show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+                    test_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
                 elif [ "${OPERATION}" == "test" ]; then
                     CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-                    show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+                    test_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}" "${CHECK}"
                 fi
             done
         elif [[ "${OS}" == "windows"* ]]; then
@@ -449,9 +440,9 @@ function test_all() {
             for LANG in "${LANGS[@]}"; do
                 validate_release releases_"${OS}"
                 if [ "${OPERATION}" == "show" ]; then
-                    show_url_result "${OS}" "${RELEASE}" "${LANG}" "SKIP"
+                    test_result "${OS}" "${RELEASE}" "${LANG}" ""
                 elif [ "${OPERATION}" == "test" ]; then
-                    show_test_result SKIP "${OS}" "${RELEASE}" "${LANG}" "${URL}"
+                    test_result "${OS}" "${RELEASE}" "${LANG}" "${URL}" "SKIP"
                 fi
             done
         elif [[ "${OS}" == "macos" ]]; then
@@ -467,10 +458,10 @@ function test_all() {
             validate_release releases_"${OS}"
             URL=$(get_"${OS}" | cut_1 | head -1)
             if [ "${OPERATION}" == "show" ]; then
-                show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+                test_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
             elif [ "${OPERATION}" == "test" ]; then
                 CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-                show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+                test_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}" "${CHECK}"
             fi
         fi
     done
@@ -1217,11 +1208,11 @@ function web_get() {
 
     # Test mode for ISO
     if [ "${OPERATION}" == "show" ]; then
-        show_url_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+        test_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
         exit 0
     elif [ "${OPERATION}" == "test" ]; then
         CHECK=$(web_check "${URL}" && echo 'PASS' || echo 'FAIL')
-        show_test_result "${CHECK}" "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
+        test_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}" "${CHECK}"
         exit 0
     elif [ "${OPERATION}" == "download" ]; then
         DIR="$(pwd)"
@@ -2057,11 +2048,11 @@ function get_macos() {
     local chunkListSession=$(echo "$info" | grep 'expires' | grep 'chunklist')
 
     if [ "${OPERATION}" == "show" ]; then
-        show_url_result "${OS}" "${RELEASE}" "" "${downloadLink}"
+        test_result "${OS}" "${RELEASE}" "" "${downloadLink}"
         exit 0
     elif [ "${OPERATION}" == "test" ]; then
         local CHECK=$(web_check "${downloadLink}" --header "Host: oscdn.apple.com" --header "Connection: close" --header "User-Agent: InternetRecovery/1.0" --header "Cookie: AssetToken=${downloadSession}" && echo 'PASS' || echo 'FAIL')
-        show_test_result "${CHECK}" "${OS}" "${RELEASE}" "" "${downloadLink}"
+        test_result "${OS}" "${RELEASE}" "" "${downloadLink}" "${CHECK}"
         exit 0
     elif [ "${OPERATION}" == "download" ]; then
         echo "Downloading macOS ${RELEASE} from ${downloadLink}"


### PR DESCRIPTION
The pull request refactors and updates various functions related to listing ISO URLs and checking if the ISO download URLs are valid.

You can now:

List all URLs for an OS via:

`quickget --url-all ubuntu`

Check all URLs for an OS via:

`quickget --check-all ubuntu`

It is also possible to run these tests for all support OS' via:

`quickget --url-all`
`quickget --check-all`

Here are the failed test from `--check-all`

```
FAIL: arcolinux-v24.05.11-large           https://mirror.accum.se/mirror/arcolinux.info/iso/v24.05.11/arcolinuxl-v24.05.11-x86_64.iso
FAIL: arcolinux-v24.05.11-small           https://mirror.accum.se/mirror/arcolinux.info/iso/v24.05.11/arcolinuxs-v24.05.11-x86_64.iso
FAIL: arcolinux-v24.02.01-large           https://mirror.accum.se/mirror/arcolinux.info/iso/v24.02.01/arcolinuxl-v24.02.01-x86_64.iso
FAIL: arcolinux-v24.02.01-small           https://mirror.accum.se/mirror/arcolinux.info/iso/v24.02.01/arcolinuxs-v24.02.01-x86_64.iso
FAIL: blendos-v3-gnome                    https://mirror.ico277.xyz/blendos/gnome/blendos-v3-stable-gnome.iso
FAIL: easyos-5.7                          https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2024/5.7/easy-5.7-amd64.img
FAIL: easyos-5.6.7                        https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2024/5.6.7/easy-5.6.7-amd64.img
FAIL: easyos-5.6.6                        https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2024/5.6.6/easy-5.6.6-amd64.img
FAIL: easyos-5.6.5                        https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/5.6.5/easy-5.6.5-amd64.img
FAIL: easyos-5.6.4                        https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/5.6.4/easy-5.6.4-amd64.img
FAIL: easyos-5.6.3                        https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/5.6.3/easy-5.6.3-amd64.img
FAIL: easyos-5.6.2                        https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/5.6.2/easy-5.6.2-amd64.img
FAIL: easyos-5.6.1                        https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/5.6.1/easy-5.6.1-amd64.img
FAIL: fedora-39-Onyx                      
FAIL: fedora-39-Sericea                                        
FAIL: parrotsec-6.0-home                  https://download.parrot.sh/parrot/iso/6.0/Parrot-home-6.0_amd64.iso
FAIL: parrotsec-6.0-htb                   https://download.parrot.sh/parrot/iso/6.0/Parrot-htb-6.0_amd64.iso
FAIL: parrotsec-6.0-security              https://download.parrot.sh/parrot/iso/6.0/Parrot-security-6.0_amd64.iso
FAIL: parrotsec-5.3-home                  https://download.parrot.sh/parrot/iso/5.3/Parrot-home-5.3_amd64.iso
FAIL: parrotsec-5.3-htb                   https://download.parrot.sh/parrot/iso/5.3/Parrot-htb-5.3_amd64.iso
FAIL: parrotsec-5.3-security              https://download.parrot.sh/parrot/iso/5.3/Parrot-security-5.3_amd64.iso
```

- arcolinux has some failures (but there are 6 that pass for arcolinux) because they do not publish iso images in a consistent fashion. 
- blendos is a legit failure, the gnome iso on their server has incorrect permissions.
- easyos always fails for me. I can not reach their download server via a browser.
- fedora 39 does not have Onyx or Sericea images available; we can probably account for that.
- parrotsec did work, but the TLS/SSL certificate expired (the irony) on Sunday, 28 April 2024 at 19:07:02 so these failures are legit. 

The good news is, **the other 778** tests are passing.