### PR TITLE
fix: running quickemu in zsh and spice display

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -995,7 +995,7 @@ function configure_ports() {
     fi
 
     if [ "${display}" == "none" ] || [ "${display}" == "spice" ] || [ "${display}" == "spice-app" ]; then
-        local SPICE="disable-ticketing=on"
+        SPICE="disable-ticketing=on"
         # gl=on can be use with 'spice' too, but only over local connections (not tcp ports)
         if [ "${display}" == "spice-app" ]; then
             SPICE+=",gl=${gl}"

--- a/quickemu
+++ b/quickemu
@@ -562,7 +562,7 @@ function configure_ram() {
             RAM_HOST=$(($(sysctl -n hw.memsize) / (1048576*1024)))
         else
             # Determine the number of gigabytes of RAM in the host by extracting the first numerical value from the output.
-            RAM_HOST=$(free --giga -h | tr ' ' '\n' | grep -m 1 [0-9] | cut -d'G' -f 1)
+            RAM_HOST=$(free --giga -h | tr ' ' '\n' | grep -m 1 "[0-9]" | cut -d'G' -f 1)
         fi
 
         if [ "${RAM_HOST}" -ge 128 ]; then


### PR DESCRIPTION
because of auto completion of zsh, piping to grep [0-9] not work
this patch will simply fix this problem by quoting [0-9]