### PR TITLE
Add support for Fedora 40

### DIFF
--- a/quickget
+++ b/quickget
@@ -771,7 +771,7 @@ function editions_endless() {
 }
 
 function releases_fedora() {
-    echo 39 38
+    echo 40 39 38
 }
 
 function editions_fedora() {


### PR DESCRIPTION
This change adds support for Fedora 40.

Downloads of all flavors have been tested, so there are no exceptions to add to `handle_missing()`.