### PR TITLE
feat: adding nixos 24.05 to releases_nixos

### DIFF
--- a/quickget
+++ b/quickget
@@ -906,7 +906,8 @@ function releases_nitrux() {
 }
 
 function releases_nixos() {
-    echo unstable 24.05 23.11 23.05
+    # unstable plus the two most recent releases
+    echo unstable $(web_pipe https://nix-channels.s3.amazonaws.com/?delimiter=/ | grep -o -P '(?<=<Key>nixos-)[0-9]+.[0-9]+(?=</Key>)' | sort -nr | head -n +2)
 }
 
 function editions_nixos() {

--- a/quickget
+++ b/quickget
@@ -910,7 +910,7 @@ function releases_nixos() {
 }
 
 function editions_nixos() {
-    echo minimal plasma5 gnome
+    echo minimal plasma5 plasma6 gnome
 }
 
 function releases_nwg-shell() {

--- a/quickget
+++ b/quickget
@@ -906,7 +906,7 @@ function releases_nitrux() {
 }
 
 function releases_nixos() {
-    echo unstable 23.11 23.05
+    echo unstable 24.05 23.11 23.05
 }
 
 function editions_nixos() {


### PR DESCRIPTION
# Summary 

Updating quickget to add:
* nixos `24.05` release
* nixos `plasma6` edition

## Testing

I'm on an archlinux system. I installed [quickemu from the AUR](https://aur.archlinux.org/packages/quickemu).

On my local system I edited `/usr/bin/quickget` which is where the script is dropped by the aur package.

### 24.05 minimal - 

```
$  quickget nixos 24.05 minimal
Downloading NixOS 24.05 minimal
- URL: https://releases.nixos.org/nixos/24.05/nixos-24.05.803.b3b2b28c1daa/nixos-minimal-24.05.803.b3b2b28c1daa-x86_64-linux.iso
####################################################################################################################################### 100.0%
Checking nixos-24.05-minimal/latest-nixos-minimal-x86_64-linux.iso with sha256sum... Good!
Making nixos-24.05-minimal.conf
Setting nixos-24.05-minimal.conf executable

To start your NixOS virtual machine run:
    quickemu --vm nixos-24.05-minimal.conf
```

Then ran `quickemu --vm nixos-24.05-minimal.conf` [It worked](https://pixelfed.social/p/JollyRoberts/703739821993111760)

### 24.05 gnome -

```
$  quickget nixos 24.05 gnome
Downloading NixOS 24.05 gnome
- URL: https://releases.nixos.org/nixos/24.05/nixos-24.05.803.b3b2b28c1daa/nixos-gnome-24.05.803.b3b2b28c1daa-x86_64-linux.iso
####################################################################################################################################### 100.0%
Checking nixos-24.05-gnome/latest-nixos-gnome-x86_64-linux.iso with sha256sum... Good!
Making nixos-24.05-gnome.conf
Setting nixos-24.05-gnome.conf executable

To start your NixOS virtual machine run:
    quickemu --vm nixos-24.05-gnome.conf
```

Then ran `quickemu --vm nixos-24.05-gnome.conf` [It worked](https://pixelfed.social/p/JollyRoberts/703705936265344617)

### 24.05 plasma5 - 
> This one breaks, but I think its on the nixos nginx redirect side or something. As seen in the below wget output.
```
$  quickget nixos 24.05 plasma5
Downloading NixOS 24.05 plasma5
- URL: https://releases.nixos.org/nixos/24.05/nixos-24.05.803.b3b2b28c1daa/nixos-plasma5-24.05.803.b3b2b28c1daa-x86_64-linux.iso
####################################################################################################################################### 100.0%
WARNING! Can't guess hash algorithm, not checking nixos-24.05-plasma5/latest-nixos-plasma5-x86_64-linux.iso hash.
Making nixos-24.05-plasma5.conf
Setting nixos-24.05-plasma5.conf executable

To start your NixOS virtual machine run:
    quickemu --vm nixos-24.05-plasma5.conf

```
```
$  wget -v https://channels.nixos.org/nixos-24.05/latest-nixos-plasma5-x86_64-linux.iso.sha256
--2024-06-04 19:29:40--  https://channels.nixos.org/nixos-24.05/latest-nixos-plasma5-x86_64-linux.iso.sha256
Loaded CA certificate '/etc/ssl/certs/ca-certificates.crt'
Resolving channels.nixos.org (channels.nixos.org)... 199.232.58.217, 2a04:4e42:4b::729
Connecting to channels.nixos.org (channels.nixos.org)|199.232.58.217|:443... connected.
HTTP request sent, awaiting response... 302 Moved Permanently
Location: https://releases.nixos.org/nixos/24.05/nixos-24.05.803.b3b2b28c1daa/nixos-plasma5-24.05.803.b3b2b28c1daa-x86_64-linux.iso.sha256 [following]
--2024-06-04 19:29:41--  https://releases.nixos.org/nixos/24.05/nixos-24.05.803.b3b2b28c1daa/nixos-plasma5-24.05.803.b3b2b28c1daa-x86_64-linux.iso.sha256
Resolving releases.nixos.org (releases.nixos.org)... 199.232.58.217, 2a04:4e42:4b::729
Connecting to releases.nixos.org (releases.nixos.org)|199.232.58.217|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2024-06-04 19:29:42 ERROR 404: Not Found.
```


### 24.05 plasma6 - 

```
$  quickget nixos 24.05 plasma6
Downloading NixOS 24.05 plasma6
- URL: https://releases.nixos.org/nixos/24.05/nixos-24.05.803.b3b2b28c1daa/nixos-plasma6-24.05.803.b3b2b28c1daa-x86_64-linux.iso
####################################################################################################################################### 100.0%
Checking nixos-24.05-plasma6/latest-nixos-plasma6-x86_64-linux.iso with sha256sum... Good!
Making nixos-24.05-plasma6.conf
Setting nixos-24.05-plasma6.conf executable

To start your NixOS virtual machine run:
    quickemu --vm nixos-24.05-plasma6.conf
```
Then ran `quickemu --vm nixos-24.05-plasma6.conf` [It worked](https://pixelfed.social/p/JollyRoberts/703746718909565985)

### 23.11 minimal - 
```
$  quickget nixos 23.11 minimal
Downloading NixOS 23.11 minimal
- URL: https://releases.nixos.org/nixos/23.11/nixos-23.11.7497.03fca4cf6dd8/nixos-minimal-23.11.7497.03fca4cf6dd8-x86_64-linux.iso
####################################################################################################################################### 100.0%
Checking nixos-23.11-minimal/latest-nixos-minimal-x86_64-linux.iso with sha256sum... Good!
Making nixos-23.11-minimal.conf
Setting nixos-23.11-minimal.conf executable

To start your NixOS virtual machine run:
    quickemu --vm nixos-23.11-minimal.conf

```
Then ran `quickemu --vm nixos-23.11-minimal.conf` [It worked](https://pixelfed.social/p/JollyRoberts/703945816496672880)

### 23.11 gnome - 
```
$  quickget nixos 23.11 gnome
Downloading NixOS 23.11 gnome
- URL: https://releases.nixos.org/nixos/23.11/nixos-23.11.7476.a62e6edd6d5e/nixos-gnome-23.11.7476.a62e6edd6d5e-x86_64-linux.iso
####################################################################################################################################### 100.0%
Checking nixos-23.11-gnome/latest-nixos-gnome-x86_64-linux.iso with sha256sum... Good!
Making nixos-23.11-gnome.conf
Setting nixos-23.11-gnome.conf executable

To start your NixOS virtual machine run:
    quickemu --vm nixos-23.11-gnome.conf

```
Then ran `quickemu --vm nixos-23.11-gnome.conf` [It worked](https://pixelfed.social/p/JollyRoberts/703947822967690622)

### 23.11 plasma5 - 
```
$  quickget nixos 23.11 plasma5
Downloading NixOS 23.11 plasma5
- URL: https://releases.nixos.org/nixos/23.11/nixos-23.11.7476.a62e6edd6d5e/nixos-plasma5-23.11.7476.a62e6edd6d5e-x86_64-linux.iso
####################################################################################################################################### 100.0%
Checking nixos-23.11-plasma5/latest-nixos-plasma5-x86_64-linux.iso with sha256sum... Good!
Making nixos-23.11-plasma5.conf
Setting nixos-23.11-plasma5.conf executable

To start your NixOS virtual machine run:
    quickemu --vm nixos-23.11-plasma5.conf

```
Then ran `quickemu --vm nixos-23.11-plasma5.conf` [It worked](https://pixelfed.social/p/JollyRoberts/703950618200796091)

### 23.11 plasma6 - 
```
$  quickget nixos 23.11 plasma6
Downloading NixOS 23.11 plasma6
- URL: https://releases.nixos.org/nixos/23.11/nixos-23.11.7476.a62e6edd6d5e/nixos-plasma6-23.11.7476.a62e6edd6d5e-x86_64-linux.iso
####################################################################################################################################### 100.0%
WARNING! Can't guess hash algorithm, not checking nixos-23.11-plasma6/latest-nixos-plasma6-x86_64-linux.iso hash.
Making nixos-23.11-plasma6.conf
Setting nixos-23.11-plasma6.conf executable

To start your NixOS virtual machine run:
    quickemu --vm nixos-23.11-plasma6.conf

```
Then ran `quickemu --vm nixos-23.11-plasma6.conf` [vm boots, but the installer is not happy, though not related to this change](https://pixelfed.social/p/JollyRoberts/703952691116609650)