### PR TITLE
chore(updated supported releases): Updated support for ParrotOS 6.1

### DIFF
--- a/quickget
+++ b/quickget
@@ -906,7 +906,7 @@ function releases_nitrux() {
 }
 
 function releases_nixos() {
-    echo unstable 23.11 23.05
+    echo unstable 24.05 23.11
 }
 
 function editions_nixos() {
@@ -942,7 +942,7 @@ function releases_oraclelinux() {
 }
 
 function releases_parrotsec() {
-    echo 6.0 5.3
+    echo 6.1 6.0
 }
 
 function editions_parrotsec() {

--- a/quickget
+++ b/quickget
@@ -906,7 +906,7 @@ function releases_nitrux() {
 }
 
 function releases_nixos() {
-    echo unstable 24.05 23.11
+    echo unstable 23.11 23.05
 }
 
 function editions_nixos() {

--- a/quickget
+++ b/quickget
@@ -942,7 +942,7 @@ function releases_oraclelinux() {
 }
 
 function releases_parrotsec() {
-    echo 6.1 6.0
+    echo $(web_pipe "https://download.parrot.sh/parrot/iso/" | grep -o -P '(?<=href=")[0-9].*(?=/")' | sort -nr | head -n +2)
 }
 
 function editions_parrotsec() {


### PR DESCRIPTION
Added support for:

- ParrotOS 6.1

Removed support for:

- ParrotOS 5.9