### PR TITLE
fix: Fixes nix flakes by adding version to package.nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -52,11 +52,18 @@ let
     usbutils
     xdg-user-dirs
   ];
+  versionMatches =
+    builtins.match ''
+      .*
+      readonly[[:blank:]]VERSION="([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)"
+      .*
+    '' (builtins.readFile ./quickemu);
 in
 
 stdenv.mkDerivation rec {
   pname = "quickemu";
-  version = "4.9.4";
+  version = builtins.concatStringsSep "" versionMatches;
+    
   src = lib.cleanSource ./.;
 
   postPatch = ''

--- a/package.nix
+++ b/package.nix
@@ -56,6 +56,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "quickemu";
+  version = "4.9.4";
   src = lib.cleanSource ./.;
 
   postPatch = ''


### PR DESCRIPTION
Essentially, when you try and import the project directly with nix flakes, you receive a missing 'name' attribute error. This is because 'name' is supposed to be defined in stdenv.mkDerivation, but is not. I [looked into it](https://discourse.nixos.org/t/clarification-on-package-names-and-versions/9819/2) and found that `name` is actually `<pname>-<version>`, so I just added it.

Below are the before and after outputs of flake.nix using `nix flake show`:

### Before:
![image](https://github.com/quickemu-project/quickemu/assets/30960302/fce9dcc1-ab67-466d-8575-6733e8be552a)

### After:
![image](https://github.com/quickemu-project/quickemu/assets/30960302/23c7e608-de61-42fa-b96b-4b012ff37b48)
