### PR TITLE
refactor: attempt to press any key 5 times during Window boot from CD/DVD

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -2121,16 +2121,15 @@ if [ -z "${VM_PID}" ]; then
     fi
 
     vm_boot
-    # If the VM being started is an uninstalled Windows VM then auto-skip the press-any key prompt.
-    if [ -n "${iso}" ] && [ "${guest_os}" == "windows" ]; then
-        sleep 3.5
-        monitor_send_cmd "sendkey ret"
-    fi
-    if [ -n "${iso}" ] && [ "${guest_os}" == "windows-server" ]; then
-        sleep 7
-        monitor_send_cmd "sendkey ret"
-    fi
     start_viewer
+    # If the VM being started is an uninstalled Windows VM then auto-skip the press-any key prompt.
+    if [ -n "${iso}" ] && [[ "${guest_os}" == "windows"* ]]; then
+        # shellcheck disable=SC2034
+        for LOOP in {1..5}; do
+          sleep 1
+          monitor_send_cmd "sendkey ret"
+        done
+    fi
 else
     echo "${VMNAME}"
     echo " - Process:  Already running ${VM} as ${VMNAME} (${VM_PID})"


### PR DESCRIPTION
# Description

Boot Windows from CD/DVD prompts to "press any key" to boot from the ISO media. The patch attempts to press enter 5 times at one-second intervals when booting from ISO media, instead of badly guessing when to press the enter key once.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
