### PR TITLE
fix(windows-server): default to e1000 network device. fixes #1315

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -747,7 +747,8 @@ function configure_os_quirks() {
     fi
 
     case ${guest_os} in
-        *bsd|linux*|windows*) NET_DEVICE="virtio-net";;
+        windows-server) NET_DEVICE="e1000";;
+        *bsd|linux*|windows) NET_DEVICE="virtio-net";;
         freedos) sound_card="sb16";;
         *solaris) usb_controller="xhci"
                   sound_card="ac97";;


### PR DESCRIPTION
# Description

Set the default network interface to e1000 on Windows Server to ensure networking functions post-install. Tested Windows Server 2012-R2, 2016, 2019 and 2022.

- Fixes #1315

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (updates documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
