### PR TITLE
fix: update bazzite to always get the latest stable release. close #1306

### DIFF
--- a/quickget
+++ b/quickget
@@ -629,8 +629,11 @@ function releases_batocera() {
 }
 
 function releases_bazzite() {
-    #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://api.github.com/repos/ublue-os/bazzite/releases" | grep 'download_url' | grep 'sum' | cut -d '/' -f8 | cut -d'v' -f2 | head -n 5)
+    echo latest
+}
+
+function editions_bazzite() {
+    echo gnome kde
 }
 
 function releases_biglinux() {
@@ -1663,9 +1666,12 @@ function get_batocera() {
 function get_bazzite() {
     local HASH=""
     local ISO=""
-    local URL="https://github.com/ublue-os/bazzite/releases/download/v${RELEASE}"
-    ISO=$(web_pipe "https://api.github.com/repos/ublue-os/bazzite/releases" | grep 'download_url' | grep 'sum' | cut -d '"' -f4 | cut -d'.' -f1-5 | grep "${RELEASE}" | cut -d'/' -f9)
-    HASH=$(web_pipe "${URL}/${ISO}.sha256sum" | grep 'SHA256' | cut -d' ' -f4)
+    local URL="https://download.bazzite.gg"
+    case ${EDITION} in
+        gnome) ISO="bazzite-gnome-stable.iso";;
+        kde)  ISO="bazzite-stable.iso";;
+    esac
+    HASH=$(web_pipe "${URL}/${ISO}-CHECKSUM" | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"
 }
 


### PR DESCRIPTION
Add the option to choose KDE or GNOME editions.
