### PR TITLE
fix: resolve portability issues between Linux distros and macOS

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -336,7 +336,7 @@ function configure_cpu() {
         SMM="off"
     else
         if [ -r /sys/class/dmi/id/sys_vendor ]; then
-            MANUFACTURER=$(head -1 /sys/class/dmi/id/sys_vendor)
+            MANUFACTURER=$(head -n 1 /sys/class/dmi/id/sys_vendor)
         fi
         CPU_KVM_UNHALT=",kvm_pv_unhalt"
         GUEST_TWEAKS+=" -global kvm-pit.lost_tick_policy=discard"
@@ -1895,7 +1895,7 @@ if [ "${OS_KERNEL}" == "Darwin" ]; then
     display="cocoa"
 fi
 
-QEMU_VER_LONG=$(${QEMU_IMG} --version | head -1 | awk '{print $3}')
+QEMU_VER_LONG=$(${QEMU_IMG} --version | head -n 1 | awk '{print $3}')
 QEMU_VER_SHORT=$(echo "${QEMU_VER_LONG//./}" | cut -c1-2)
 if [ "${QEMU_VER_SHORT}" -lt 60 ]; then
     echo "ERROR! QEMU 6.0.0 or newer is required, detected ${QEMU_VER_LONG}."
@@ -2094,7 +2094,7 @@ fileshare_param_check
 # Check if vm is already run
 VM_PID=""
 if [ -r "${VMDIR}/${VMNAME}.pid" ]; then
-    VM_PID=$(head -1 "${VMDIR}/${VMNAME}.pid")
+    VM_PID=$(head -n 1 "${VMDIR}/${VMNAME}.pid")
     if ! kill -0 "${VM_PID}" > /dev/null 2>&1; then
         # VM is not running, cleaning up.
         VM_PID=""

--- a/quickget
+++ b/quickget
@@ -906,7 +906,7 @@ function releases_nitrux() {
 }
 
 function releases_nixos() {
-    echo unstable 23.11 23.05 22.11 22.05 21.11 21.05
+    echo unstable 23.11 23.05
 }
 
 function editions_nixos() {

--- a/quickget
+++ b/quickget
@@ -719,7 +719,7 @@ function editions_debian() {
 
 function releases_deepin() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://cdimage.deepin.com/releases/" | grep "href=" | cut -d'"' -f2 | grep -v "\.\." | grep -v nightly | grep -v preview | sed 's|/||g' | sort -r)
+    echo $(web_pipe "https://cdimage.deepin.com/releases/" | grep "href=" | cut -d'"' -f2 | grep -v "\.\." | grep -v nightly | grep -v preview | sed 's|/||g' | tail -n 10 | sort -r)
 }
 
 function releases_devuan() {

--- a/quickget
+++ b/quickget
@@ -697,12 +697,20 @@ function releases_crunchbang++() {
 }
 
 function releases_debian() {
+    local ARCHIVE=""
+    local MAJ=""
     local NEW=""
     local OLD=""
     NEW=$(web_pipe "https://cdimage.debian.org/debian-cd/" | grep '\.[0-9]/' | cut -d'>' -f 9 | cut -d'/' -f 1)
-    OLD=$(web_pipe "https://cdimage.debian.org/cdimage/archive/" | grep -e '>[1-9][0-9]\.' | grep -v 'live' | grep -v NEVER | cut -d'>' -f 9 | cut -d'/' -f 1 | tac | head -20)
-    #shellcheck disable=SC2086
-    echo ${NEW} ${OLD}
+    echo -n "${NEW}"
+    MAJ=$(echo "${NEW}" | cut -d'.' -f 1)
+    ARCHIVE="$(web_pipe "https://cdimage.debian.org/cdimage/archive/" | grep folder | grep -v NEVER | cut -d'"' -f 6)"
+    for i in {1..2}; do
+        CUR=$((MAJ - i))
+        OLD=$(grep ^"${CUR}"  <<< "${ARCHIVE}" | tail -n 1 | tr -d '/')
+        echo -n " ${OLD}"
+    done
+    echo
 }
 
 function editions_debian() {

--- a/quickget
+++ b/quickget
@@ -742,7 +742,7 @@ function releases_elementary() {
 
 function releases_endeavouros() {
     local ENDEAVOUR_RELEASES=""
-    ENDEAVOUR_RELEASES="$(web_pipe "https://mirror.alpix.eu/endeavouros/iso/" | LC_ALL="en_US.UTF-8" sort -Mr | grep -o -P '(?<=<a href=").*(?=.iso">)' | grep -v 'x86_64' | cut -c 13- | head -n 5 | tr '\n' ' ')"
+    ENDEAVOUR_RELEASES="$(web_pipe "https://mirror.alpix.eu/endeavouros/iso/" | grep -o '<a href="[^"]*.iso">' | sed 's/^<a href="//;s/.iso">.*//' | grep -v 'x86_64' | LC_ALL="en_US.UTF-8" sort -Mr | cut -c 13- | head -n 5 | tr '\n' ' ')"
     echo "${ENDEAVOUR_RELEASES,,}"
 }
 
@@ -804,7 +804,7 @@ function editions_ghostbsd() {
 
 function releases_gnomeos() {
     #shellcheck disable=SC2046,SC2005
-    echo "nightly" $(web_pipe "https://download.gnome.org/gnomeos/" | grep -o -P '(?<=<a href=").*(?=/" title=")' | sort -nr)
+    echo "nightly" $(web_pipe "https://download.gnome.org/gnomeos/" | grep "title=" | awk -F'"' '{print $4}' | tr -d '/' | sort -nr)
 }
 
 function releases_guix() {
@@ -1702,7 +1702,7 @@ function get_cachyos() {
     local HASH=""
     local REL=""
     local URL="https://mirror.cachyos.org/ISO/${EDITION}/"
-    REL=$(web_pipe "${URL}" | grep -Po '(?<=">)[0-9]+(?=/</a>)' | sort -ru | tail -n 1)
+    REL=$(web_pipe "${URL}" | grep -o '>[0-9]*/</a>' | grep -o '[0-9]*' | sort -ru | tail -n 1)
     local ISO="cachyos-${EDITION}-linux-${REL}.iso"
     HASH=$(web_pipe "${URL}/${REL}/${ISO}.sha256" | cut -d' ' -f1)
     echo "${URL}/${REL}/${ISO} ${HASH}"
@@ -1822,7 +1822,7 @@ function get_endeavouros() {
     local ISO=""
     local URL="https://mirror.alpix.eu/endeavouros/iso"
     # Find EndeavourOS releases from mirror, pick one matching release
-    ENDEAVOUR_RELEASES="$(web_pipe "${URL}/" | grep -o -P '(?<=<a href=").*(?=.iso">)' | grep -v 'x86_64')"
+    ENDEAVOUR_RELEASES="$(web_pipe "${URL}/" | grep -o '<a href="[^"]*.iso">' | sed 's/^<a href="//;s/.iso">.*//' | grep -v 'x86_64')"
     ISO="$(echo "${ENDEAVOUR_RELEASES}" | grep -i "${RELEASE}").iso"
     HASH=$(web_pipe "${URL}/${ISO}.sha512sum" | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"
@@ -1953,7 +1953,7 @@ function get_haiku() {
 function get_holoiso() {
     local HASH=""
     local URL=""
-    URL=$(web_pipe "https://api.github.com/repos/HoloISO/releases/releases" | jq ".[] | select(.tag_name==\"${RELEASE}\") | .body" | grep -Po "https://\S+holoiso.ru.eu.org/\S+.iso" | head -n 1)
+    URL=$(web_pipe "https://api.github.com/repos/HoloISO/releases/releases" | jq -r ".[] | select(.tag_name==\"${RELEASE}\") | .body" | sed -n 's/.*\(https:\/\/[^ ]*holoiso\.ru\.eu\.org\/[^ ]*\.iso\).*/\1/p' | head -n 1)
     echo "${URL} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -156,11 +156,11 @@ function error_specify_release() {
     case ${OS} in
         *ubuntu-server*)
             echo -en " - Releases:\t"
-            releases_ubuntu-server | sed -Ee 's/eol-\S+//g' # hide eol releases
+            releases_ubuntu-server
             ;;
         *ubuntu*)
             echo -en " - Releases:\t"
-            releases_ubuntu | sed -Ee 's/eol-\S+//g' # hide eol releases
+            releases_ubuntu
             ;;
         *windows*)
             echo -en " - Releases:\t"
@@ -302,7 +302,7 @@ function csv_data() {
             EDITIONS=$(editions_"${OS}")
         fi
 
-        for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
+        for RELEASE in $("releases_${FUNC}"); do
             if [[ "${OS}" == *"ubuntu"* ]] && [[ ${RELEASE} == *"daily"*  ]] && [ ${HAS_ZSYNC} -eq 1 ]; then
                 DOWNLOADER="zsync"
             else
@@ -410,7 +410,7 @@ function test_all() {
     fi
     local URL=""
 
-    for RELEASE in $("releases_${FUNC}" | sed -Ee 's/eol-\S+//g' ); do # hide eol releases
+    for RELEASE in $("releases_${FUNC}"); do
         if [[ $(type -t "editions_${OS}") == function ]]; then
             for EDITION in $(editions_"${OS}"); do
                 validate_release releases_"${OS}"
@@ -1101,24 +1101,21 @@ function releases_tuxedo-os() {
 function releases_ubuntu() {
     local VERSION_DATA=""
     local SUPPORTED_VERSIONS=()
-    local EOL_VERSIONS=()
     VERSION_DATA="$(IFS=$'\n' web_pipe https://api.launchpad.net/devel/ubuntu/series | jq -r '.entries[]')"
     # shellcheck disable=SC2207
     SUPPORTED_VERSIONS=($(IFS=$'\n' jq -r 'select(.status=="Supported" or .status=="Current Stable Release") | .version' <<<"${VERSION_DATA}" | sort))
-    # shellcheck disable=SC2207
-    EOL_VERSIONS=($(IFS=$'\n' jq -r 'select(.status=="Obsolete") | .version' <<<"${VERSION_DATA}" | sort))
     case "${OS}" in
         ubuntu)
-            echo "${SUPPORTED_VERSIONS[@]}" daily-live "${EOL_VERSIONS[@]/#/eol-}";;
+            echo "${SUPPORTED_VERSIONS[@]}" daily-live;;
         kubuntu|lubuntu|ubuntukylin|ubuntu-mate|ubuntustudio|xubuntu)
             # after 16.04
-            echo "${SUPPORTED_VERSIONS[@]:1}" daily-live "${EOL_VERSIONS[@]/#/eol-}";;
+            echo "${SUPPORTED_VERSIONS[@]:1}" daily-live;;
         ubuntu-budgie)
             # after 18.04
-            echo "${SUPPORTED_VERSIONS[@]:2}" daily-live "${EOL_VERSIONS[@]/#/eol-}";;
+            echo "${SUPPORTED_VERSIONS[@]:2}" daily-live;;
         edubuntu|ubuntu-unity|ubuntucinnamon)
             # after 23.10
-            echo "${SUPPORTED_VERSIONS[@]:5}" daily-live "${EOL_VERSIONS[@]/#/eol-}";;
+            echo "${SUPPORTED_VERSIONS[@]:5}" daily-live;;
     esac
 }
 
@@ -2580,9 +2577,7 @@ function get_ubuntu() {
         # Ubuntu Studio daily-live images are in the dvd directory
         RELEASE="dvd"
     fi
-    if [[ "${RELEASE}" == "eol-"* ]]; then
-        URL="https://old-releases.ubuntu.com/releases/${RELEASE/eol-/}"
-    elif [[ "${RELEASE}" == "jammy-daily" ]]; then
+    if [[ "${RELEASE}" == "jammy-daily" ]]; then
         if [[ "${OS}" == "ubuntustudio" ]]; then
             URL="https://cdimage.ubuntu.com/${OS}/jammy/dvd/current"
         else

--- a/quickget
+++ b/quickget
@@ -1307,7 +1307,7 @@ function web_check() {
             shift
         fi
     done
-    curl --silent --location --head --output /dev/null --fail "${HEADERS[@]}" "${URL}"
+    curl --silent --location --head --output /dev/null --fail --connect-timeout 30 --max-time 30 --retry 3 "${HEADERS[@]}" "${URL}"
 }
 
 function zsync_get() {

--- a/quickget
+++ b/quickget
@@ -414,7 +414,7 @@ function test_all() {
         if [[ $(type -t "editions_${OS}") == function ]]; then
             for EDITION in $(editions_"${OS}"); do
                 validate_release releases_"${OS}"
-                URL=$(get_"${OS}" | cut -d' ' -f1 | head -1)
+                URL=$(get_"${OS}" | cut -d' ' -f1 | head -n 1)
                 if [ "${OPERATION}" == "show" ]; then
                     test_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
                 elif [ "${OPERATION}" == "test" ]; then
@@ -443,7 +443,7 @@ function test_all() {
             (get_ubuntu)
         else
             validate_release releases_"${OS}"
-            URL=$(get_"${OS}" | cut -d' ' -f1 | head -1)
+            URL=$(get_"${OS}" | cut -d' ' -f1 | head -n 1)
             if [ "${OPERATION}" == "show" ]; then
                 test_result "${OS}" "${RELEASE}" "${EDITION}" "${URL}"
             elif [ "${OPERATION}" == "test" ]; then
@@ -610,7 +610,7 @@ function editions_arcolinux() {
 
 function releases_artixlinux() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f 4 | sort -ru | tail -1)
+    echo $(web_pipe "https://mirror1.artixlinux.org/iso/" | grep "artix-" | cut -d'"' -f2 | grep -v sig | cut -d'-' -f 4 | sort -ru | tail -n 1)
 }
 
 function editions_artixlinux() {
@@ -625,7 +625,7 @@ function releases_athenaos() {
 
 function releases_batocera() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://mirrors.o2switch.fr/batocera/x86_64/stable/" | grep ^\<a | cut -d'"' -f2 | cut -d '/' -f1 | grep -v '\.' | sort -ru | tail +2 | head -n 5)
+    echo $(web_pipe "https://mirrors.o2switch.fr/batocera/x86_64/stable/" | grep ^\<a | cut -d'"' -f2 | cut -d '/' -f1 | grep -v '\.' | sort -ru | tail -n +2 | head -n 5)
 }
 
 function releases_bazzite() {
@@ -635,7 +635,7 @@ function releases_bazzite() {
 
 function releases_biglinux() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://iso.biglinux.com.br" | grep -Eo 'biglinux_[0-9]{4}(-[0-9]{2}){2}_k[0-9]{2,3}.iso' | cut -d'_' -f2 | sort -ru | head -1)
+    echo $(web_pipe "https://iso.biglinux.com.br" | grep -Eo 'biglinux_[0-9]{4}(-[0-9]{2}){2}_k[0-9]{2,3}.iso' | cut -d'_' -f2 | sort -ru | head -n 1)
 }
 
 function editions_biglinux() {
@@ -728,8 +728,8 @@ function releases_dragonflybsd() {
 function releases_easyos() {
     #local Y2023=""
     #local Y2024=""
-    #Y2024=$(web_pipe https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2024/ | grep "tr class" | tail +2 | cut -d'"' -f6 | cut -d'/' -f1 | sort -r)
-    #Y2023=$(web_pipe https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/ | grep "tr class" | tail +2 | cut -d'"' -f6 | cut -d'/' -f1 | sort -r)
+    #Y2024=$(web_pipe https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2024/ | grep "tr class" | tail -n +2 | cut -d'"' -f6 | cut -d'/' -f1 | sort -r)
+    #Y2023=$(web_pipe https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/2023/ | grep "tr class" | tail -n +2 | cut -d'"' -f6 | cut -d'/' -f1 | sort -r)
     #echo -n ${2024}
     #echo ${Y2023}
     # Not dynamic for now
@@ -795,7 +795,7 @@ function editions_gentoo() {
 
 function releases_ghostbsd() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://download.ghostbsd.org/releases/amd64/" | grep "href" | cut -d'"' -f2 | cut -d'/' -f1 | sort -r | tail +3 | head -3)
+    echo $(web_pipe "https://download.ghostbsd.org/releases/amd64/" | grep "href" | cut -d'"' -f2 | cut -d'/' -f1 | sort -r | tail -n +3 | head -n 3)
 }
 
 function editions_ghostbsd() {
@@ -917,7 +917,7 @@ function releases_openbsd() {
 
 function releases_openindiana() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://dlc.openindiana.org/isos/hipster/" | grep link | cut -d'/' -f 1 | cut -d '"' -f4 | sort -r | tail +2 | head -n 5)
+    echo $(web_pipe "https://dlc.openindiana.org/isos/hipster/" | grep link | cut -d'/' -f 1 | cut -d '"' -f4 | sort -r | tail -n +2 | head -n 5)
 }
 
 function editions_openindiana() {
@@ -1009,7 +1009,7 @@ function editions_siduction() {
 
 function releases_slackware() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://slackware.nl/slackware/slackware-iso/" | grep "slackware-" | cut -d'<' -f7 | cut -d'-' -f2 | sort -ru | head -5)
+    echo $(web_pipe "https://slackware.nl/slackware/slackware-iso/" | grep "slackware-" | cut -d'<' -f7 | cut -d'-' -f2 | sort -ru | head -n 5)
 }
 
 function releases_slax() {
@@ -1136,7 +1136,7 @@ function releases_vanillaos() {
 
 function releases_void() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://repo-default.voidlinux.org/live/" | grep "^<a href=\"2" | cut -d'"' -f2 | tr -d '/' | sort -ru | head -3)
+    echo $(web_pipe "https://repo-default.voidlinux.org/live/" | grep "^<a href=\"2" | cut -d'"' -f2 | tr -d '/' | sort -ru | head -n 3)
 }
 
 function editions_void() {
@@ -1599,7 +1599,7 @@ function get_antix() {
         full-*) ISO+="_x64-full.iso";;
         net-*)  ISO+="-net_x64-net.iso";;
     esac
-    HASH=$(web_pipe "${URL}/${README}.txt" | grep "${ISO}" | cut -d' ' -f1 | head -1)
+    HASH=$(web_pipe "${URL}/${README}.txt" | grep "${ISO}" | cut -d' ' -f1 | head -n 1)
     echo "${URL}/${ISO} ${HASH}"
 }
 
@@ -1694,7 +1694,7 @@ function get_bunsenlabs() {
     local HASH=""
     local ISO="boron-1-240123-amd64.hybrid.iso"
     local URL="https://ddl.bunsenlabs.org/ddl"
-    HASH=$(web_pipe "${URL}/release.sha256.txt" | head -1 | cut -d' ' -f1)
+    HASH=$(web_pipe "${URL}/release.sha256.txt" | head -n 1 | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"
 }
 
@@ -1747,7 +1747,7 @@ function get_debian() {
         URL="${URL/hybrid/cd}"
         ISO="${ISO/-live/}"
     fi
-    HASH=$(web_pipe "${URL}/SHA512SUMS" | grep "${ISO}" | cut -d' ' -f1 | head -1)
+    HASH=$(web_pipe "${URL}/SHA512SUMS" | grep "${ISO}" | cut -d' ' -f1 | head -n 1)
     echo "${URL}/${ISO} ${HASH}"
 }
 
@@ -2208,7 +2208,7 @@ function get_nitrux() {
     local ISO=""
     URLBASE="https://sourceforge.net/projects/nitruxos/files/Release"
     URL="${URLBASE}/ISO"
-    ISO=$(web_pipe 'https://sourceforge.net/projects/nitruxos/rss?path=/Release/ISO' | grep '.iso' | head -1 | cut -d']' -f1 | cut -d '/' -f4)
+    ISO=$(web_pipe 'https://sourceforge.net/projects/nitruxos/rss?path=/Release/ISO' | grep '.iso' | head -n 1 | cut -d']' -f1 | cut -d '/' -f4)
     HASH=$(web_pipe "${URLBASE}/MD5/${ISONAME}.md5sum" | grep "${ISO}" | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"
 }
@@ -2225,7 +2225,7 @@ function get_nwg-shell() {
     local HASH=""
     local ISO="nwg-live-${RELEASE}-x86_64.iso"
     local URL="https://sourceforge.net/projects/nwg-iso/files"
-    HASH="$(web_pipe "https://sourceforge.net/projects/nwg-iso/rss?path=/" | grep "${ISO}" | cut -d'>' -f3 | cut -d'<' -f1 | tail -1)"
+    HASH="$(web_pipe "https://sourceforge.net/projects/nwg-iso/rss?path=/" | grep "${ISO}" | cut -d'>' -f3 | cut -d'<' -f1 | tail -n 1)"
     echo "${URL}/${ISO} ${HASH}"
 }
 
@@ -2459,7 +2459,7 @@ function get_sparkylinux() {
         minimalgui) URL="https://sourceforge.net/projects/sparkylinux/files/base";;
         *) URL="https://sourceforge.net/projects/sparkylinux/files/${EDITION}";;
     esac
-    HASH=$(web_pipe "${URL}/${ISO}.allsums.txt" | head -2 | grep 'iso' | cut -d' ' -f1)
+    HASH=$(web_pipe "${URL}/${ISO}.allsums.txt" | head -n 2 | grep 'iso' | cut -d' ' -f1)
     echo "${URL}/${ISO}" "${HASH}"
 }
 
@@ -2627,7 +2627,7 @@ function get_vanillaos() {
     local HASH=""
     local HASH_URL=""
     local ISO=""
-    ISO=$(web_pipe "https://api.github.com/repos/Vanilla-OS/live-iso/releases" | grep 'download_url' | grep "${RELEASE}" | head -1 | cut -d'"' -f4)
+    ISO=$(web_pipe "https://api.github.com/repos/Vanilla-OS/live-iso/releases" | grep 'download_url' | grep "${RELEASE}" | head -n 1 | cut -d'"' -f4)
     HASH_URL="${ISO//.iso/.sha256.txt}"
     HASH=$(web_pipe "${HASH_URL}" | cut -d' ' -f1)
     echo "${ISO} ${HASH}"
@@ -3394,7 +3394,7 @@ if [ ! -x "${CURL}" ]; then
     echo "ERROR! curl not found. Please install curl"
     exit 1
 fi
-CURL_VERSION=$("${CURL}" --version | head -1 | cut -d' ' -f2)
+CURL_VERSION=$("${CURL}" --version | head -n 1 | cut -d' ' -f2)
 
 QEMU_IMG=$(command -v qemu-img)
 if [ ! -x "${QEMU_IMG}" ]; then

--- a/quickget
+++ b/quickget
@@ -774,7 +774,7 @@ function editions_fedora() {
 
 function releases_freebsd() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/" |grep -e 'class="link"' |grep -v '\.\.'|cut -d\" -f4|tr -d '/' | sort -r)
+    echo $(web_pipe "https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES/" | grep -e 'class="link"' | grep -v '\.\.' | cut -d\" -f 4 | grep -v "14.1" | tr -d '/' | sort -r)
 }
 
 function editions_freebsd() {

--- a/quickreport
+++ b/quickreport
@@ -2,11 +2,21 @@
 
 quick_report() {
     local GPUS
+    local OS_KERNEL
     local PRETTY_NAME
     local QUICKEMU
     local VERSION
-    if [ -e /etc/os-release ]; then
-        PRETTY_NAME="$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
+    OS_KERNEL=$(uname -s)
+
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
+        # Get macOS product name and version using swvers
+        if [ -x "$(command -v sw_vers)" ]; then
+            PRETTY_NAME="$(sw_vers -productName) $(sw_vers -productVersion)"
+        else
+            PRETTY_NAME="macOS"
+        fi
+    elif [ -e /etc/os-release ]; then
+        PRETTY_NAME=$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)
     else
         PRETTY_NAME="Unknown OS"
     fi
@@ -26,10 +36,22 @@ quick_report() {
 ----------------------------------"
         echo -e "Distro:\t${PRETTY_NAME}"
         echo -e "Kernel:\t$(uname -s -r -m)"
-        echo -e "Memory:\t$(free --si -h | awk '/Mem:/{print $2}')"
+
+        if [ "${OS_KERNEL}" == "Darwin" ]; then
+            echo -e "Memory:\t$(($(sysctl -n hw.memsize) / (1048576*1024)))G"
+        else
+            # Determine the number of gigabytes of RAM in the host by extracting the first numerical value from the output.
+            echo -e "Memory:\t$(free --giga -h | tr ' ' '\n' | grep -m 1 [0-9] | cut -d'G' -f 1)G"
+        fi
+
         # Break IFS on new line
         IFS=$'\n'
-        GPUS=$(lspci | grep -i vga | cut -d':' -f3)
+        if [ "${OS_KERNEL}" == "Darwin" ]; then
+            # Get GPU information using system_profiler
+            GPUS=$(system_profiler SPDisplaysDataType | grep "Chipset Model" | awk -F: '{print $2}' | sed 's/^ *//')
+        else
+            GPUS=$(lspci | grep -i vga | cut -d':' -f3)
+        fi
 
         if [ "$(echo "${GPUS}" | wc -l)" -eq 1 ]; then
             echo "GPU:"
@@ -63,13 +85,20 @@ quick_report() {
 ----------------------------------"
     fi
 
-    if command -v qemu-system-"$(uname -m)" &> /dev/null; then
-        VERSION=$(qemu-system-"$(uname -m)" -version | head -n 1 | cut -d' ' -f4)
+    local HOST_ARCH
+    HOST_ARCH=$(uname -m)
+    local QEMU_ARCH="${HOST_ARCH}"
+    if [ "${HOST_ARCH}" == "arm64" ]; then
+        QEMU_ARCH="aarch64"
+    fi
+
+    if command -v "qemu-system-${QEMU_ARCH}" &> /dev/null; then
+        VERSION=$("qemu-system-${QEMU_ARCH}" --version | head -n 1 | cut -d' ' -f4)
         echo \
 "----------------------------------
             QEMU ${VERSION}
 ----------------------------------"
-        qemu-system-"$(uname -m)" -cpu help
+        "qemu-system-${QEMU_ARCH}" -cpu help
     else
         echo \
 "----------------------------------
@@ -81,7 +110,11 @@ quick_report() {
 "----------------------------------
                CPU
 ----------------------------------"
-    lscpu
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
+        sysctl -n machdep.cpu.brand_string
+    else
+        lscpu
+    fi
 }
 
 clear

--- a/quickreport
+++ b/quickreport
@@ -43,11 +43,11 @@ quick_report() {
         VERSION=$(curl --version)
         echo \
 "----------------------------------
-            curl $(echo "${VERSION}" | head -1 | cut -d' ' -f2)
+            curl $(echo "${VERSION}" | head -n 1 | cut -d' ' -f2)
 ----------------------------------"
-        echo -e "Libraries:$(echo "${VERSION}" | head -1 | cut -d')' -f2-)"
-        echo -e "Protocols:$(echo "${VERSION}" | tail +3 | head -1 | cut -d':' -f2-)"
-        echo -e "Features: $(echo "${VERSION}" | tail +4 | head -1 | cut -d':' -f2-)"
+        echo -e "Libraries:$(echo "${VERSION}" | head -n 1 | cut -d')' -f2-)"
+        echo -e "Protocols:$(echo "${VERSION}" | tail -n +3 | head -n 1 | cut -d':' -f2-)"
+        echo -e "Features: $(echo "${VERSION}" | tail -n +4 | head -n 1 | cut -d':' -f2-)"
     else
         echo \
 "----------------------------------
@@ -56,7 +56,7 @@ quick_report() {
     fi
 
     if command -v qemu-system-"$(uname -m)" &> /dev/null; then
-        VERSION=$(qemu-system-"$(uname -m)" -version | head -1 | cut -d' ' -f4)
+        VERSION=$(qemu-system-"$(uname -m)" -version | head -n 1 | cut -d' ' -f4)
         echo \
 "----------------------------------
             QEMU ${VERSION}

--- a/quickreport
+++ b/quickreport
@@ -3,6 +3,7 @@
 quick_report() {
     local GPUS
     local PRETTY_NAME
+    local QUICKEMU
     local VERSION
     if [ -e /etc/os-release ]; then
         PRETTY_NAME="$(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
@@ -10,8 +11,15 @@ quick_report() {
         PRETTY_NAME="Unknown OS"
     fi
 
-    if command -v quickemu &> /dev/null; then
-        VERSION=$(quickemu --version)
+    CWD="$(dirname "${0}")"
+    if [ -x "${CWD}/quickemu" ]; then
+        QUICKEMU="${CWD}/quickemu"
+    elif [ -x "$(command -v quickemu)" ]; then
+        QUICKEMU="$(command -v quickemu)"
+    fi
+
+    if [ -n "${QUICKEMU}" ]; then
+        VERSION=$(${QUICKEMU} --version)
         echo \
 "----------------------------------
         Quickemu ${VERSION}


### PR DESCRIPTION
# Portability

When running `quickemu`, `quickget` and `quickreport` across different Linux distros and macOS, there are several portability issues with how `tail`, `head` and `grep` are invoked. 

This pull request addresses those issues. 

# Compatibility

`quickreport` is also updated to work on macOS x86 and Apple Silicon.

# CI timeouts and runtime

Lastly, some CI jobs were getting wedged and consuming 360 minutes of runtime before being forcibly terminated. To address that, `web_check()` now has timeouts and retries, EOL Ubuntu releases are removed, Debian releases are limited to the latest release in a series, and some other distros cap the number of available releases.