### PR TITLE
fix: running quickemu and quickreport in zsh. close #1268

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -562,7 +562,7 @@ function configure_ram() {
             RAM_HOST=$(($(sysctl -n hw.memsize) / (1048576*1024)))
         else
             # Determine the number of gigabytes of RAM in the host by extracting the first numerical value from the output.
-            RAM_HOST=$(free --giga -h | tr ' ' '\n' | grep -m 1 [0-9] | cut -d'G' -f 1)
+            RAM_HOST=$(free --giga -h | tr ' ' '\n' | grep -m 1 "[0-9]" | cut -d'G' -f 1)
         fi
 
         if [ "${RAM_HOST}" -ge 128 ]; then

--- a/quickreport
+++ b/quickreport
@@ -41,7 +41,7 @@ quick_report() {
             echo -e "Memory:\t$(($(sysctl -n hw.memsize) / (1048576*1024)))G"
         else
             # Determine the number of gigabytes of RAM in the host by extracting the first numerical value from the output.
-            echo -e "Memory:\t$(free --giga -h | tr ' ' '\n' | grep -m 1 [0-9] | cut -d'G' -f 1)G"
+            echo -e "Memory:\t$(free --giga -h | tr ' ' '\n' | grep -m 1 "[0-9]" | cut -d'G' -f 1)G"
         fi
 
         # Break IFS on new line


### PR DESCRIPTION
Due to zsh auto completion of piping to `grep [0-9]` does not work. This patch fixes this problem by quoting `"[0-9]"`.
