### PR TITLE
fix: get rounded integer RAM_HOST values

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -561,7 +561,7 @@ function configure_ram() {
             RAM_HOST=$(($(sysctl -n hw.memsize) / (1048576*1024)))
         else
             # Determine the number of gigabytes of RAM in the host by extracting the first numerical value from the output.
-            RAM_HOST=$(free --giga -h | tr ' ' '\n' | grep -m 1 "[0-9]" | cut -d'G' -f 1)
+            RAM_HOST=$(free --giga | tr ' ' '\n' | grep -m 1 "[0-9]" )
         fi
 
         if [ "${RAM_HOST}" -ge 128 ]; then


### PR DESCRIPTION
# Description

Set RAM_HOST to a rounded integer value so tests do not fail and produce ugly warnings


- Fixes #1346
- Resolves #

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my code
