### PR TITLE
Make wget2 preferred downloader if found.

### DIFF
--- a/quickget
+++ b/quickget
@@ -1220,7 +1220,7 @@ function web_get() {
     fi
 
     if command -v wget2 &>/dev/null; then
-        if ! wget2 --quiet --continue --tries=3 --read-timeout=10 --force-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" --user-agent "${USER_AGENT}" "${HEADERS[@]}"; then
+        if ! wget2 --quiet --continue --tries=3 --read-timeout=10 --chunk-size 500M --max-threads $(nproc) --force-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" --user-agent "${USER_AGENT}" "${HEADERS[@]}"; then
             echo "ERROR! Failed to download ${URL} with wget2."
             echo "       Will try again with wget."
             exit 1

--- a/quickget
+++ b/quickget
@@ -1219,21 +1219,22 @@ function web_get() {
         echo "- URL: ${URL}"
     fi
 
-    if ! curl --progress-bar --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}"; then
-        echo "ERROR! Failed to download ${URL} with curl."
-        echo "       Will try again with wget."
-        rm -f "${DIR}/${FILE}"
-        if command -v wget2 &>/dev/null; then
-            if ! wget2 --quiet --continue --tries=3 --read-timeout=10 --force-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" "${HEADERS[@]}"; then
-                echo "ERROR! Failed to download ${URL} with wget2."
-                echo "       Try deleting '${DIR}/${FILE}' running 'quickget' again."
-                exit 1
-            fi
-        elif ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" "${HEADERS[@]}"; then
-            echo "ERROR! Failed to download ${URL} with wget."
-            echo "       Try deleting '${DIR}/${FILE}' running 'quickget' again."
+    if command -v wget2 &>/dev/null; then
+        if ! wget2 --quiet --continue --tries=3 --read-timeout=10 --force-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" --user-agent "${USER_AGENT}" "${HEADERS[@]}"; then
+            echo "ERROR! Failed to download ${URL} with wget2."
+            echo "       Will try again with wget."
             exit 1
         fi
+    elif command -v wget &>/dev/null; then
+        if ! wget --quiet --continue --tries=3 --read-timeout=10 --show-progress --progress=bar:force:noscroll "${URL}" -O "${DIR}/${FILE}" --user-agent "${USER_AGENT}" "${HEADERS[@]}"; then
+            echo "ERROR! Failed to download ${URL} with wget."
+            echo "       Will try again with curl."
+            exit 1
+        fi
+    else ! curl --progress-bar --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}"; then
+        echo "ERROR! Failed to download ${URL} with curl."
+        echo "       Try deleting '${DIR}/${FILE}' running 'quickget' again."
+        rm -f "${DIR}/${FILE}"
     fi
 }
 


### PR DESCRIPTION
Make wget2 the default downloader. (Is generally faster than the other two for downloads) 

 - Fall back to `wget` and then `curl` if not found (wget is faster for downloads than curl)
 - Add user agents to `wget`/`wget2`