### PR TITLE
fix: patch samba detection in Nix flake

### DIFF
--- a/devshell.nix
+++ b/devshell.nix
@@ -15,7 +15,8 @@ mkShell {
     pciutils
     procps
     python3
-    qemu
+    qemu_full
+    samba
     socat
     spice-gtk
     swtpm
@@ -43,8 +44,8 @@ mkShell {
       -e '/OVMF_CODE_4M.secboot.fd/s|ovmfs=(|ovmfs=("${pkgs.OVMFFull.firmware}","${pkgs.OVMFFull.variables}" |' \
       -e '/OVMF_CODE_4M.fd/s|ovmfs=(|ovmfs=("${pkgs.OVMF.firmware}","${pkgs.OVMF.variables}" |' \
       -e '/cp "''${VARS_IN}" "''${VARS_OUT}"/a chmod +w "''${VARS_OUT}"' \
-      -e 's/Icon=.*qemu.svg/Icon=qemu/' \
+      -e 's,\$(command -v smbd),${pkgs.samba}/bin/smbd,' \
       quickemu > $PWD/.direnv/bin/quickemu
-      chmod +x $PWD/.direnv/bin/quickemu
+    chmod +x $PWD/.direnv/bin/quickemu
   '';
 }

--- a/package.nix
+++ b/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
       -e '/OVMF_CODE_4M.secboot.fd/s|ovmfs=(|ovmfs=("${OVMFFull.firmware}","${OVMFFull.variables}" |' \
       -e '/OVMF_CODE_4M.fd/s|ovmfs=(|ovmfs=("${OVMF.firmware}","${OVMF.variables}" |' \
       -e '/cp "''${VARS_IN}" "''${VARS_OUT}"/a chmod +w "''${VARS_OUT}"' \
-      -e 's/Icon=.*qemu.svg/Icon=qemu/' \
+      -e 's,\$(command -v smbd),${samba}/bin/smbd,' \
       quickemu
   '';
 


### PR DESCRIPTION
# Description

This completes the fix for connecting to the QEMU samba share using Nix flake/devshell.

- https://github.com/NixOS/nixpkgs/pull/323133

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Packaging (updates the packaging)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections