### PR TITLE
chore: remove Windows 8.1, Windows 10 LTSC and Windows Server 2012 R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ required to run the virtual machines.
 - Host support for **Linux and macOS**
 - **macOS** Sonoma, Ventura, Monterey, Big Sur, Catalina & Mojave
 - **Windows** 10 and 11 including TPM 2.0
-- **Windows Server** 2022 2019 2016 2012-r2
+- **Windows Server** 2022 2019 2016
 - [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu
   flavours](https://ubuntu.com/download/flavours)**
 - **Nearly 1000 operating system editions are supported!**

--- a/quickget
+++ b/quickget
@@ -1158,24 +1158,14 @@ function releases_vxlinux() {
 }
 
 function releases_windows() {
-    echo 11 10-ltsc 10 8
+    echo 11 10
 }
 
 function languages_windows() {
-    if [ "${RELEASE}" == 8 ]; then
-        I18NS=("Arabic" "Brazilian Portuguese" "Bulgarian" "Chinese (Simplified)" "Chinese (Traditional)" "Chinese (Traditional Hong Kong)" \
-        "Croatian" "Czech" "Danish" "Dutch" "English (United States)" "English International" "Estonian" "Finnish" "French" "German" "Greek" \
-        "Hebrew" "Hungarian" "Italian" "Japanese" "Latvian" "Lithuanian" "Norwegian" "Polish" "Portuguese" "Romanian" "Russian" "Serbian Latin" \
-        "Slovak" "Slovenian" "Spanish" "Swedish" "Thai" "Turkish" "Ukrainian")
-    elif [ "${RELEASE}" == "10-ltsc" ]; then
-        I18NS=("English (United States)" "English (Great Britain)" "Chinese (Simplified)" "Chinese (Traditional)" \
-        "French" "German" "Italian" "Japanese" "Korean" "Portuguese (Brazil)" "Spanish")
-    else
-        I18NS=("Arabic" "Brazilian Portuguese" "Bulgarian" "Chinese (Simplified)" "Chinese (Traditional)" "Croatian" "Czech" "Danish" "Dutch" \
-        "English (United States)" "English International" "Estonian" "Finnish" "French" "French Canadian" "German" "Greek" "Hebrew" "Hungarian" \
-        "Italian" "Japanese" "Korean" "Latvian" "Lithuanian" "Norwegian" "Polish" "Portuguese" "Romanian" "Russian" "Serbian Latin" "Slovak" \
-        "Slovenian" "Spanish" "Spanish (Mexico)" "Swedish" "Thai" "Turkish" "Ukrainian")
-    fi
+    I18NS=("Arabic" "Brazilian Portuguese" "Bulgarian" "Chinese (Simplified)" "Chinese (Traditional)" "Croatian" "Czech" "Danish" "Dutch" \
+    "English (United States)" "English International" "Estonian" "Finnish" "French" "French Canadian" "German" "Greek" "Hebrew" "Hungarian" \
+    "Italian" "Japanese" "Korean" "Latvian" "Lithuanian" "Norwegian" "Polish" "Portuguese" "Romanian" "Russian" "Serbian Latin" "Slovak" \
+    "Slovenian" "Spanish" "Spanish (Mexico)" "Swedish" "Thai" "Turkish" "Ukrainian")
 }
 
 function releases_windows-server() {
@@ -3045,7 +3035,6 @@ function download_windows_server() {
     local PRETTY_RELEASE=""
 
     case "${RELEASE}" in
-        "10-ltsc") PRETTY_RELEASE="10 LTSC";;
         *) PRETTY_RELEASE="${RELEASE}";;
     esac
 
@@ -3159,12 +3148,12 @@ function download_windows_workstation() {
     # https://github.com/ElliotKillick/Mido
     # Download newer consumer Windows versions from behind gated Microsoft API
 
-    # Either 8, 10, or 11
+    # Either 10, or 11
     local windows_version="$1"
 
     local url="https://www.microsoft.com/en-us/software-download/windows$windows_version"
     case "$windows_version" in
-        8 | 10) url="${url}ISO";;
+        10) url="${url}ISO";;
     esac
 
     local user_agent="Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0"
@@ -3262,9 +3251,7 @@ function download_windows_workstation() {
 }
 
 function get_windows() {
-    if [ "${RELEASE}" == "10-ltsc" ]; then
-        download_windows_server windows-10-enterprise ltsc
-    elif [ "${OS}" == "windows-server" ]; then
+    if [ "${OS}" == "windows-server" ]; then
         download_windows_server "windows-server-${RELEASE}"
     else
         download_windows_workstation "${RELEASE}"

--- a/quickget
+++ b/quickget
@@ -1179,7 +1179,7 @@ function languages_windows() {
 }
 
 function releases_windows-server() {
-    echo 2022 2019 2016 2012-r2
+    echo 2022 2019 2016
 }
 
 function languages_windows-server() {
@@ -3046,7 +3046,6 @@ function download_windows_server() {
 
     case "${RELEASE}" in
         "10-ltsc") PRETTY_RELEASE="10 LTSC";;
-        "2012-r2") PRETTY_RELEASE="2012 R2";;
         *) PRETTY_RELEASE="${RELEASE}";;
     esac
 

--- a/quickget
+++ b/quickget
@@ -1532,7 +1532,7 @@ EOF
         fi
 
         # Enable TPM for Windows 11
-        if [ "${OS}" == "windows" ] && [ "${RELEASE}" == 11 ] || [ "${OS}" == "windows-server" ] && [ "${RELEASE}" == "2022" ]; then
+        if [ "${OS}" == "windows" ] && [ "${RELEASE}" == "11" ] || [ "${OS}" == "windows-server" ] && [ "${RELEASE}" == "2022" ]; then
             echo "tpm=\"on\"" >> "${CONF_FILE}"
             echo "secureboot=\"off\"" >> "${CONF_FILE}"
         fi


### PR DESCRIPTION
# Description

The patch removes support for the following versions of Windows:
- Windows 8.1, which has been EOL since January 10, 2023.
- Windows 10 LTSC, which is intended for large-scale, long-term enterprise deployments and makes little to no sense for a virtual machine.
  - The Windows 10 LTSC support in Quickemu also lacked VirtIO and automated installation.
  - Regular Windows 10 is still available in Quickemu.
- Windows Server 2012 R2 which is EOL since October 10, 2023.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (updates documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation