### PR TITLE
refactor: update Nix flake to be consistent with the quickgui flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,16 +16,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719506693,
-        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
-        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
-        "revCount": 644565,
+        "lastModified": 1717952948,
+        "narHash": "sha256-mJi4/gjiwQlSaxjA6AusXBN/6rQRaPCycR7bd8fydnQ=",
+        "rev": "2819fffa7fa42156680f0d282c60d81e8fb185b7",
+        "revCount": 631440,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.644565%2Brev-b2852eb9365c6de48ffb0dc2c9562591f652242a/01906511-d0fc-7244-b596-2d790f5bfdb0/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.631440%2Brev-2819fffa7fa42156680f0d282c60d81e8fb185b7/0190034c-678d-7039-b45c-fa38168f2500/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A.tar.gz"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A.tar.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Quickemu flake";
   inputs = {
     flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/*.tar.gz";
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*.tar.gz";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*.tar.gz";
   };
 
   outputs = {
@@ -10,28 +10,33 @@
     flake-schemas,
     nixpkgs,
   }: let
-    forAllSystems = function:
-      nixpkgs.lib.genAttrs [
-        "x86_64-linux"
-        "aarch64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
-      ] (system: function nixpkgs.legacyPackages.${system});
+      # Define supported systems and a helper function for generating system-specific outputs
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
+
+      forEachSupportedSystem = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        system = system;
+        pkgs = import nixpkgs { inherit system; };
+      });
   in {
-    # Schemas tell Nix about the structure of your flake's outputs
+    # Define schemas for the flake's outputs
     schemas = flake-schemas.schemas;
 
-    overlays.default = final: prev: {
-      quickemu = final.callPackage ./package.nix {};
-    };
+    # Define overlays for each supported system
+    overlays = forEachSupportedSystem ({pkgs, system, ...}: {
+      default = final: prev: {
+        quickemu = final.callPackage ./package.nix { };
+      };
+    });
 
-    packages = forAllSystems (pkgs: rec {
-      quickemu = pkgs.callPackage ./package.nix {};
+    # Define packages for each supported system
+    packages = forEachSupportedSystem ({pkgs, system, ...}: rec {
+      quickemu = pkgs.callPackage ./package.nix { };
       default = quickemu;
     });
 
-    devShells = forAllSystems (pkgs: {
-      default = pkgs.callPackage ./devshell.nix {};
+    # Define devShells for each supported system
+    devShells = forEachSupportedSystem ({pkgs, system, ...}: {
+      default = pkgs.callPackage ./devshell.nix { };
     });
   };
 }


### PR DESCRIPTION
# Description

This updates the Nix flake to be consistent with the Quickgui flake and always track the Nixpkgs stable branch.

The builds tool in the Nix devshell track the 6-monthly stable branch of Nixpkgs for better predictability.

## Type of change

- [x] Packaging (updates the packaging)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections