### PR TITLE
feat: add support for running quickemu on macOS hosts

### DIFF
--- a/.github/workflows/test-quickget.yml
+++ b/.github/workflows/test-quickget.yml
@@ -13,96 +13,40 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  list-all-supported:
-    name: "List all supported OS 📝"
-    runs-on: ubuntu-22.04
-    # The type of runner that the job will run on
-    #runs-on: ubuntu-latest
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
-      - name: "List all supported OS variants"
-        run: |
-          mkdir -p results
-          ./quickget --list | tee results/supported.txt
-          echo -e "\nResults:"
-          echo "- All supported OS variants: $(wc -l results/supported.txt | cut -d' ' -f 1)"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: supported
-          path: results/supported.txt
-
-  list-all-urls:
-    needs: [list-all-supported]
-    name: "List all URLs 🔗"
+  quickget-tests:
+    name: "Run quickget tests 👟"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: "quickget --url"
+      - name: "Install dependencies 📦️"
         run: |
-          export TERM=xterm-256color
+          sudo apt-get -y update
+          sudo apt-get -y install curl qemu-utils
+      - name: "List OS variants 📃"
+        run: |
           mkdir -p results
-          ./quickget --url | tee results/urls.txt
-      - uses: actions/download-artifact@v4
-        with:
-          path: results
-          merge-multiple: true
-      - name: "Show differences ⚖️"
+          ./quickget --list | tail -n +2 | tee results/list.txt
+      - name: "Check OS downloads 💿️"
         run: |
-          echo -e "\nResults:"
-          echo -e "List All URLs:\t$(grep -c http results/urls.txt)"
-          echo -e "OS Info URLs:\t$(wc -l results/supported.txt | cut -d' ' -f 1)"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: urls
-          path: results/urls.txt
-
-  check-all-urls:
-    name: "Check all image URLs 💿️"
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: "quickget --check"
-        run: |
-          export TERM=xterm-256color
           mkdir -p results
-          ./quickget --check | tee results/checks.txt
-          WINDOWS=$(grep -c "windows-" results/checks.txt)
-          FAILED=$(grep -c ^FAIL results/checks.txt)
-          SKIPPED=$(grep -c ^SKIP results/checks.txt)
-          PASSED=$(grep -c ^PASS results/checks.txt)
-          CHECKED=$((FAILED + SKIPPED + PASSED))
+          ./quickget --check | tee results/check.txt
+      - name: "Display results 📊"
+        run: |
+          WINDOWS=$(grep -c "windows-" results/check.txt)
+          FAILED=$(grep -c ^FAIL results/check.txt)
+          SKIPPED=$(grep -c ^SKIP results/check.txt)
+          PASSED=$(grep -c ^PASS results/check.txt)
+          CHECKED=$((WINDOWS + FAILED + SKIPPED + PASSED))
           echo -e "\nResults:"
+          echo -e "- CHECKED:\t${CHECKED}"
           echo -e "- PASSED:\t${PASSED}"
           echo -e "- SKIPPED:\t${SKIPPED}\t(of which ${WINDOWS} are Windows)"
           echo -e "- FAILED:\t${FAILED}\n"
-          grep ^FAIL results/checks.txt | tee results/failed.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: checks
-          path: results/checks.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: failed
-          path: results/failed.txt
-
-  upload-artifacts:
-    needs: [list-all-urls, check-all-urls]
-    name: "Uploading artifacts"
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: results
-          merge-multiple: true
-      - name: "List results"
-        run: |
-          ls -R results/
-      - uses: actions/upload-artifact@v4
-        with:
-          overwrite: true
-          name: results
-          path: results/
+          grep ^FAIL results/check.txt | tee results/failed.txt
+          VARIATIONS=$(wc -l results/list.txt | cut -d' ' -f 1)
+          DOWNLOADS=$(wc -l results/check.txt | cut -d' ' -f 1)
+          echo
+          echo "Compare OS variations with downloads:"
+          echo -e "- Variations:\t${VARIATIONS}"
+          echo -e "- Downloads:\t${DOWNLOADS}"

--- a/quickemu
+++ b/quickemu
@@ -287,33 +287,34 @@ function configure_cpu() {
     HOST_CPU_VENDOR=$(get_cpu_info 'Vendor')
 
     CPU_MODEL="host"
+    QEMU_ACCEL="tcg"
     # Configure appropriately for the host platform
     if [ "${OS_KERNEL}" == "Darwin" ]; then
         MANUFACTURER=$(ioreg -l | grep -e Manufacturer | grep -v iMan | cut -d'"' -f4 | sort -u)
         CPU_KVM_UNHALT=""
         KVM_GUEST_TWEAKS=""
-        QEMU_ACCEL=",accel=hvf"
+        QEMU_ACCEL="hvf"
         # QEMU for macOS from Homebrew does not support SMM
         SMM="off"
     else
         MANUFACTURER=$(head -1 /sys/class/dmi/id/sys_vendor)
         CPU_KVM_UNHALT=",kvm_pv_unhalt"
         KVM_GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard "
-        QEMU_ACCEL=",accel=kvm"
+        QEMU_ACCEL="kvm"
     fi
 
     # If the architecture of the VM is different from the host, disable acceleration
     if [ "${ARCH_VM}" != "${ARCH_HOST}" ]; then
-        QEMU_ACCEL=""
         CPU_MODEL="qemu64"
         CPU_KVM_UNHALT=""
         KVM_GUEST_TWEAKS=""
+        QEMU_ACCEL="tcg"
     fi
 
     # Detect if running in a VM
     case ${MANUFACTURER,,} in
         qemu|virtualbox) CPU_MODEL="qemu64"
-                         QEMU_ACCEL=""
+                         QEMU_ACCEL="tcg"
                          HYPERVISOR="${MANUFACTURER,,}";;
         *) HYPERVISOR="";;
     esac
@@ -1133,7 +1134,7 @@ function vm_boot() {
         args+=(-name ${VMNAME},process=${VMNAME})
     fi
     # shellcheck disable=SC2054,SC2206,SC2140
-    args+=(-machine ${MACHINE_TYPE},smm=${SMM},vmport=off${QEMU_ACCEL} ${GUEST_TWEAKS}
+    args+=(-machine ${MACHINE_TYPE},smm=${SMM},vmport=off,accel=${QEMU_ACCEL} ${GUEST_TWEAKS}
         ${CPU} ${SMP}
         -m ${RAM_VM} ${BALLOON}
         -rtc base=localtime,clock=host,driftfix=slew

--- a/quickemu
+++ b/quickemu
@@ -962,9 +962,9 @@ function vm_boot() {
     VGA=""
     VIDEO=""
 
-    KERNEL_NAME=$(uname --kernel-name)
-    KERNEL_NODE="($(uname --nodename))"
-    KERNEL_VER=$(uname --kernel-release | cut -d'.' -f1-2)
+    KERNEL_NAME="$(${UNAME} --kernel-name)"
+    KERNEL_NODE="$(${UNAME} --nodename)"
+    KERNEL_VER="$(${UNAME} --kernel-release | cut -d'.' -f1-2)"
 
     if [ -e /etc/os-release ]; then
         LSB_DESCRIPTION=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
@@ -1685,6 +1685,16 @@ QEMU_IMG=$(command -v qemu-img)
 if [ ! -e "${QEMU}" ] || [ ! -e "${QEMU_IMG}" ]; then
     echo "ERROR! QEMU not found. Please make install qemu-system-x86_64 and qemu-img"
     exit 1
+fi
+
+# Check for gnu tools on macOS
+UNAME="uname"
+if command -v guname &>/dev/null; then
+    UNAME="guname"
+fi
+DARWIN=0
+if [ "${UNAME}" == "Darwin" ]; then
+    DARWIN=1
 fi
 
 QEMU_VER_LONG=$(${QEMU} -version | head -n1 | cut -d' ' -f4 | cut -d'(' -f1)

--- a/quickemu
+++ b/quickemu
@@ -847,9 +847,13 @@ function configure_display() {
             # https://kevinlocke.name/bits/2021/12/10/windows-11-guest-virtio-libvirt/#video
             case ${display} in
                 gtk|none|spice) DISPLAY_DEVICE="qxl-vga";;
-                sdl|spice-app)  DISPLAY_DEVICE="virtio-vga";;
+                cocoa|sdl|spice-app)  DISPLAY_DEVICE="virtio-vga";;
             esac;;
-        *) DISPLAY_DEVICE="qxl-vga";;
+        *) if [ "${OS_KERNEL}" == "Darwin" ]; then
+               DISPLAY_DEVICE="VGA"
+            else
+               DISPLAY_DEVICE="qxl-vga"
+            fi;;
     esac
 
     # Map Quickemu $display to QEMU -display

--- a/quickemu
+++ b/quickemu
@@ -1028,9 +1028,9 @@ function vm_boot() {
     VGA=""
     VIDEO=""
 
-    KERNEL_NAME="$(${UNAME} --kernel-name)"
-    KERNEL_NODE="$(${UNAME} --nodename)"
-    KERNEL_VER="$(${UNAME} --kernel-release | cut -d'.' -f1-2)"
+    KERNEL_NAME="$(uname -s)"
+    KERNEL_NODE="$(uname -n | cut -d'.' -f 1)"
+    KERNEL_VER="$(uname -r)"
 
     if [ -e /etc/os-release ]; then
         LSB_DESCRIPTION=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
@@ -1763,18 +1763,13 @@ if [ ! -e "${QEMU}" ] || [ ! -e "${QEMU_IMG}" ]; then
 fi
 
 # Check for gnu tools on macOS
-UNAME="uname"
-if command -v guname &>/dev/null; then
-    UNAME="guname"
-fi
-
 STAT="stat"
 if command -v gstat &>/dev/null; then
     STAT="gstat"
 fi
 
 DARWIN=0
-if [ "${UNAME}" == "Darwin" ]; then
+if [ "$(uname -s)" == "Darwin" ]; then
     DARWIN=1
 fi
 

--- a/quickemu
+++ b/quickemu
@@ -300,7 +300,9 @@ function configure_cpu() {
         # QEMU for macOS from Homebrew does not support SMM
         SMM="off"
     else
-        MANUFACTURER=$(head -1 /sys/class/dmi/id/sys_vendor)
+        if [ -r /sys/class/dmi/id/sys_vendor ]; then
+            MANUFACTURER=$(head -1 /sys/class/dmi/id/sys_vendor)
+        fi
         CPU_KVM_UNHALT=",kvm_pv_unhalt"
         GUEST_TWEAKS+=" -global kvm-pit.lost_tick_policy=discard"
         QEMU_ACCEL="kvm"

--- a/quickemu
+++ b/quickemu
@@ -1168,7 +1168,8 @@ function vm_boot() {
         args+=(-k "${keyboard_layout}")
     fi
 
-    if [ -n "${BRAILLE}" ]; then
+    # Braille requires SDL, so disable for macOS
+    if [ -n "${BRAILLE}" ] && [ ${DARWIN} -eq 0 ]; then
         if ${QEMU} -chardev help | grep -q braille; then
             # shellcheck disable=SC2054
             #args+=(-chardev braille,id=brltty

--- a/quickemu
+++ b/quickemu
@@ -653,7 +653,7 @@ function configure_storage() {
 
         # Only check disk image size if preallocation is off
         if [ "${preallocation}" == "off" ]; then
-            DISK_CURR_SIZE=$(stat -c%s "${disk_img}")
+            DISK_CURR_SIZE=$(${STAT} -c%s "${disk_img}")
             if [ "${DISK_CURR_SIZE}" -le "${DISK_MIN_SIZE}" ]; then
                 echo "             Looks unused, booting from ${iso}${img}"
                 if [ -z "${iso}" ] && [ -z "${img}" ]; then
@@ -1553,7 +1553,7 @@ function fileshare_param_check() {
             echo " - WARNING! Public directory: '${PUBLIC}' doesn't exist!"
         else
             PUBLIC_TAG="Public-${USER,,}"
-            PUBLIC_PERMS=$(stat -c "%A" "${PUBLIC}")
+            PUBLIC_PERMS=$(${STAT}  -c "%A" "${PUBLIC}")
         fi
     fi
 }
@@ -1692,6 +1692,12 @@ UNAME="uname"
 if command -v guname &>/dev/null; then
     UNAME="guname"
 fi
+
+STAT="stat"
+if command -v gstat &>/dev/null; then
+    STAT="gstat"
+fi
+
 DARWIN=0
 if [ "${UNAME}" == "Darwin" ]; then
     DARWIN=1

--- a/quickemu
+++ b/quickemu
@@ -253,7 +253,7 @@ function check_cpu_flag() {
             return 1
         fi
     else
-      HOST_CPU_FLAG="${1},,"
+      HOST_CPU_FLAG="${1}"
       if lscpu | grep -o "^Flags\b.*: .*\b${HOST_CPU_FLAG}\b" > /dev/null; then
           return 0
       else

--- a/quickemu
+++ b/quickemu
@@ -205,6 +205,30 @@ function configure_usb() {
     fi
 }
 
+# macOS and Linux compatible get_cpu_info function
+function get_cpu_info() {
+    local INFO_NAME="${1}"
+
+    if [ ${DARWIN} -eq 1 ]; then
+        if [ "^Model name:" == "${INFO_NAME}" ]; then
+            sysctl -n machdep.cpu.brand_string | sed 's/ //g'
+        elif [ "Socket" == "${INFO_NAME}" ]; then
+            sysctl -n hw.packages
+        elif [ "Vendor" == "${INFO_NAME}" ]; then
+            sysctl -n machdep.cpu.vendor | sed 's/ //g'
+        else
+            echo "ERROR! Could not find macOS translation for ${INFO_NAME}"
+            exit 1
+        fi
+    else
+        if [ "^Model name:" == "${INFO_NAME}" ]; then
+            lscpu | grep "${INFO_NAME}" | cut -d':' -f2 | sed -e 's/^[[:space:]]*//'
+        else
+            lscpu | grep -E "${INFO_NAME}" | cut -d':' -f2 | sed 's/ //g'
+        fi
+    fi
+}
+
 function check_cpu_flag() {
     local HOST_CPU_FLAG="${1}"
     if lscpu | grep -o "^Flags\b.*: .*\b${HOST_CPU_FLAG}\b" > /dev/null; then
@@ -232,9 +256,9 @@ function efi_vars() {
 
 function configure_cpu() {
     HOST_CPU_CORES=$(nproc)
-    HOST_CPU_MODEL=$(lscpu | grep '^Model name:' | cut -d':' -f2 | sed -e 's/^[[:space:]]*//')
-    HOST_CPU_SOCKETS=$(lscpu | grep -E 'Socket' | cut -d':' -f2 | sed 's/ //g')
-    HOST_CPU_VENDOR=$(lscpu | grep -E 'Vendor' | cut -d':' -f2 | sed 's/ //g')
+    HOST_CPU_MODEL=$(get_cpu_info '^Model name:')
+    HOST_CPU_SOCKETS=$(get_cpu_info 'Socket')
+    HOST_CPU_VENDOR=$(get_cpu_info 'Vendor')
 
     # A CPU with Intel VT-x / AMD SVM support is required
     if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then

--- a/quickemu
+++ b/quickemu
@@ -1025,7 +1025,7 @@ function vm_boot() {
     KERNEL_NAME="Unknown"
     KERNEL_NODE=""
     KERNEL_VER="?"
-    LSB_DESCRIPTION="Unknown OS"
+    local HOST_OS="Unknown OS"
     MACHINE_TYPE="${MACHINE_TYPE:-q35}"
     MAC_BOOTLOADER=""
     MAC_MISSING=""
@@ -1042,12 +1042,17 @@ function vm_boot() {
     KERNEL_NODE="$(uname -n | cut -d'.' -f 1)"
     KERNEL_VER="$(uname -r)"
 
-    if [ -e /etc/os-release ]; then
-        LSB_DESCRIPTION=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
+    if [ ${DARWIN} -eq 1 ]; then
+        # Get macOS product name and version using swvers
+        if [ -x "$(command -v sw_vers)" ]; then
+            HOST_OS="$(sw_vers --productName) $(sw_vers --productVersion)"
+        fi
+    elif [ -e /etc/os-release ]; then
+        HOST_OS=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
     fi
 
     echo "Quickemu ${VERSION} using ${QEMU} v${QEMU_VER_LONG}"
-    echo " - Host:     ${LSB_DESCRIPTION} running ${KERNEL_NAME} ${KERNEL_VER} ${KERNEL_NODE}"
+    echo " - Host:     ${HOST_OS} running ${KERNEL_NAME} ${KERNEL_VER} ${KERNEL_NODE}"
 
     # Force to lowercase.
     boot=${boot,,}

--- a/quickemu
+++ b/quickemu
@@ -623,7 +623,7 @@ function configure_os_quirks() {
             done
 
             # Disable S3 support in the VM to prevent macOS suspending during install
-            GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard -global ICH9-LPC.disable_s3=1 -device isa-applesmc,osk=$(echo "bheuneqjbexolgurfrjbeqfthneqrqcyrnfrqbagfgrny(p)NccyrPbzchgreVap" | tr 'A-Za-z' 'N-ZA-Mn-za-m')"
+            GUEST_TWEAKS="${KVM_GUEST_TWEAKS}-global ICH9-LPC.disable_s3=1 -device isa-applesmc,osk=$(echo "bheuneqjbexolgurfrjbeqfthneqrqcyrnfrqbagfgrny(p)NccyrPbzchgreVap" | tr 'A-Za-z' 'N-ZA-Mn-za-m')"
 
             # Disable High Precision Timer
             if [ "${QEMU_VER_SHORT}" -ge 70 ]; then
@@ -671,7 +671,7 @@ function configure_os_quirks() {
             fi
             # Disable S3 support in the VM to ensure Windows can boot with SecureBoot enabled
             #  - https://wiki.archlinux.org/title/QEMU#VM_does_not_boot_when_using_a_Secure_Boot_enabled_OVMF
-            GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard -global ICH9-LPC.disable_s3=1"
+            GUEST_TWEAKS="${KVM_GUEST_TWEAKS}-global ICH9-LPC.disable_s3=1"
 
             # Disable High Precision Timer
             if [ "${QEMU_VER_SHORT}" -ge 70 ]; then
@@ -1801,10 +1801,12 @@ fi
 DARWIN=0
 CPU_KVM=",kvm=on"
 CPU_KVM_UNHALT=",kvm_pv_unhalt"
+KVM_GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard "
 if [ "$(uname -s)" == "Darwin" ]; then
     DARWIN=1
     CPU_KVM=""
     CPU_KVM_UNHALT=""
+    KVM_GUEST_TWEAKS=""
 fi
 
 QEMU_VER_LONG=$(${QEMU} -version | head -n1 | cut -d' ' -f4 | cut -d'(' -f1)

--- a/quickemu
+++ b/quickemu
@@ -244,11 +244,21 @@ function get_cpu_info() {
 }
 
 function check_cpu_flag() {
-    local HOST_CPU_FLAG="${1}"
-    if lscpu | grep -o "^Flags\b.*: .*\b${HOST_CPU_FLAG}\b" > /dev/null; then
-        return 0
+    local HOST_CPU_FLAG=""
+    if [ ${DARWIN} -eq 1 ]; then
+        HOST_CPU_FLAG="${1}^^"
+        if sysctl -n machdep.cpu.features | grep -o "${HOST_CPU_FLAG}" > /dev/null; then
+            return 0
+        else
+            return 1
+        fi
     else
-        return 1
+      HOST_CPU_FLAG="${1},,"
+      if lscpu | grep -o "^Flags\b.*: .*\b${HOST_CPU_FLAG}\b" > /dev/null; then
+          return 0
+      else
+          return 1
+      fi
     fi
 }
 

--- a/quickemu
+++ b/quickemu
@@ -306,8 +306,15 @@ function configure_cpu() {
         QEMU_ACCEL="kvm"
     fi
 
-    # If the architecture of the VM is different from the host, disable acceleration
-    if [ "${ARCH_VM}" != "${ARCH_HOST}" ]; then
+    if [ "${ARCH_VM}" == "aarch64"  ]; then
+        # Support to run aarch64 VMs (best guess; untested)
+        # https://qemu-project.gitlab.io/qemu/system/arm/virt.html
+        case ${ARCH_HOST} in
+            arm64|aarch64) CPU_MODEL="max"
+                           MACHINE_TYPE="virt,highmem=off";;
+        esac
+    elif [ "${ARCH_VM}" != "${ARCH_HOST}" ]; then
+        # If the architecture of the VM is different from the host, disable acceleration
         CPU_MODEL="qemu64"
         CPU_KVM_UNHALT=""
         QEMU_ACCEL="tcg"

--- a/quickemu
+++ b/quickemu
@@ -336,6 +336,111 @@ function configure_cpu() {
         fi
     fi
 
+    CPU="-cpu ${CPU_MODEL}"
+
+    # Make any OS specific adjustments
+    if [ "${guest_os}" == "freedos" ] || [ "${guest_os}" == "windows" ] || [ "${guest_os}" == "windows-server" ]; then
+        # SMM is not available on QEMU for macOS via Homebrew
+        if [ "${OS_KERNEL}" == "Linux" ]; then
+            SMM="on"
+        fi
+    fi
+
+    case ${guest_os} in
+        batocera|freedos|haiku|solaris) MACHINE_TYPE="pc";;
+        kolibrios|reactos)
+            CPU="-cpu qemu32"
+            MACHINE_TYPE="pc";;
+        macos)
+            # If the host has an Intel CPU, passes the host CPU model features, model, stepping, exactly to the guest.
+            # Disable huge pages (,-pdpe1gb) on macOS to prevent crashes
+            # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
+            if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
+                CPU_MODEL="host"
+                CPU="-cpu ${CPU_MODEL},-pdpe1gb,+hypervisor"
+            else
+                CPU_MODEL="Haswell-v4"
+                CPU="-cpu ${CPU_MODEL},vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,vmware-cpuid-freq=on"
+            fi
+            # A CPU with fma is required for Metal support
+            # A CPU with invtsc is required for macOS to boot
+            case ${macos_release} in
+                ventura|sonoma)
+                    # A CPU with AVX2 support is required for >= macOS Ventura
+                    if check_cpu_flag sse4_2 && check_cpu_flag avx2; then
+                        if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
+                            CPU+=",+avx2,+sse4.2"
+                        fi
+                    else
+                        echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 and AVX2 support."
+                        echo "       Try macOS Monterey or Big Sur."
+                        exit 1
+                    fi;;
+                catalina|big-sur|monterey)
+                    # A CPU with SSE4.2 support is required for >= macOS Catalina
+                    if check_cpu_flag sse4_2; then
+                        if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
+                            CPU+=",+sse4.2"
+                        fi
+                    else
+                        echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 support."
+                        exit 1
+                    fi;;
+                *)
+                    # A CPU with SSE4.1 support is required for >= macOS Sierra
+                    if check_cpu_flag sse4_1; then
+                        if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
+                            CPU+=",+sse4.1"
+                        fi
+                    else
+                        echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.1 support."
+                        exit 1
+                    fi;;
+            esac
+
+            if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
+                for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist f16c fma invtsc \
+                          mmx movbe mpx popcnt smep vaes vbmi2 vpclmulqdq \
+                          xgetbv1 xsave xsaveopt; do
+                    if check_cpu_flag "${FLAG}"; then
+                        CPU+=",+${FLAG}"
+                    fi
+                done
+            fi
+
+            # Disable S3 support in the VM to prevent macOS suspending during install
+            GUEST_TWEAKS+=" -global ICH9-LPC.disable_s3=1 -device isa-applesmc,osk=$(echo "bheuneqjbexolgurfrjbeqfthneqrqcyrnfrqbagfgrny(p)NccyrPbzchgreVap" | tr 'A-Za-z' 'N-ZA-Mn-za-m')"
+
+            # Disable High Precision Timer
+            if [ "${QEMU_VER_SHORT}" -ge 70 ]; then
+                MACHINE_TYPE+=",hpet=off"
+            else
+                GUEST_TWEAKS+=" -no-hpet"
+            fi
+            ;;
+        windows|windows-server)
+            if [ "${QEMU_VER_SHORT}" -gt 60 ]; then
+                CPU="-cpu ${CPU_MODEL},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
+            else
+                CPU="-cpu ${CPU_MODEL},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies${CPU_KVM_UNHALT},hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
+            fi
+            # Disable S3 support in the VM to ensure Windows can boot with SecureBoot enabled
+            #  - https://wiki.archlinux.org/title/QEMU#VM_does_not_boot_when_using_a_Secure_Boot_enabled_OVMF
+            GUEST_TWEAKS+=" -global ICH9-LPC.disable_s3=1"
+
+            # Disable High Precision Timer
+            if [ "${QEMU_VER_SHORT}" -ge 70 ]; then
+              MACHINE_TYPE+=",hpet=off"
+            else
+              GUEST_TWEAKS+=" -no-hpet"
+            fi
+            ;;
+    esac
+
+    if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ] && [ "${guest_os}" != "macos" ]; then
+        CPU+=",topoext"
+    fi
+
     if [ -z "${cpu_cores}" ]; then
         if [ "${HOST_CPU_CORES}" -ge 32 ]; then
             GUEST_CPU_CORES="16"
@@ -577,106 +682,24 @@ function configure_bios() {
 }
 
 function configure_os_quirks() {
-    # Make any OS specific adjustments
+
+    if [ "${guest_os}" == "batocera" ] || [ "${guest_os}" == "freedos" ] || [ "${guest_os}" == "haiku" ] || [ "${guest_os}" == "kolibrios" ]; then
+        NET_DEVICE="rtl8139"
+    fi
+
+    if [ "${guest_os}" == "freebsd" ] || [ "${guest_os}" == "ghostbsd" ]; then
+        mouse="usb"
+    fi
+
     case ${guest_os} in
-        batocera|*bsd|freedos|haiku|linux*|*solaris)
-            CPU="-cpu ${CPU_MODEL}"
-            if [ "${guest_os}" == "freebsd" ] || [ "${guest_os}" == "ghostbsd" ]; then
-                mouse="usb"
-            elif [ "${guest_os}" == "batocera" ] || [ "${guest_os}" == "freedos" ] || [ "${guest_os}" == "haiku" ]; then
-                MACHINE_TYPE="pc"
-                NET_DEVICE="rtl8139"
-            fi
-
-            if [ "${guest_os}" == "freedos" ] ; then
-                # fix for #382
-                SMM="on"
-                sound_card="sb16"
-            fi
-
-            if [[ "${guest_os}" == *"solaris" ]]; then
-                MACHINE_TYPE="pc"
-                usb_controller="xhci"
-                sound_card="ac97"
-            fi
-            ;;
-        kolibrios|reactos)
-            CPU="-cpu qemu32"
-            MACHINE_TYPE="pc"
-            case ${guest_os} in
-                kolibrios) NET_DEVICE="rtl8139";;
-                reactos)   NET_DEVICE="e1000"
-                           keyboard="ps2";;
-            esac
-            ;;
+        *bsd|linux*|windows*) NET_DEVICE="virtio-net";;
+        freedos) sound_card="sb16";;
+        *solaris) usb_controller="xhci"
+                  sound_card="ac97";;
+        reactos) NET_DEVICE="e1000"
+                 keyboard="ps2";;
         macos)
-            # If the host has an Intel CPU, passes the host CPU model features, model, stepping, exactly to the guest.
-            # Disable huge pages (,-pdpe1gb) on macOS to prevent crashes
-            # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
-            if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ] && [ -n "${HYPERVISOR}" ]; then
-                CPU_MODEL="host"
-                CPU="-cpu ${CPU_MODEL},-pdpe1gb,+hypervisor"
-            else
-                CPU_MODEL="Haswell-v4"
-                CPU="-cpu ${CPU_MODEL},vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,vmware-cpuid-freq=on"
-            fi
-            # A CPU with fma is required for Metal support
-            # A CPU with invtsc is required for macOS to boot
-            case ${macos_release} in
-                ventura|sonoma)
-                    # A CPU with AVX2 support is required for >= macOS Ventura
-                    if check_cpu_flag sse4_2 && check_cpu_flag avx2; then
-                        if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-                            CPU+=",+avx2,+sse4.2"
-                        fi
-                    else
-                        echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 and AVX2 support."
-                        echo "       Try macOS Monterey or Big Sur."
-                        exit 1
-                    fi;;
-                catalina|big-sur|monterey)
-                    # A CPU with SSE4.2 support is required for >= macOS Catalina
-                    if check_cpu_flag sse4_2; then
-                        if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-                            CPU+=",+sse4.2"
-                        fi
-                    else
-                        echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 support."
-                        exit 1
-                    fi;;
-                *)
-                    # A CPU with SSE4.1 support is required for >= macOS Sierra
-                    if check_cpu_flag sse4_1; then
-                        if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-                            CPU+=",+sse4.1"
-                        fi
-                    else
-                        echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.1 support."
-                        exit 1
-                    fi;;
-            esac
-
-            if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-                for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist f16c fma invtsc \
-                          mmx movbe mpx popcnt smep vaes vbmi2 vpclmulqdq \
-                          xgetbv1 xsave xsaveopt; do
-                    if check_cpu_flag "${FLAG}"; then
-                        CPU+=",+${FLAG}"
-                    fi
-                done
-            fi
-
-            # Disable S3 support in the VM to prevent macOS suspending during install
-            GUEST_TWEAKS+=" -global ICH9-LPC.disable_s3=1 -device isa-applesmc,osk=$(echo "bheuneqjbexolgurfrjbeqfthneqrqcyrnfrqbagfgrny(p)NccyrPbzchgreVap" | tr 'A-Za-z' 'N-ZA-Mn-za-m')"
-
-            # Disable High Precision Timer
-            if [ "${QEMU_VER_SHORT}" -ge 70 ]; then
-                MACHINE_TYPE+=",hpet=off"
-            else
-                GUEST_TWEAKS+=" -no-hpet"
-            fi
-
-            # Tune Qemu optimisations based on the macOS release, or fallback to lowest
+            # Tune QEMU optimisations based on the macOS release, or fallback to lowest
             # common supported options if none is specified.
             #   * VirtIO Block Media doesn't work in High Sierra (at all) or the Mojave (Recovery Image)
             #   * VirtIO Network is supported since Big Sur
@@ -704,36 +727,8 @@ function configure_os_quirks() {
                     USB_HOST_PASSTHROUGH_CONTROLLER="usb-ehci";;
             esac
             ;;
-        windows|windows-server)
-            if [ "${QEMU_VER_SHORT}" -gt 60 ]; then
-                CPU="-cpu ${CPU_MODEL},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
-            else
-                CPU="-cpu ${CPU_MODEL},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies${CPU_KVM_UNHALT},hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
-            fi
-            # Disable S3 support in the VM to ensure Windows can boot with SecureBoot enabled
-            #  - https://wiki.archlinux.org/title/QEMU#VM_does_not_boot_when_using_a_Secure_Boot_enabled_OVMF
-            GUEST_TWEAKS+=" -global ICH9-LPC.disable_s3=1"
-
-            # Disable High Precision Timer
-            if [ "${QEMU_VER_SHORT}" -ge 70 ]; then
-              MACHINE_TYPE+=",hpet=off"
-            else
-              GUEST_TWEAKS+=" -no-hpet"
-            fi
-
-            # SMM is not available on QEMU for macOS via Homebrew
-            if [ "${OS_KERNEL}" == "Linux" ]; then
-                SMM="on"
-            fi
-            ;;
-        *) CPU="-cpu ${CPU_MODEL}"
-           NET_DEVICE="rtl8139"
-           echo "WARNING! Unrecognised guest OS: ${guest_os}";;
+        *) NET_DEVICE="rtl8139";;
     esac
-
-    if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ] && [ "${guest_os}" != "macos" ]; then
-      CPU+=",topoext"
-    fi
 }
 
 function configure_storage() {

--- a/quickemu
+++ b/quickemu
@@ -775,6 +775,7 @@ function configure_display() {
 
     # Map Quickemu $display to QEMU -display
     case ${display} in
+        cocoa)      DISPLAY_RENDER="${display}";;
         gtk)        DISPLAY_RENDER="${display},grab-on-hover=on,zoom-to-fit=off,gl=${gl}";;
         none|spice) DISPLAY_RENDER="none";;
         sdl)        DISPLAY_RENDER="${display},gl=${gl}";;
@@ -1445,7 +1446,7 @@ function usage() {
     echo "  --braille                         : Enable braille support. Requires SDL."
     echo "  --delete-disk                     : Delete the disk image and EFI variables"
     echo "  --delete-vm                       : Delete the entire VM and its configuration"
-    echo "  --display                         : Select display backend. 'sdl' (default), 'gtk', 'none', 'spice' or 'spice-app'"
+    echo "  --display                         : Select display backend. 'sdl' (default), 'cocoa', 'gtk', 'none', 'spice' or 'spice-app'"
     echo "  --fullscreen                      : Starts VM in full screen mode (Ctl+Alt+f to exit)"
     echo "  --ignore-msrs-always              : Configure KVM to always ignore unhandled machine-specific registers"
     echo "  --kill                            : Kill the VM process if it is running"
@@ -1489,12 +1490,14 @@ function display_param_check() {
     if [ "${display}" != "gtk" ] && [ "${display}" != "none" ] && [ "${display}" != "sdl" ] && [ "${display}" != "spice" ] && [ "${display}" != "spice-app" ]; then
         echo "ERROR! Requested output '${display}' is not recognised."
         exit 1
+    elif [ "${display}" == "cocoa" ] && [ ${DARWIN} -eq 0 ]; then
+        echo "ERROR! Requested output '${display}' is only supported on macOS."
+        exit 1
+    elif [ "${display}" != "cocoa" ] && [ ${DARWIN} -eq 1 ]; then
+        echo "WARNING! Requested output '${display}' but only 'cocoa' is avalible on macOS."
+        echo "         Setting display to 'cocoa'."
+        display="cocoa"
     fi
-
-    # Enable grab-on-hover for SDL: https://github.com/quickemu-project/quickemu/issues/541
-    case "${display}" in
-        sdl) export SDL_MOUSE_FOCUS_CLICKTHROUGH=1;;
-    esac
 
     # Set the default 3D acceleration.
     if [ -z "${gl}" ]; then
@@ -1508,6 +1511,13 @@ function display_param_check() {
             gl="on"
         fi
     fi
+
+    # Disable GL for cocoa
+    # Enable grab-on-hover for SDL: https://github.com/quickemu-project/quickemu/issues/541
+    case "${display}" in
+        cocoa) gl="off";;
+        sdl) export SDL_MOUSE_FOCUS_CLICKTHROUGH=1;;
+    esac
 }
 
 function ports_param_check() {

--- a/quickemu
+++ b/quickemu
@@ -322,7 +322,10 @@ function configure_cpu() {
         QEMU_ACCEL="tcg"
     fi
 
-    # Detect if running in a VM
+    # TODO: More robust detection of running in a VM
+    # - macOS check for CPU flag: vmx
+    # - Linux AMD check for CPU flag: svm
+    # - Linux Intel check for CPU flag: vmx
     case ${MANUFACTURER,,} in
         qemu|virtualbox) CPU_MODEL="qemu64"
                          QEMU_ACCEL="tcg"

--- a/quickemu
+++ b/quickemu
@@ -665,7 +665,7 @@ function configure_os_quirks() {
             esac
 
             if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-              for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist ept_1gb f16c fma invtsc \
+              for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist f16c fma invtsc \
                           mmx movbe mpx pdpe1gb popcnt smep vaes vbmi2 vpclmulqdq \
                           xgetbv1 xsave xsaveopt; do
                   if check_cpu_flag "${FLAG}"; then

--- a/quickemu
+++ b/quickemu
@@ -541,7 +541,7 @@ function configure_os_quirks() {
     # Make any OS specific adjustments
     case ${guest_os} in
         batocera|*bsd|freedos|haiku|linux*|*solaris)
-            CPU="-cpu host,kvm=on"
+            CPU="-cpu host${CPU_KVM}"
             if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
                 CPU="${CPU},topoext"
             fi
@@ -566,7 +566,7 @@ function configure_os_quirks() {
             fi
             ;;
         kolibrios|reactos)
-            CPU="-cpu qemu32,kvm=on"
+            CPU="-cpu qemu32${CPU_KVM}"
             if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
                 CPU="${CPU},topoext"
             fi
@@ -593,21 +593,21 @@ function configure_os_quirks() {
             case ${macos_release} in
                 ventura|sonoma)
                     if check_cpu_flag sse4_2 && check_cpu_flag avx2; then
-                        CPU="-cpu Haswell-v4,kvm=on,vendor=GenuineIntel,+avx,+avx2,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        CPU="-cpu Haswell-v4${CPU_KVM},vendor=GenuineIntel,+avx,+avx2,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 and AVX2 support."
                         exit 1
                     fi;;
                 catalina|big-sur|monterey)
                     if check_cpu_flag sse4_2; then
-                        CPU="-cpu Haswell-v4,kvm=on,vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        CPU="-cpu Haswell-v4${CPU_KVM},vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 support."
                         exit 1
                     fi;;
                 *)
                     if check_cpu_flag sse4_1; then
-                        CPU="-cpu Penryn,kvm=on,vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.1,vmware-cpuid-freq=on"
+                        CPU="-cpu Penryn${CPU_KVM},vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.1,vmware-cpuid-freq=on"
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.1 support."
                         exit 1
@@ -662,9 +662,9 @@ function configure_os_quirks() {
             ;;
         windows|windows-server)
             if [ "${QEMU_VER_SHORT}" -gt 60 ]; then
-                CPU="-cpu host,kvm=on,+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
+                CPU="-cpu host${CPU_KVM},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
             else
-                CPU="-cpu host,kvm=on,+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies,kvm_pv_unhalt,hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
+                CPU="-cpu host${CPU_KVM},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies${CPU_KVM_UNHALT},hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
             fi
             if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
                 CPU="${CPU},topoext"
@@ -681,7 +681,7 @@ function configure_os_quirks() {
             fi
             SMM="on"
             ;;
-        *) CPU="-cpu host,kvm=on"
+        *) CPU="-cpu host${CPU_KVM}"
            NET_DEVICE="rtl8139"
            echo "WARNING! Unrecognised guest OS: ${guest_os}";;
     esac
@@ -1799,8 +1799,12 @@ if command -v gstat &>/dev/null; then
 fi
 
 DARWIN=0
+CPU_KVM=",kvm=on"
+CPU_KVM_UNHALT=",kvm_pv_unhalt"
 if [ "$(uname -s)" == "Darwin" ]; then
     DARWIN=1
+    CPU_KVM=""
+    CPU_KVM_UNHALT=""
 fi
 
 QEMU_VER_LONG=$(${QEMU} -version | head -n1 | cut -d' ' -f4 | cut -d'(' -f1)

--- a/quickemu
+++ b/quickemu
@@ -240,9 +240,11 @@ function get_cpu_info() {
         fi
     else
         if [ "^Model name:" == "${INFO_NAME}" ]; then
-            lscpu | grep "${INFO_NAME}" | cut -d':' -f2 | sed -e 's/^[[:space:]]*//'
+            for MODEL_NAME in $(IFS=$'\n' lscpu | grep "${INFO_NAME}" | cut -d':' -f2 | sed -e 's/^[[:space:]]*//'); do
+                echo -n "${MODEL_NAME} "
+            done
         else
-            lscpu | grep -E "${INFO_NAME}" | cut -d':' -f2 | sed 's/ //g'
+            lscpu | grep -E "${INFO_NAME}" | cut -d':' -f2 | sed 's/ //g' | sort -u
         fi
     fi
 }

--- a/quickemu
+++ b/quickemu
@@ -341,8 +341,13 @@ configure_ram() {
     RAM_VM="2G"
     if [ -z "${ram}" ]; then
         local RAM_HOST=""
-        # Determine the number of gigabytes of RAM in the host by extracting the first numerical value from the output.
-        RAM_HOST=$(free --giga | tr ' ' '\n' | grep -m 1 [0-9])
+        if [ ${DARWIN} -eq 1 ]; then
+            RAM_HOST=$(($(sysctl -n hw.memsize) / (1048576*1024)))
+        else
+            # Determine the number of gigabytes of RAM in the host by extracting the first numerical value from the output.
+            RAM_HOST=$(free --giga -h | tr ' ' '\n' | grep -m 1 [0-9] | cut -d'G' -f 1)
+        fi
+
         if [ "${RAM_HOST}" -ge 128 ]; then
             RAM_VM="32G"
         elif [ "${RAM_HOST}" -ge 64 ]; then

--- a/quickemu
+++ b/quickemu
@@ -1558,16 +1558,17 @@ function display_param_check() {
         display="sdl"
     fi
 
-    if [ "${display}" != "gtk" ] && [ "${display}" != "none" ] && [ "${display}" != "sdl" ] && [ "${display}" != "spice" ] && [ "${display}" != "spice-app" ]; then
-        echo "ERROR! Requested output '${display}' is not recognised."
-        exit 1
-    elif [ "${display}" == "cocoa" ] && [ ${DARWIN} -eq 0 ]; then
-        echo "ERROR! Requested output '${display}' is only supported on macOS."
-        exit 1
-    elif [ "${display}" != "cocoa" ] && [ ${DARWIN} -eq 1 ]; then
-        echo "WARNING! Requested output '${display}' but only 'cocoa' is avalible on macOS."
-        echo "         Setting display to 'cocoa'."
-        display="cocoa"
+    if [ ${DARWIN} -eq 1 ]; then
+        if [ "${display}" != "cocoa" ]; then
+          echo "WARNING! Requested output '${display}' but only 'cocoa' is avalible on macOS."
+          echo "         Setting display to 'cocoa'."
+          display="cocoa"
+        fi
+    else
+        if [ "${display}" != "gtk" ] && [ "${display}" != "none" ] && [ "${display}" != "sdl" ] && [ "${display}" != "spice" ] && [ "${display}" != "spice-app" ]; then
+            echo "ERROR! Requested output '${display}' is not recognised."
+            exit 1
+        fi
     fi
 
     # Set the default 3D acceleration.

--- a/quickemu
+++ b/quickemu
@@ -849,16 +849,11 @@ function configure_display() {
                 gtk|none|spice) DISPLAY_DEVICE="qxl-vga";;
                 cocoa|sdl|spice-app)  DISPLAY_DEVICE="virtio-vga";;
             esac;;
-        *) if [ "${OS_KERNEL}" == "Darwin" ]; then
-               DISPLAY_DEVICE="VGA"
-            else
-               DISPLAY_DEVICE="qxl-vga"
-            fi;;
+        *) DISPLAY_DEVICE="qxl-vga";;
     esac
 
     # Map Quickemu $display to QEMU -display
     case ${display} in
-        cocoa)      DISPLAY_RENDER="${display}";;
         gtk)        DISPLAY_RENDER="${display},grab-on-hover=on,zoom-to-fit=off,gl=${gl}";;
         none|spice) DISPLAY_RENDER="none";;
         sdl)        DISPLAY_RENDER="${display},gl=${gl}";;
@@ -1585,10 +1580,9 @@ function display_param_check() {
     fi
 
     if [ "${OS_KERNEL}" == "Darwin" ]; then
-        if [ "${display}" != "cocoa" ]; then
-          echo "WARNING! Requested output '${display}' but only 'cocoa' is avalible on macOS."
-          echo "         Setting display to 'cocoa'."
-          display="cocoa"
+        if [ "${display}" != "cocoa" ] && [ "${display}" != "none" ]; then
+          echo "ERROR! Requested output '${display}' but only 'cocoa' and 'none' are avalible on macOS."
+          exit 1
         fi
     else
         if [ "${display}" != "gtk" ] && [ "${display}" != "none" ] && [ "${display}" != "sdl" ] && [ "${display}" != "spice" ] && [ "${display}" != "spice-app" ]; then

--- a/quickemu
+++ b/quickemu
@@ -1839,8 +1839,8 @@ if [ "${OS_KERNEL}" == "Darwin" ]; then
     display="cocoa"
 fi
 
-QEMU_VER_LONG=$(${QEMU} -version | head -n1 | cut -d' ' -f4 | cut -d'(' -f1)
-QEMU_VER_SHORT=$(${QEMU} -version | head -n1 | cut -d' ' -f4 | cut -d'(' -f1 | sed 's/\.//g' | cut -c1-2)
+QEMU_VER_LONG=$(${QEMU_IMG} --version | head -1 | awk '{print $3}')
+QEMU_VER_SHORT=$(echo "${QEMU_VER_LONG//./}" | cut -c1-2)
 if [ "${QEMU_VER_SHORT}" -lt 60 ]; then
     echo "ERROR! QEMU 6.0.0 or newer is required, detected ${QEMU_VER_LONG}."
     exit 1

--- a/quickemu
+++ b/quickemu
@@ -1814,10 +1814,12 @@ readonly DISK_MIN_SIZE=$((197632 * 8))
 readonly VERSION="4.9.5"
 
 # TODO: Make this run the native architecture binary
-QEMU=$(command -v qemu-system-x86_64)
+ARCH_VM="x86_64"
+ARCH_HOST=$(uname -m)
+QEMU=$(command -v qemu-system-${ARCH_VM})
 QEMU_IMG=$(command -v qemu-img)
 if [ ! -x "${QEMU}" ] || [ ! -x "${QEMU_IMG}" ]; then
-    echo "ERROR! QEMU not found. Please make sure 'qemu-system-x86_64' and 'qemu-img' are installed."
+    echo "ERROR! QEMU not found. Please make sure 'qemu-system-${ARCH_VM}' and 'qemu-img' are installed."
     exit 1
 fi
 

--- a/quickemu
+++ b/quickemu
@@ -288,7 +288,7 @@ function configure_cpu() {
     if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
         if ! check_cpu_flag vmx; then
             echo "ERROR! Intel VT-x support is required."
-            exit 1
+            #exit 1
         fi
     elif [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
         if ! check_cpu_flag svm; then

--- a/quickemu
+++ b/quickemu
@@ -225,11 +225,15 @@ function get_cpu_info() {
 
     if [ "${OS_KERNEL}" == "Darwin" ]; then
         if [ "^Model name:" == "${INFO_NAME}" ]; then
-            sysctl -n machdep.cpu.brand_string | sed 's/ //g'
+            sysctl -n machdep.cpu.brand_string
         elif [ "Socket" == "${INFO_NAME}" ]; then
             sysctl -n hw.packages
         elif [ "Vendor" == "${INFO_NAME}" ]; then
-            sysctl -n machdep.cpu.vendor | sed 's/ //g'
+            if [ "${ARCH_HOST}" == "arm64" ]; then
+                sysctl -n machdep.cpu.brand_string | cut -d' ' -f1
+            else
+                sysctl -n machdep.cpu.vendor | sed 's/ //g'
+            fi
         else
             echo "ERROR! Could not find macOS translation for ${INFO_NAME}"
             exit 1

--- a/quickemu
+++ b/quickemu
@@ -296,14 +296,13 @@ function configure_cpu() {
     if [ "${OS_KERNEL}" == "Darwin" ]; then
         MANUFACTURER=$(ioreg -l | grep -e Manufacturer | grep -v iMan | cut -d'"' -f4 | sort -u)
         CPU_KVM_UNHALT=""
-        KVM_GUEST_TWEAKS=""
         QEMU_ACCEL="hvf"
         # QEMU for macOS from Homebrew does not support SMM
         SMM="off"
     else
         MANUFACTURER=$(head -1 /sys/class/dmi/id/sys_vendor)
         CPU_KVM_UNHALT=",kvm_pv_unhalt"
-        KVM_GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard "
+        GUEST_TWEAKS+=" -global kvm-pit.lost_tick_policy=discard"
         QEMU_ACCEL="kvm"
     fi
 
@@ -311,7 +310,6 @@ function configure_cpu() {
     if [ "${ARCH_VM}" != "${ARCH_HOST}" ]; then
         CPU_MODEL="qemu64"
         CPU_KVM_UNHALT=""
-        KVM_GUEST_TWEAKS=""
         QEMU_ACCEL="tcg"
     fi
 
@@ -675,7 +673,7 @@ function configure_os_quirks() {
             fi
 
             # Disable S3 support in the VM to prevent macOS suspending during install
-            GUEST_TWEAKS="${KVM_GUEST_TWEAKS}-global ICH9-LPC.disable_s3=1 -device isa-applesmc,osk=$(echo "bheuneqjbexolgurfrjbeqfthneqrqcyrnfrqbagfgrny(p)NccyrPbzchgreVap" | tr 'A-Za-z' 'N-ZA-Mn-za-m')"
+            GUEST_TWEAKS+=" -global ICH9-LPC.disable_s3=1 -device isa-applesmc,osk=$(echo "bheuneqjbexolgurfrjbeqfthneqrqcyrnfrqbagfgrny(p)NccyrPbzchgreVap" | tr 'A-Za-z' 'N-ZA-Mn-za-m')"
 
             # Disable High Precision Timer
             if [ "${QEMU_VER_SHORT}" -ge 70 ]; then
@@ -696,7 +694,7 @@ function configure_os_quirks() {
                     MAC_DISK_DEV="virtio-blk-pci"
                     NET_DEVICE="virtio-net"
                     USB_HOST_PASSTHROUGH_CONTROLLER="nec-usb-xhci"
-                    GUEST_TWEAKS="${GUEST_TWEAKS} -global nec-usb-xhci.msi=off"
+                    GUEST_TWEAKS+=" -global nec-usb-xhci.msi=off"
                     sound_card="${sound_card:-usb-audio}"
                     usb_controller="xhci";;
                 *)
@@ -723,7 +721,7 @@ function configure_os_quirks() {
             fi
             # Disable S3 support in the VM to ensure Windows can boot with SecureBoot enabled
             #  - https://wiki.archlinux.org/title/QEMU#VM_does_not_boot_when_using_a_Secure_Boot_enabled_OVMF
-            GUEST_TWEAKS="${KVM_GUEST_TWEAKS}-global ICH9-LPC.disable_s3=1"
+            GUEST_TWEAKS+=" -global ICH9-LPC.disable_s3=1"
 
             # Disable High Precision Timer
             if [ "${QEMU_VER_SHORT}" -ge 70 ]; then

--- a/quickemu
+++ b/quickemu
@@ -423,27 +423,35 @@ function configure_bios() {
         # OVMF_CODE.secboot.fd is like OVMF_CODE_4M.fd, but will abort if QEMU
         # does not support SMM.
 
+        local SHARE_PATH="/usr/share"
+        if [ ${DARWIN} -eq 1 ]; then
+            # Do not assume brew; quickemu could have been installed via Nix
+            if command -v brew &>/dev/null; then
+                SHARE_PATH="$(brew --prefix qemu)/share/qemu"
+            fi
+        fi
+
         # https://bugzilla.redhat.com/show_bug.cgi?id=1929357#c5
         if [ -n "${EFI_CODE}" ] || [ ! -e "${EFI_CODE}" ]; then
             case ${secureboot} in
                 on) # shellcheck disable=SC2054,SC2140
-                    ovmfs=("/usr/share/OVMF/OVMF_CODE_4M.secboot.fd","/usr/share/OVMF/OVMF_VARS_4M.fd" \
-                        "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd","/usr/share/edk2/ovmf/OVMF_VARS.fd" \
-                        "/usr/share/OVMF/x64/OVMF_CODE.secboot.fd","/usr/share/OVMF/x64/OVMF_VARS.fd" \
-                        "/usr/share/edk2-ovmf/OVMF_CODE.secboot.fd","/usr/share/edk2-ovmf/OVMF_VARS.fd" \
-                        "/usr/share/qemu/ovmf-x86_64-smm-ms-code.bin","/usr/share/qemu/ovmf-x86_64-smm-ms-vars.bin" \
-                        "/usr/share/qemu/edk2-x86_64-secure-code.fd","/usr/share/qemu/edk2-x86_64-code.fd" \
-                        "/usr/share/edk2-ovmf/x64/OVMF_CODE.secboot.fd","/usr/share/edk2-ovmf/x64/OVMF_VARS.fd"
+                    ovmfs=("${SHARE_PATH}/OVMF/OVMF_CODE_4M.secboot.fd","${SHARE_PATH}/OVMF/OVMF_VARS_4M.fd" \
+                        "${SHARE_PATH}/edk2/ovmf/OVMF_CODE.secboot.fd","${SHARE_PATH}/edk2/ovmf/OVMF_VARS.fd" \
+                        "${SHARE_PATH}/OVMF/x64/OVMF_CODE.secboot.fd","${SHARE_PATH}/OVMF/x64/OVMF_VARS.fd" \
+                        "${SHARE_PATH}/edk2-ovmf/OVMF_CODE.secboot.fd","${SHARE_PATH}/edk2-ovmf/OVMF_VARS.fd" \
+                        "${SHARE_PATH}/qemu/ovmf-x86_64-smm-ms-code.bin","${SHARE_PATH}/qemu/ovmf-x86_64-smm-ms-vars.bin" \
+                        "${SHARE_PATH}/qemu/edk2-x86_64-secure-code.fd","${SHARE_PATH}/qemu/edk2-x86_64-code.fd" \
+                        "${SHARE_PATH}/edk2-ovmf/x64/OVMF_CODE.secboot.fd","${SHARE_PATH}/edk2-ovmf/x64/OVMF_VARS.fd"
                     );;
                 *)  # shellcheck disable=SC2054,SC2140
-                    ovmfs=("/usr/share/OVMF/OVMF_CODE_4M.fd","/usr/share/OVMF/OVMF_VARS_4M.fd" \
-                        "/usr/share/edk2/ovmf/OVMF_CODE.fd","/usr/share/edk2/ovmf/OVMF_VARS.fd" \
-                        "/usr/share/OVMF/OVMF_CODE.fd","/usr/share/OVMF/OVMF_VARS.fd" \
-                        "/usr/share/OVMF/x64/OVMF_CODE.fd","/usr/share/OVMF/x64/OVMF_VARS.fd" \
-                        "/usr/share/edk2-ovmf/OVMF_CODE.fd","/usr/share/edk2-ovmf/OVMF_VARS.fd" \
-                        "/usr/share/qemu/ovmf-x86_64-4m-code.bin","/usr/share/qemu/ovmf-x86_64-4m-vars.bin" \
-                        "/usr/share/qemu/edk2-x86_64-code.fd","/usr/share/qemu/edk2-x86_64-code.fd" \
-                        "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd","/usr/share/edk2-ovmf/x64/OVMF_VARS.fd"
+                    ovmfs=("${SHARE_PATH}/OVMF/OVMF_CODE_4M.fd","${SHARE_PATH}/OVMF/OVMF_VARS_4M.fd" \
+                        "${SHARE_PATH}/edk2/ovmf/OVMF_CODE.fd","${SHARE_PATH}/edk2/ovmf/OVMF_VARS.fd" \
+                        "${SHARE_PATH}/OVMF/OVMF_CODE.fd","${SHARE_PATH}/OVMF/OVMF_VARS.fd" \
+                        "${SHARE_PATH}/OVMF/x64/OVMF_CODE.fd","${SHARE_PATH}/OVMF/x64/OVMF_VARS.fd" \
+                        "${SHARE_PATH}/edk2-ovmf/OVMF_CODE.fd","${SHARE_PATH}/edk2-ovmf/OVMF_VARS.fd" \
+                        "${SHARE_PATH}/qemu/ovmf-x86_64-4m-code.bin","${SHARE_PATH}/qemu/ovmf-x86_64-4m-vars.bin" \
+                        "${SHARE_PATH}/qemu/edk2-x86_64-code.fd","${SHARE_PATH}/qemu/edk2-x86_64-code.fd" \
+                        "${SHARE_PATH}/edk2-ovmf/x64/OVMF_CODE.fd","${SHARE_PATH}/edk2-ovmf/x64/OVMF_VARS.fd"
                     );;
             esac
             # Attempt each EFI_CODE file one by one, selecting the corresponding code and vars

--- a/quickemu
+++ b/quickemu
@@ -286,23 +286,39 @@ function configure_cpu() {
     HOST_CPU_SOCKETS=$(get_cpu_info 'Socket')
     HOST_CPU_VENDOR=$(get_cpu_info 'Vendor')
 
-    # Detect if running in a VM
+    CPU_MODEL="host"
+    # Configure appropriately for the host platform
     if [ "${OS_KERNEL}" == "Darwin" ]; then
         MANUFACTURER=$(ioreg -l | grep -e Manufacturer | grep -v iMan | cut -d'"' -f4 | sort -u)
+        # Disable huge pages on macOS to prevent crashes
+        # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
+        CPU_MODEL+=",-pdpe1gb"
+        CPU_KVM_UNHALT=""
+        KVM_GUEST_TWEAKS=""
+        QEMU_ACCEL=",accel=hvf"
+        # QEMU for macOS from Homebrew does not support SMM
+        SMM="off"
     else
         MANUFACTURER=$(head -1 /sys/class/dmi/id/sys_vendor)
+        CPU_KVM_UNHALT=",kvm_pv_unhalt"
+        KVM_GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard "
+        QEMU_ACCEL=",accel=kvm"
     fi
 
+    # If the architecture of the VM is different from the host, disable acceleration
+    if [ "${ARCH_VM}" != "${ARCH_HOST}" ]; then
+        QEMU_ACCEL=""
+        CPU_MODEL="qemu64"
+        CPU_KVM_UNHALT=""
+        KVM_GUEST_TWEAKS=""
+    fi
+
+    # Detect if running in a VM
     case ${MANUFACTURER,,} in
-        qemu) CPU_MODEL="Penryn"
-              HYPERVISOR="${MANUFACTURER,,}";;
-        *)    CPU_MODEL="host"
-              # Disable huge pages
-              # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
-              if [ "${OS_KERNEL}" == "Darwin" ]; then
-                  CPU_MODEL+=",-pdpe1gb"
-              fi
-              HYPERVISOR="";;
+        qemu|virtualbox) CPU_MODEL="qemu64"
+                         QEMU_ACCEL=""
+                         HYPERVISOR="${MANUFACTURER,,}";;
+        *) HYPERVISOR="";;
     esac
 
     if [ -z "${HYPERVISOR}" ]; then
@@ -564,7 +580,7 @@ function configure_os_quirks() {
     # Make any OS specific adjustments
     case ${guest_os} in
         batocera|*bsd|freedos|haiku|linux*|*solaris)
-            CPU="-cpu ${CPU_MODEL}${CPU_KVM}"
+            CPU="-cpu ${CPU_MODEL}"
             if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
                 CPU="${CPU},topoext"
             fi
@@ -589,7 +605,7 @@ function configure_os_quirks() {
             fi
             ;;
         kolibrios|reactos)
-            CPU="-cpu qemu32${CPU_KVM}"
+            CPU="-cpu qemu32"
             if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
                 CPU="${CPU},topoext"
             fi
@@ -616,21 +632,21 @@ function configure_os_quirks() {
             case ${macos_release} in
                 ventura|sonoma)
                     if check_cpu_flag sse4_2 && check_cpu_flag avx2; then
-                        CPU="-cpu Haswell-v4${CPU_KVM},vendor=GenuineIntel,+avx,+avx2,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        CPU="-cpu Haswell-v4,vendor=GenuineIntel,+avx,+avx2,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 and AVX2 support."
                         exit 1
                     fi;;
                 catalina|big-sur|monterey)
                     if check_cpu_flag sse4_2; then
-                        CPU="-cpu Haswell-v4${CPU_KVM},vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        CPU="-cpu Haswell-v4,vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 support."
                         exit 1
                     fi;;
                 *)
                     if check_cpu_flag sse4_1; then
-                        CPU="-cpu Penryn${CPU_KVM},vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.1,vmware-cpuid-freq=on"
+                        CPU="-cpu Penryn,vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.1,vmware-cpuid-freq=on"
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.1 support."
                         exit 1
@@ -685,9 +701,9 @@ function configure_os_quirks() {
             ;;
         windows|windows-server)
             if [ "${QEMU_VER_SHORT}" -gt 60 ]; then
-                CPU="-cpu ${CPU_MODEL}${CPU_KVM},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
+                CPU="-cpu ${CPU_MODEL},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
             else
-                CPU="-cpu ${CPU_MODEL}${CPU_KVM},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies${CPU_KVM_UNHALT},hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
+                CPU="-cpu ${CPU_MODEL},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies${CPU_KVM_UNHALT},hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
             fi
             if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
                 CPU="${CPU},topoext"
@@ -702,9 +718,13 @@ function configure_os_quirks() {
             else
               GUEST_TWEAKS+=" -no-hpet"
             fi
-            SMM="on"
+
+            # SMM is not available on QEMU for macOS via Homebrew
+            if [ "${OS_KERNEL}" == "Linux" ]; then
+                SMM="on"
+            fi
             ;;
-        *) CPU="-cpu ${CPU_MODEL}${CPU_KVM}"
+        *) CPU="-cpu ${CPU_MODEL}"
            NET_DEVICE="rtl8139"
            echo "WARNING! Unrecognised guest OS: ${guest_os}";;
     esac
@@ -1101,17 +1121,12 @@ function vm_boot() {
     echo "#!/usr/bin/env bash" > "${VMDIR}/${VMNAME}.sh"
 
     # Changing process name is not supported on macOS
-    if [ "${OS_KERNEL}" == "Darwin" ]; then
-        if [ -z "${HYPERVISOR}" ]; then
-            # shellcheck disable=SC2054,SC2206,SC2140
-            args+=(-accel hvf)
-        fi
-    else
+    if [ "${OS_KERNEL}" == "Linux" ]; then
         # shellcheck disable=SC2054,SC2206,SC2140
-        args+=(-name ${VMNAME},process=${VMNAME} -enable-kvm)
+        args+=(-name ${VMNAME},process=${VMNAME})
     fi
     # shellcheck disable=SC2054,SC2206,SC2140
-    args+=(-machine ${MACHINE_TYPE},smm=${SMM},vmport=off ${GUEST_TWEAKS}
+    args+=(-machine ${MACHINE_TYPE},smm=${SMM},vmport=off${QEMU_ACCEL} ${GUEST_TWEAKS}
         ${CPU} ${SMP}
         -m ${RAM_VM} ${BALLOON}
         -rtc base=localtime,clock=host,driftfix=slew
@@ -1830,14 +1845,7 @@ if command -v gstat &>/dev/null; then
 fi
 
 OS_KERNEL=$(uname -s)
-CPU_KVM=",kvm=on"
-CPU_KVM_UNHALT=",kvm_pv_unhalt"
-KVM_GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard "
-# Detect macOS and disable KVM
 if [ "${OS_KERNEL}" == "Darwin" ]; then
-    CPU_KVM=""
-    CPU_KVM_UNHALT=""
-    KVM_GUEST_TWEAKS=""
     display="cocoa"
 fi
 

--- a/quickemu
+++ b/quickemu
@@ -297,7 +297,12 @@ function configure_cpu() {
         qemu) CPU_MODEL="Penryn"
               HYPERVISOR="${MANUFACTURER,,}";;
         *)    CPU_MODEL="host"
-              HYPERVISOR="";
+              # Disable huge pages
+              # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
+              if [ "${OS_KERNEL}" == "Darwin" ]; then
+                  CPU_MODEL+=",-pdpe1gb"
+              fi
+              HYPERVISOR="";;
     esac
 
     if [ -z "${HYPERVISOR}" ]; then

--- a/quickemu
+++ b/quickemu
@@ -284,16 +284,32 @@ function configure_cpu() {
     HOST_CPU_SOCKETS=$(get_cpu_info 'Socket')
     HOST_CPU_VENDOR=$(get_cpu_info 'Vendor')
 
-    # A CPU with Intel VT-x / AMD SVM support is required
-    if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
-        if ! check_cpu_flag vmx; then
-            echo "ERROR! Intel VT-x support is required."
-            #exit 1
-        fi
-    elif [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
-        if ! check_cpu_flag svm; then
-            echo "ERROR! AMD SVM support is required."
-            exit 1
+    # Detect if running in a VM
+    if [ ${DARWIN} -eq 1 ]; then
+        MANUFACTURER=$(ioreg -l | grep -e Manufacturer | grep -v iMan | cut -d'"' -f4 | sort -u)
+    else
+        MANUFACTURER=$(head -1 /sys/class/dmi/id/sys_vendor)
+    fi
+
+    case ${MANUFACTURER,,} in
+        qemu) CPU_MODEL="Penryn"
+              IN_VM=0;;
+        *)    CPU_MODEL="host"
+              IN_VM=1;;
+    esac
+
+    if [ ! ${IN_VM} ]; then
+        # A CPU with Intel VT-x / AMD SVM support is required
+        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
+            if ! check_cpu_flag vmx; then
+                echo "ERROR! Intel VT-x support is required."
+                exit 1
+            fi
+        elif [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
+            if ! check_cpu_flag svm; then
+                echo "ERROR! AMD SVM support is required."
+                exit 1
+            fi
         fi
     fi
 
@@ -1077,11 +1093,12 @@ function vm_boot() {
 
     echo "#!/usr/bin/env bash" > "${VMDIR}/${VMNAME}.sh"
 
-
     # Changing process name is not supported on macOS
-    if [ ${DARWIN} -eq 1 ];  then
-        # shellcheck disable=SC2054,SC2206,SC2140
-        args+=(-accel hvf)
+    if [ ${DARWIN} -eq 1 ]; then
+        if [ ! ${IN_VM} ]; then
+            # shellcheck disable=SC2054,SC2206,SC2140
+            args+=(-accel hvf)
+        fi
     else
         # shellcheck disable=SC2054,SC2206,SC2140
         args+=(-name ${VMNAME},process=${VMNAME} -enable-kvm)
@@ -1799,13 +1816,13 @@ if command -v gstat &>/dev/null; then
 fi
 
 DARWIN=0
-CPU_MODEL="host"
 CPU_KVM=",kvm=on"
 CPU_KVM_UNHALT=",kvm_pv_unhalt"
 KVM_GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard "
+
+# Detect macOS and disable KVM
 if [ "$(uname -s)" == "Darwin" ]; then
     DARWIN=1
-    CPU_MODEL="Penryn"
     CPU_KVM=""
     CPU_KVM_UNHALT=""
     KVM_GUEST_TWEAKS=""

--- a/quickemu
+++ b/quickemu
@@ -246,7 +246,9 @@ function get_cpu_info() {
 function check_cpu_flag() {
     local HOST_CPU_FLAG=""
     if [ "${OS_KERNEL}" == "Darwin" ]; then
-        HOST_CPU_FLAG="${1}^^"
+        # Convert the flag to uppercase and replace _ with .
+        HOST_CPU_FLAG="${1^^}"
+        HOST_CPU_FLAG="${HOST_CPU_FLAG//_/.}"
         if sysctl -n machdep.cpu.features | grep -o "${HOST_CPU_FLAG}" > /dev/null; then
             return 0
         else

--- a/quickemu
+++ b/quickemu
@@ -22,7 +22,9 @@ function ignore_msrs_always() {
 
 function ignore_msrs_alert() {
     local ignore_msrs=""
-    if [ -e /sys/module/kvm/parameters/ignore_msrs ]; then
+    if [ ${DARWIN} -eq 1 ]; then
+        return
+    elif [ -e /sys/module/kvm/parameters/ignore_msrs ]; then
         ignore_msrs=$(cat /sys/module/kvm/parameters/ignore_msrs)
         if [ "${ignore_msrs}" == "N" ]; then
             echo " - MSR:      WARNING! Ignoring unhandled Model-Specific Registers is disabled."

--- a/quickemu
+++ b/quickemu
@@ -394,7 +394,7 @@ function configure_cpu() {
 
     SMP="-smp cores=${GUEST_CPU_LOGICAL_CORES},threads=${GUEST_CPU_THREADS},sockets=${HOST_CPU_SOCKETS}"
     echo " - CPU:      ${HOST_CPU_MODEL}"
-    echo " - CPU VM:   ${HOST_CPU_SOCKETS} Socket(s), ${GUEST_CPU_LOGICAL_CORES} Core(s), ${GUEST_CPU_THREADS} Thread(s)"
+    echo " - CPU VM:   ${CPU_MODEL%%,*}, ${HOST_CPU_SOCKETS} Socket(s), ${GUEST_CPU_LOGICAL_CORES} Core(s), ${GUEST_CPU_THREADS} Thread(s)"
 
     if [ "${guest_os}" == "macos" ] || [ "${guest_os}" == "windows" ] || [ "${guest_os}" == "windows-server" ]; then
         # Display MSRs alert if the guest is macOS or windows

--- a/quickemu
+++ b/quickemu
@@ -1060,6 +1060,8 @@ function vm_boot() {
     boot=${boot,,}
     guest_os=${guest_os,,}
     args=()
+    # Set the hostname of the VM
+    NET="user,hostname=${VMNAME}"
 
     configure_cpu
     configure_ram
@@ -1068,8 +1070,6 @@ function vm_boot() {
     configure_storage
     configure_display
     configure_audio
-    # Set the hostname of the VM
-    NET="user,hostname=${VMNAME}"
     configure_ports
     configure_file_sharing
     configure_usb

--- a/quickemu
+++ b/quickemu
@@ -315,9 +315,23 @@ function configure_cpu() {
         done
     fi
 
-    # Account for Hyperthreading/SMT.
-    if [ -e /sys/devices/system/cpu/smt/control ] && [ "${GUEST_CPU_CORES}" -ge 2 ]; then
+    if [ ${DARWIN} -eq 1 ]; then
+        # Get the number of physical cores
+        physicalcpu=$(sysctl -n hw.physicalcpu)
+        # Get the number of logical processors
+        logicalcpu=$(sysctl -n hw.logicalcpu)
+        # Check if Hyper-Threading is enabled
+        if [ "${logicalcpu}" -gt "${physicalcpu}" ]; then
+            HOST_CPU_SMT="on"
+        else
+            HOST_CPU_SMT="off"
+        fi
+    elif [ -e /sys/devices/system/cpu/smt/control ]; then
         HOST_CPU_SMT=$(cat /sys/devices/system/cpu/smt/control)
+    fi
+
+    # Account for Hyperthreading/SMT.
+    if [ "${GUEST_CPU_CORES}" -ge 2 ]; then
         case ${HOST_CPU_SMT} in
             on) GUEST_CPU_THREADS=2
                 GUEST_CPU_LOGICAL_CORES=$(( GUEST_CPU_CORES / GUEST_CPU_THREADS ));;

--- a/quickemu
+++ b/quickemu
@@ -1109,25 +1109,28 @@ function vm_boot() {
     fi
 
     # shellcheck disable=SC2054
-    args+=(-device virtio-rng-pci,rng=rng0
-        -object rng-random,id=rng0,filename=/dev/urandom
-        -device "${USB_HOST_PASSTHROUGH_CONTROLLER}",id=spicepass
-        -chardev spicevmc,id=usbredirchardev1,name=usbredir
-        -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1
-        -chardev spicevmc,id=usbredirchardev2,name=usbredir
-        -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2
-        -chardev spicevmc,id=usbredirchardev3,name=usbredir
-        -device usb-redir,chardev=usbredirchardev3,id=usbredirdev3
-        -device pci-ohci,id=smartpass
-        -device usb-ccid
-    )
+    args+=(-device virtio-rng-pci,rng=rng0 -object rng-random,id=rng0,filename=/dev/urandom)
 
-    if ${QEMU} -device help | grep -q smartcard; then
+    # macOS doesn't support SPICE
+    if [ ${DARWIN} -eq 0 ]; then
         # shellcheck disable=SC2054
-        args+=(-chardev spicevmc,id=ccid,name=smartcard
-               -device ccid-card-passthru,chardev=ccid)
-    else
-        echo " - WARNING!  ${QEMU} was not compiled with support for smartcard devices"
+        args+=(-device "${USB_HOST_PASSTHROUGH_CONTROLLER}",id=spicepass
+            -chardev spicevmc,id=usbredirchardev1,name=usbredir
+            -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1
+            -chardev spicevmc,id=usbredirchardev2,name=usbredir
+            -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2
+            -chardev spicevmc,id=usbredirchardev3,name=usbredir
+            -device usb-redir,chardev=usbredirchardev3,id=usbredirdev3
+            -device pci-ohci,id=smartpass
+            -device usb-ccid)
+
+        if ${QEMU} -device help | grep -q smartcard; then
+            # shellcheck disable=SC2054
+            args+=(-chardev spicevmc,id=ccid,name=smartcard
+                  -device ccid-card-passthru,chardev=ccid)
+        else
+            echo " - WARNING!  ${QEMU} was not compiled with support for smartcard devices"
+        fi
     fi
 
     # setup usb-controller

--- a/quickemu
+++ b/quickemu
@@ -541,7 +541,7 @@ function configure_os_quirks() {
     # Make any OS specific adjustments
     case ${guest_os} in
         batocera|*bsd|freedos|haiku|linux*|*solaris)
-            CPU="-cpu host${CPU_KVM}"
+            CPU="-cpu ${CPU_MODEL}${CPU_KVM}"
             if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
                 CPU="${CPU},topoext"
             fi
@@ -662,9 +662,9 @@ function configure_os_quirks() {
             ;;
         windows|windows-server)
             if [ "${QEMU_VER_SHORT}" -gt 60 ]; then
-                CPU="-cpu host${CPU_KVM},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
+                CPU="-cpu ${CPU_MODEL}${CPU_KVM},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_passthrough"
             else
-                CPU="-cpu host${CPU_KVM},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies${CPU_KVM_UNHALT},hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
+                CPU="-cpu ${CPU_MODEL}${CPU_KVM},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies${CPU_KVM_UNHALT},hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
             fi
             if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
                 CPU="${CPU},topoext"
@@ -681,7 +681,7 @@ function configure_os_quirks() {
             fi
             SMM="on"
             ;;
-        *) CPU="-cpu host${CPU_KVM}"
+        *) CPU="-cpu ${CPU_MODEL}${CPU_KVM}"
            NET_DEVICE="rtl8139"
            echo "WARNING! Unrecognised guest OS: ${guest_os}";;
     esac
@@ -1799,11 +1799,13 @@ if command -v gstat &>/dev/null; then
 fi
 
 DARWIN=0
+CPU_MODEL="host"
 CPU_KVM=",kvm=on"
 CPU_KVM_UNHALT=",kvm_pv_unhalt"
 KVM_GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard "
 if [ "$(uname -s)" == "Darwin" ]; then
     DARWIN=1
+    CPU_MODEL="Penryn"
     CPU_KVM=""
     CPU_KVM_UNHALT=""
     KVM_GUEST_TWEAKS=""

--- a/quickemu
+++ b/quickemu
@@ -290,9 +290,6 @@ function configure_cpu() {
     # Configure appropriately for the host platform
     if [ "${OS_KERNEL}" == "Darwin" ]; then
         MANUFACTURER=$(ioreg -l | grep -e Manufacturer | grep -v iMan | cut -d'"' -f4 | sort -u)
-        # Disable huge pages on macOS to prevent crashes
-        # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
-        CPU_MODEL+=",-pdpe1gb"
         CPU_KVM_UNHALT=""
         KVM_GUEST_TWEAKS=""
         QEMU_ACCEL=",accel=hvf"
@@ -623,43 +620,54 @@ function configure_os_quirks() {
             # A CPU with SSE4.1 support is required for >= macOS Sierra
             # A CPU with SSE4.2 support is required for >= macOS Catalina
             # A CPU with AVX2 support is required for >= macOS Ventura
-            if ! check_cpu_flag fma && ! check_cpu_flag invtsc; then
-                echo "ERROR! macOS requires a CPU with FMA and INV TSC support."
-                exit 1
-            fi
-
-            # TODO: Investigate if hosts with an Intel CPU can just use `-cpu host`
             case ${macos_release} in
+                # Disable huge pages (,-pdpe1gb) on macOS to prevent crashes
+                # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
                 ventura|sonoma)
                     if check_cpu_flag sse4_2 && check_cpu_flag avx2; then
-                        CPU="-cpu Haswell-v4,vendor=GenuineIntel,+avx,+avx2,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
+                            CPU="-cpu host,-pdpe1gb"
+                        else
+                            CPU="-cpu Haswell-v4,vendor=GenuineIntel,-pdpe1gb,+avx,+avx2,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        fi
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 and AVX2 support."
+                        echo "       Try macOS Monterey or Big Sur."
                         exit 1
                     fi;;
                 catalina|big-sur|monterey)
                     if check_cpu_flag sse4_2; then
-                        CPU="-cpu Haswell-v4,vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
+                            CPU="-cpu host,-pdpe1gb"
+                        else
+                            CPU="-cpu Haswell-v4,vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        fi
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 support."
                         exit 1
                     fi;;
                 *)
                     if check_cpu_flag sse4_1; then
-                        CPU="-cpu Penryn,vendor=GenuineIntel,+avx,+sse,+sse2,+sse3,+sse4.1,vmware-cpuid-freq=on"
+                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
+                            CPU="-cpu host,-pdpe1gb"
+                        else
+                            CPU="-cpu Penryn,vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,+sse4.1,vmware-cpuid-freq=on"
+                        fi
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.1 support."
                         exit 1
                     fi;;
             esac
 
-            for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist ept_1gb f16c fma invtsc \
-                        mmx movbe mpx pdpe1gb popcnt smep vaes vbmi2 vpclmulqdq \
-                        xgetbv1 xsave xsaveopt; do
-                if check_cpu_flag "${FLAG}"; then
-                    CPU+=",+${FLAG}"
-                fi
-            done
+            if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ]; then
+              for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist ept_1gb f16c fma invtsc \
+                          mmx movbe mpx pdpe1gb popcnt smep vaes vbmi2 vpclmulqdq \
+                          xgetbv1 xsave xsaveopt; do
+                  if check_cpu_flag "${FLAG}"; then
+                      CPU+=",+${FLAG}"
+                  fi
+              done
+            fi
 
             # Disable S3 support in the VM to prevent macOS suspending during install
             GUEST_TWEAKS="${KVM_GUEST_TWEAKS}-global ICH9-LPC.disable_s3=1 -device isa-applesmc,osk=$(echo "bheuneqjbexolgurfrjbeqfthneqrqcyrnfrqbagfgrny(p)NccyrPbzchgreVap" | tr 'A-Za-z' 'N-ZA-Mn-za-m')"

--- a/quickemu
+++ b/quickemu
@@ -453,11 +453,12 @@ function configure_bios() {
         if [ ${DARWIN} -eq 1 ]; then
             # Do not assume brew; quickemu could have been installed via Nix
             if command -v brew &>/dev/null; then
-                SHARE_PATH="$(brew --prefix qemu)/share/qemu"
+                SHARE_PATH="$(brew --prefix qemu)/share"
             fi
         fi
 
         # https://bugzilla.redhat.com/show_bug.cgi?id=1929357#c5
+        # TODO: Check if macOS should use 'edk2-i386-vars.fd'
         if [ -n "${EFI_CODE}" ] || [ ! -e "${EFI_CODE}" ]; then
             case ${secureboot} in
                 on) # shellcheck disable=SC2054,SC2140

--- a/quickemu
+++ b/quickemu
@@ -630,7 +630,7 @@ function configure_os_quirks() {
                 # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
                 ventura|sonoma)
                     if check_cpu_flag sse4_2 && check_cpu_flag avx2; then
-                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
+                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
                             CPU="-cpu host,-pdpe1gb"
                         else
                             CPU="-cpu Haswell-v4,vendor=GenuineIntel,-pdpe1gb,+avx,+avx2,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
@@ -642,7 +642,7 @@ function configure_os_quirks() {
                     fi;;
                 catalina|big-sur|monterey)
                     if check_cpu_flag sse4_2; then
-                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
+                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
                             CPU="-cpu host,-pdpe1gb"
                         else
                             CPU="-cpu Haswell-v4,vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
@@ -653,7 +653,7 @@ function configure_os_quirks() {
                     fi;;
                 *)
                     if check_cpu_flag sse4_1; then
-                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
+                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
                             CPU="-cpu host,-pdpe1gb"
                         else
                             CPU="-cpu Penryn,vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,+sse4.1,vmware-cpuid-freq=on"
@@ -664,7 +664,7 @@ function configure_os_quirks() {
                     fi;;
             esac
 
-            if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ]; then
+            if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
               for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist ept_1gb f16c fma invtsc \
                           mmx movbe mpx pdpe1gb popcnt smep vaes vbmi2 vpclmulqdq \
                           xgetbv1 xsave xsaveopt; do

--- a/quickemu
+++ b/quickemu
@@ -1831,6 +1831,7 @@ if [ "$(uname -s)" == "Darwin" ]; then
     CPU_KVM=""
     CPU_KVM_UNHALT=""
     KVM_GUEST_TWEAKS=""
+    display="cocoa"
 fi
 
 QEMU_VER_LONG=$(${QEMU} -version | head -n1 | cut -d' ' -f4 | cut -d'(' -f1)

--- a/quickemu
+++ b/quickemu
@@ -1043,7 +1043,7 @@ function vm_boot() {
     KERNEL_NAME="Unknown"
     KERNEL_NODE=""
     KERNEL_VER="?"
-    local HOST_OS="Unknown OS"
+    OS_RELEASE="Unknown OS"
     MACHINE_TYPE="${MACHINE_TYPE:-q35}"
     MAC_BOOTLOADER=""
     MAC_MISSING=""
@@ -1063,14 +1063,14 @@ function vm_boot() {
     if [ ${DARWIN} -eq 1 ]; then
         # Get macOS product name and version using swvers
         if [ -x "$(command -v sw_vers)" ]; then
-            HOST_OS="$(sw_vers --productName) $(sw_vers --productVersion)"
+            OS_RELEASE="$(sw_vers --productName) $(sw_vers --productVersion)"
         fi
     elif [ -e /etc/os-release ]; then
-        HOST_OS=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
+        OS_RELEASE=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
     fi
 
     echo "Quickemu ${VERSION} using ${QEMU} v${QEMU_VER_LONG}"
-    echo " - Host:     ${HOST_OS} running ${KERNEL_NAME} ${KERNEL_VER} ${KERNEL_NODE}"
+    echo " - Host:     ${OS_RELEASE} running ${KERNEL_NAME} ${KERNEL_VER} ${KERNEL_NODE}"
 
     # Force to lowercase.
     boot=${boot,,}

--- a/quickemu
+++ b/quickemu
@@ -581,10 +581,6 @@ function configure_os_quirks() {
     case ${guest_os} in
         batocera|*bsd|freedos|haiku|linux*|*solaris)
             CPU="-cpu ${CPU_MODEL}"
-            if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
-                CPU="${CPU},topoext"
-            fi
-
             if [ "${guest_os}" == "freebsd" ] || [ "${guest_os}" == "ghostbsd" ]; then
                 mouse="usb"
             elif [ "${guest_os}" == "batocera" ] || [ "${guest_os}" == "freedos" ] || [ "${guest_os}" == "haiku" ]; then
@@ -606,9 +602,6 @@ function configure_os_quirks() {
             ;;
         kolibrios|reactos)
             CPU="-cpu qemu32"
-            if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
-                CPU="${CPU},topoext"
-            fi
             MACHINE_TYPE="pc"
             case ${guest_os} in
                 kolibrios) NET_DEVICE="rtl8139";;
@@ -716,9 +709,6 @@ function configure_os_quirks() {
             else
                 CPU="-cpu ${CPU_MODEL},+hypervisor,+invtsc,l3-cache=on,migratable=no,hv_frequencies${CPU_KVM_UNHALT},hv_reenlightenment,hv_relaxed,hv_spinlocks=8191,hv_stimer,hv_synic,hv_time,hv_vapic,hv_vendor_id=1234567890ab,hv_vpindex"
             fi
-            if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
-                CPU="${CPU},topoext"
-            fi
             # Disable S3 support in the VM to ensure Windows can boot with SecureBoot enabled
             #  - https://wiki.archlinux.org/title/QEMU#VM_does_not_boot_when_using_a_Secure_Boot_enabled_OVMF
             GUEST_TWEAKS+=" -global ICH9-LPC.disable_s3=1"
@@ -739,6 +729,10 @@ function configure_os_quirks() {
            NET_DEVICE="rtl8139"
            echo "WARNING! Unrecognised guest OS: ${guest_os}";;
     esac
+
+    if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ] && [ "${guest_os}" != "macos" ]; then
+      CPU+=",topoext"
+    fi
 }
 
 function configure_storage() {

--- a/quickemu
+++ b/quickemu
@@ -379,7 +379,7 @@ function configure_cpu() {
     fi
 }
 
-configure_ram() {
+function configure_ram() {
     RAM_VM="2G"
     if [ -z "${ram}" ]; then
         local RAM_HOST=""

--- a/quickemu
+++ b/quickemu
@@ -247,12 +247,45 @@ function get_cpu_info() {
     fi
 }
 
+# returns an enabled or disable CPU flag for QEMU, based on the host CPU
+# capabilities, or nothing if the flag is not supported
+# converts the flags appropriately from macOS and Linux to QEMU
+function configure_cpu_flag() {
+    local HOST_CPU_FLAG="${1}"
+    # Convert the flag to lowercase for QEMU
+    local QEMU_CPU_FLAG=${HOST_CPU_FLAG,,}
+    if check_cpu_flag "${HOST_CPU_FLAG}"; then
+        # Replace _ with - to make it compatible with QEMU
+        QEMU_CPU_FLAG="${HOST_CPU_FLAG//_/-}"
+        QEMU_CPU_FLAG="${QEMU_CPU_FLAG//4_/4\.}"
+        # macOS uses different flag names
+        if [ "${OS_KERNEL}" == "Darwin" ]; then
+            case "${HOST_CPU_FLAG}" in
+                avx) QEMU_CPU_FLAG="AVX1.0";;
+            esac
+        fi
+        echo ",+${QEMU_CPU_FLAG}"
+    else
+        # Fully disable any QEMU flags that are not supported by the host CPU
+        if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ]; then
+            case ${HOST_CPU_FLAG} in
+                pcid) echo ",-${QEMU_CPU_FLAG}";;
+            esac
+        fi
+    fi
+}
+
+# checks if a CPU flag is supported by the host CPU on Linux and macOS
 function check_cpu_flag() {
     local HOST_CPU_FLAG=""
     if [ "${OS_KERNEL}" == "Darwin" ]; then
-        # Convert the flag to uppercase and replace _ with .
+        # Make the macOS compatible: uppercase, replace _ with . and replace X2APIC with x2APIC
         HOST_CPU_FLAG="${1^^}"
         HOST_CPU_FLAG="${HOST_CPU_FLAG//_/.}"
+        HOST_CPU_FLAG="${HOST_CPU_FLAG//X2APIC/x2APIC}"
+        if [ "${HOST_CPU_FLAG}" == "AVX" ]; then
+            HOST_CPU_FLAG="AVX1.0"
+        fi
         if sysctl -n machdep.cpu.features | grep -o "${HOST_CPU_FLAG}" > /dev/null; then
             return 0
         else
@@ -371,8 +404,8 @@ function configure_cpu() {
                 CPU_MODEL="host"
                 CPU="-cpu ${CPU_MODEL},-pdpe1gb,+hypervisor"
             else
-                CPU_MODEL="Haswell-v4"
-                CPU="-cpu ${CPU_MODEL},vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,vmware-cpuid-freq=on"
+                CPU_MODEL="Haswell-v2"
+                CPU="-cpu ${CPU_MODEL},vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+ssse3,vmware-cpuid-freq=on"
             fi
             # A CPU with fma is required for Metal support
             # A CPU with invtsc is required for macOS to boot
@@ -411,12 +444,12 @@ function configure_cpu() {
             esac
 
             if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-                for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist f16c fma invtsc \
-                          mmx movbe mpx popcnt smep vaes vbmi2 vpclmulqdq \
-                          xgetbv1 xsave xsaveopt; do
-                    if check_cpu_flag "${FLAG}"; then
-                        CPU+=",+${FLAG}"
-                    fi
+                for FLAG in abm adx aes amd-ssbd apic arat bmi1 bmi2 clflush cmov cx8 cx16 de \
+                            eist erms f16c fma fp87 fsgsbase fxsr invpcid invtsc lahf_lm lm \
+                            mca mce mmx movbe mpx msr mtrr nx pae pat pcid pge pse popcnt pse36 \
+                            rdrand rdtscp sep smep syscall tsc tsc_adjust vaes vbmi2 vmx vpclmulqdq \
+                            x2apic xgetbv1 xsave xsaveopt; do
+                    CPU+=$(configure_cpu_flag "${FLAG}")
                 done
             fi
 

--- a/quickemu
+++ b/quickemu
@@ -1645,6 +1645,10 @@ function tpm_param_check() {
 }
 
 function viewer_param_check() {
+    if [ ${DARWIN} -eq 1 ]; then
+        return
+    fi
+
     if [ "${viewer}" != "none" ] && [ "${viewer}" != "spicy" ] && [ "${viewer}" != "remote-viewer" ]; then
         echo "ERROR! Requested viewer '${viewer}' is not recognised."
         exit 1

--- a/quickemu
+++ b/quickemu
@@ -1063,7 +1063,7 @@ function vm_boot() {
     if [ "${OS_KERNEL}" == "Darwin" ]; then
         # Get macOS product name and version using swvers
         if [ -x "$(command -v sw_vers)" ]; then
-            OS_RELEASE="$(sw_vers --productName) $(sw_vers --productVersion)"
+            OS_RELEASE="$(sw_vers -productName) $(sw_vers -productVersion)"
         fi
     elif [ -e /etc/os-release ]; then
         OS_RELEASE=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)

--- a/quickemu
+++ b/quickemu
@@ -205,6 +205,18 @@ function configure_usb() {
     fi
 }
 
+# get the number of processing units
+function get_nproc() {
+    if command -v nproc &>/dev/null; then
+        nproc
+    elif command -v sysctl &>/dev/null; then
+        sysctl -n hw.ncpu
+    else
+        echo "ERROR! Unable to determine the number of processing units."
+        exit 1
+    fi
+}
+
 # macOS and Linux compatible get_cpu_info function
 function get_cpu_info() {
     local INFO_NAME="${1}"
@@ -255,7 +267,7 @@ function efi_vars() {
 }
 
 function configure_cpu() {
-    HOST_CPU_CORES=$(nproc)
+    HOST_CPU_CORES=$(get_nproc)
     HOST_CPU_MODEL=$(get_cpu_info '^Model name:')
     HOST_CPU_SOCKETS=$(get_cpu_info 'Socket')
     HOST_CPU_VENDOR=$(get_cpu_info 'Vendor')

--- a/quickemu
+++ b/quickemu
@@ -293,12 +293,12 @@ function configure_cpu() {
 
     case ${MANUFACTURER,,} in
         qemu) CPU_MODEL="Penryn"
-              IN_VM=0;;
+              HYPERVISOR="${MANUFACTURER,,}";;
         *)    CPU_MODEL="host"
-              IN_VM=1;;
+              HYPERVISOR="";
     esac
 
-    if [ ! ${IN_VM} ]; then
+    if [ -z "${HYPERVISOR}" ]; then
         # A CPU with Intel VT-x / AMD SVM support is required
         if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
             if ! check_cpu_flag vmx; then
@@ -1095,7 +1095,7 @@ function vm_boot() {
 
     # Changing process name is not supported on macOS
     if [ ${DARWIN} -eq 1 ]; then
-        if [ ! ${IN_VM} ]; then
+        if [ -z "${HYPERVISOR}" ]; then
             # shellcheck disable=SC2054,SC2206,SC2140
             args+=(-accel hvf)
         fi

--- a/quickemu
+++ b/quickemu
@@ -772,6 +772,7 @@ function configure_display() {
     # Setup the appropriate audio device based on the display output
     # https://www.kraxel.org/blog/2020/01/qemu-sound-audiodev/
     case ${display} in
+        cocoa) AUDIO_DEV="coreaudio,id=audio0";;
         none|spice|spice-app) AUDIO_DEV="spice,id=audio0";;
         *) AUDIO_DEV="pa,id=audio0";;
     esac

--- a/quickemu
+++ b/quickemu
@@ -22,7 +22,7 @@ function ignore_msrs_always() {
 
 function ignore_msrs_alert() {
     local ignore_msrs=""
-    if [ ${DARWIN} -eq 1 ]; then
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
         return
     elif [ -e /sys/module/kvm/parameters/ignore_msrs ]; then
         ignore_msrs=$(cat /sys/module/kvm/parameters/ignore_msrs)
@@ -223,7 +223,7 @@ function get_nproc() {
 function get_cpu_info() {
     local INFO_NAME="${1}"
 
-    if [ ${DARWIN} -eq 1 ]; then
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
         if [ "^Model name:" == "${INFO_NAME}" ]; then
             sysctl -n machdep.cpu.brand_string | sed 's/ //g'
         elif [ "Socket" == "${INFO_NAME}" ]; then
@@ -245,7 +245,7 @@ function get_cpu_info() {
 
 function check_cpu_flag() {
     local HOST_CPU_FLAG=""
-    if [ ${DARWIN} -eq 1 ]; then
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
         HOST_CPU_FLAG="${1}^^"
         if sysctl -n machdep.cpu.features | grep -o "${HOST_CPU_FLAG}" > /dev/null; then
             return 0
@@ -285,7 +285,7 @@ function configure_cpu() {
     HOST_CPU_VENDOR=$(get_cpu_info 'Vendor')
 
     # Detect if running in a VM
-    if [ ${DARWIN} -eq 1 ]; then
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
         MANUFACTURER=$(ioreg -l | grep -e Manufacturer | grep -v iMan | cut -d'"' -f4 | sort -u)
     else
         MANUFACTURER=$(head -1 /sys/class/dmi/id/sys_vendor)
@@ -341,7 +341,7 @@ function configure_cpu() {
         done
     fi
 
-    if [ ${DARWIN} -eq 1 ]; then
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
         # Get the number of physical cores
         physicalcpu=$(sysctl -n hw.physicalcpu)
         # Get the number of logical processors
@@ -383,7 +383,7 @@ function configure_ram() {
     RAM_VM="2G"
     if [ -z "${ram}" ]; then
         local RAM_HOST=""
-        if [ ${DARWIN} -eq 1 ]; then
+        if [ "${OS_KERNEL}" == "Darwin" ]; then
             RAM_HOST=$(($(sysctl -n hw.memsize) / (1048576*1024)))
         else
             # Determine the number of gigabytes of RAM in the host by extracting the first numerical value from the output.
@@ -466,7 +466,7 @@ function configure_bios() {
         # does not support SMM.
 
         local SHARE_PATH="/usr/share"
-        if [ ${DARWIN} -eq 1 ]; then
+        if [ "${OS_KERNEL}" == "Darwin" ]; then
             # Do not assume brew; quickemu could have been installed via Nix
             if command -v brew &>/dev/null; then
                 SHARE_PATH="$(brew --prefix qemu)/share"
@@ -1060,7 +1060,7 @@ function vm_boot() {
     KERNEL_NODE="$(uname -n | cut -d'.' -f 1)"
     KERNEL_VER="$(uname -r)"
 
-    if [ ${DARWIN} -eq 1 ]; then
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
         # Get macOS product name and version using swvers
         if [ -x "$(command -v sw_vers)" ]; then
             OS_RELEASE="$(sw_vers --productName) $(sw_vers --productVersion)"
@@ -1094,7 +1094,7 @@ function vm_boot() {
     echo "#!/usr/bin/env bash" > "${VMDIR}/${VMNAME}.sh"
 
     # Changing process name is not supported on macOS
-    if [ ${DARWIN} -eq 1 ]; then
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
         if [ -z "${HYPERVISOR}" ]; then
             # shellcheck disable=SC2054,SC2206,SC2140
             args+=(-accel hvf)
@@ -1129,7 +1129,7 @@ function vm_boot() {
     args+=(-device virtio-rng-pci,rng=rng0 -object rng-random,id=rng0,filename=/dev/urandom)
 
     # macOS doesn't support SPICE
-    if [ ${DARWIN} -eq 0 ]; then
+    if [ "${OS_KERNEL}" == "Linux" ]; then
         # shellcheck disable=SC2054
         args+=(-device "${USB_HOST_PASSTHROUGH_CONTROLLER}",id=spicepass
             -chardev spicevmc,id=usbredirchardev1,name=usbredir
@@ -1186,7 +1186,7 @@ function vm_boot() {
     fi
 
     # Braille requires SDL, so disable for macOS
-    if [ -n "${BRAILLE}" ] && [ ${DARWIN} -eq 0 ]; then
+    if [ -n "${BRAILLE}" ] && [ "${OS_KERNEL}" == "Linux" ]; then
         if ${QEMU} -chardev help | grep -q braille; then
             # shellcheck disable=SC2054
             #args+=(-chardev braille,id=brltty
@@ -1558,7 +1558,7 @@ function display_param_check() {
         display="sdl"
     fi
 
-    if [ ${DARWIN} -eq 1 ]; then
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
         if [ "${display}" != "cocoa" ]; then
           echo "WARNING! Requested output '${display}' but only 'cocoa' is avalible on macOS."
           echo "         Setting display to 'cocoa'."
@@ -1645,7 +1645,7 @@ function tpm_param_check() {
 }
 
 function viewer_param_check() {
-    if [ ${DARWIN} -eq 1 ]; then
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
         return
     fi
 
@@ -1820,14 +1820,12 @@ if command -v gstat &>/dev/null; then
     STAT="gstat"
 fi
 
-DARWIN=0
+OS_KERNEL=$(uname -s)
 CPU_KVM=",kvm=on"
 CPU_KVM_UNHALT=",kvm_pv_unhalt"
 KVM_GUEST_TWEAKS="-global kvm-pit.lost_tick_policy=discard "
-
 # Detect macOS and disable KVM
-if [ "$(uname -s)" == "Darwin" ]; then
-    DARWIN=1
+if [ "${OS_KERNEL}" == "Darwin" ]; then
     CPU_KVM=""
     CPU_KVM_UNHALT=""
     KVM_GUEST_TWEAKS=""

--- a/quickemu
+++ b/quickemu
@@ -610,21 +610,24 @@ function configure_os_quirks() {
             esac
             ;;
         macos)
-            # quickget current list: mojave catalina big-sur monterey ventura sonoma
+            # If the host has an Intel CPU, passes the host CPU model features, model, stepping, exactly to the guest.
+            # Disable huge pages (,-pdpe1gb) on macOS to prevent crashes
+            # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
+            if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ] && [ -n "${HYPERVISOR}" ]; then
+                CPU_MODEL="host"
+                CPU="-cpu ${CPU_MODEL},-pdpe1gb,+hypervisor"
+            else
+                CPU_MODEL="Haswell-v4"
+                CPU="-cpu ${CPU_MODEL},vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,vmware-cpuid-freq=on"
+            fi
             # A CPU with fma is required for Metal support
             # A CPU with invtsc is required for macOS to boot
-            # A CPU with SSE4.1 support is required for >= macOS Sierra
-            # A CPU with SSE4.2 support is required for >= macOS Catalina
-            # A CPU with AVX2 support is required for >= macOS Ventura
             case ${macos_release} in
-                # Disable huge pages (,-pdpe1gb) on macOS to prevent crashes
-                # - https://stackoverflow.com/questions/60231203/qemu-qcow2-mmu-gva-to-gpa-crash-in-mac-os-x
                 ventura|sonoma)
+                    # A CPU with AVX2 support is required for >= macOS Ventura
                     if check_cpu_flag sse4_2 && check_cpu_flag avx2; then
-                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-                            CPU="-cpu host,-pdpe1gb"
-                        else
-                            CPU="-cpu Haswell-v4,vendor=GenuineIntel,-pdpe1gb,+avx,+avx2,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
+                            CPU+=",+avx2,+sse4.2"
                         fi
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 and AVX2 support."
@@ -632,22 +635,20 @@ function configure_os_quirks() {
                         exit 1
                     fi;;
                 catalina|big-sur|monterey)
+                    # A CPU with SSE4.2 support is required for >= macOS Catalina
                     if check_cpu_flag sse4_2; then
-                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-                            CPU="-cpu host,-pdpe1gb"
-                        else
-                            CPU="-cpu Haswell-v4,vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,+sse4.2,vmware-cpuid-freq=on"
+                        if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
+                            CPU+=",+sse4.2"
                         fi
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.2 support."
                         exit 1
                     fi;;
                 *)
+                    # A CPU with SSE4.1 support is required for >= macOS Sierra
                     if check_cpu_flag sse4_1; then
-                        if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-                            CPU="-cpu host,-pdpe1gb"
-                        else
-                            CPU="-cpu Penryn,vendor=GenuineIntel,-pdpe1gb,+avx,+sse,+sse2,+sse3,+sse4.1,vmware-cpuid-freq=on"
+                        if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
+                            CPU+=",+sse4.1"
                         fi
                     else
                         echo "ERROR! macOS ${macos_release} requires a CPU with SSE 4.1 support."
@@ -656,13 +657,13 @@ function configure_os_quirks() {
             esac
 
             if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
-              for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist f16c fma invtsc \
-                          mmx movbe mpx pdpe1gb popcnt smep vaes vbmi2 vpclmulqdq \
+                for FLAG in abm adx aes amd-ssbd bmi1 bmi2 cx8 eist f16c fma invtsc \
+                          mmx movbe mpx popcnt smep vaes vbmi2 vpclmulqdq \
                           xgetbv1 xsave xsaveopt; do
-                  if check_cpu_flag "${FLAG}"; then
-                      CPU+=",+${FLAG}"
-                  fi
-              done
+                    if check_cpu_flag "${FLAG}"; then
+                        CPU+=",+${FLAG}"
+                    fi
+                done
             fi
 
             # Disable S3 support in the VM to prevent macOS suspending during install

--- a/quickemu
+++ b/quickemu
@@ -1804,8 +1804,8 @@ readonly VERSION="4.9.5"
 # TODO: Make this run the native architecture binary
 QEMU=$(command -v qemu-system-x86_64)
 QEMU_IMG=$(command -v qemu-img)
-if [ ! -e "${QEMU}" ] || [ ! -e "${QEMU_IMG}" ]; then
-    echo "ERROR! QEMU not found. Please make install qemu-system-x86_64 and qemu-img"
+if [ ! -x "${QEMU}" ] || [ ! -x "${QEMU_IMG}" ]; then
+    echo "ERROR! QEMU not found. Please make sure 'qemu-system-x86_64' and 'qemu-img' are installed."
     exit 1
 fi
 

--- a/quickemu
+++ b/quickemu
@@ -1077,12 +1077,21 @@ function vm_boot() {
 
     echo "#!/usr/bin/env bash" > "${VMDIR}/${VMNAME}.sh"
 
+
+    # Changing process name is not supported on macOS
+    if [ ${DARWIN} -eq 1 ];  then
+        # shellcheck disable=SC2054,SC2206,SC2140
+        args+=(-accel hvf)
+    else
+        # shellcheck disable=SC2054,SC2206,SC2140
+        args+=(-name ${VMNAME},process=${VMNAME} -enable-kvm)
+    fi
     # shellcheck disable=SC2054,SC2206,SC2140
-    args+=(-name ${VMNAME},process=${VMNAME} -pidfile "${VMDIR}/${VMNAME}.pid"
-        -enable-kvm -machine ${MACHINE_TYPE},smm=${SMM},vmport=off ${GUEST_TWEAKS}
+    args+=(-machine ${MACHINE_TYPE},smm=${SMM},vmport=off ${GUEST_TWEAKS}
         ${CPU} ${SMP}
         -m ${RAM_VM} ${BALLOON}
-        -rtc base=localtime,clock=host,driftfix=slew)
+        -rtc base=localtime,clock=host,driftfix=slew
+        -pidfile "${VMDIR}/${VMNAME}.pid")
 
     # shellcheck disable=SC2206
     args+=(${VIDEO} -display ${DISPLAY_RENDER})

--- a/quickget
+++ b/quickget
@@ -3393,6 +3393,12 @@ if [ ! -e "${CURL}" ]; then
 fi
 CURL_VERSION=$("${CURL}" --version | head -1 | cut -d' ' -f2)
 
+QEMU_IMG=$(command -v qemu-img)
+if [ ! -x "${QEMU_IMG}" ]; then
+    echo "ERROR! qemu-img not found. Please make sure qemu-img is installed."
+    exit 1
+fi
+
 #TODO: Deprecate `list`, `list_csv`, and `list_json` in favor of `--list`, `--list-csv`, and `--list-json`
 case "${1}" in
     --download|-download)

--- a/quickget
+++ b/quickget
@@ -3387,7 +3387,7 @@ fi
 I18NS=()
 OPERATION=""
 CURL=$(command -v curl)
-if [ ! -e "${CURL}" ]; then
+if [ ! -x "${CURL}" ]; then
     echo "ERROR! curl not found. Please install curl"
     exit 1
 fi

--- a/quickget
+++ b/quickget
@@ -3145,8 +3145,7 @@ function download_windows_workstation() {
     esac
 
     local user_agent="Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0"
-    # uuidgen: For MacOS (installed by default) and other systems (e.g. with no /proc) that don't have a kernel interface for generating random UUIDs
-    session_id="$(cat /proc/sys/kernel/random/uuid 2> /dev/null || uuidgen --random)"
+    session_id="$(uuidgen)"
 
     # Get product edition ID for latest release of given Windows version
     # Product edition ID: This specifies both the Windows release (e.g. 22H2) and edition ("multi-edition" is default, either Home/Pro/Edu/etc., we select "Pro" in the answer files) in one number


### PR DESCRIPTION
# Support for macOS hosts

This pull request makes Quickemu compatible with macOS hosts, meaning that `quickemu` can now be used to create and run virtual machines on macOS hosts.

Intel and Apple Silicon CPUs on the host are supported. However, Quickemu currently only has x86 OS images available, so Apple Silicon Macs are currently provisioned with x86 virtual machines. This will be addressed in the future.

# Improved compatibility for macOS guests

In addition, this pull request significantly improves the compatibility and performance when running macOS guest VMs, particularly if your host has an Intel CPU. Thanks to @TuxVinyards and @lj3954 for their research in this area. 

- Close #447
- Close #784
- Close #1236