### PR TITLE
refactor: replace all use of fold with fmt; no need for ncurses

### DIFF
--- a/devshell.nix
+++ b/devshell.nix
@@ -11,7 +11,6 @@ mkShell {
     gnugrep
     gnused
     jq
-    ncurses
     pciutils
     procps
     python3

--- a/package.nix
+++ b/package.nix
@@ -11,7 +11,6 @@
 , gnugrep
 , gnused
 , jq
-, ncurses
 , pciutils
 , procps
 , python3
@@ -38,7 +37,6 @@ let
     gnugrep
     gnused
     jq
-    ncurses
     pciutils
     procps
     python3

--- a/quickget
+++ b/quickget
@@ -138,7 +138,7 @@ function os_homepage() {
 function error_specify_os() {
     echo "ERROR! You must specify an operating system."
     echo "- Supported Operating Systems:"
-    os_support | fold -s -w "$(tput cols)"
+    os_support | fmt -w 80
     echo -e "\nTo see all possible arguments, use:\n   quickget -h  or  quickget --help"
     exit 1
 }
@@ -146,7 +146,7 @@ function error_specify_os() {
 function os_supported() {
     if [[ ! "$(os_support)" =~ ${OS} ]]; then
         echo -e "ERROR! ${OS} is not a supported OS.\n"
-        os_support | fold -s -w "$(tput cols)"
+        os_support | fmt -w 80
         exit 1
     fi
 }
@@ -171,10 +171,10 @@ function error_specify_release() {
             ;;
         *)
             echo -en " - Releases:\t"
-            "releases_${OS}" | fold -s -w "$(tput cols)"
+            "releases_${OS}" | fmt -w 80
             if [[ $(type -t "editions_${OS}") == function ]]; then
                 echo -en " - Editions:\t"
-                "editions_${OS}" | fold -s -w "$(tput cols)"
+                "editions_${OS}" | fmt -w 80
             fi
             ;;
     esac
@@ -3364,7 +3364,7 @@ Arguments:
 --------------------------------------------------------------------------------
 
 Supported Operating Systems:\n\n' "$(quickemu --version)" "${CURL_VERSION}"
-    os_support | fold -s -w "$(tput cols)"
+    os_support | fmt -w 80
 }
 
 trap cleanup EXIT

--- a/quickget
+++ b/quickget
@@ -182,30 +182,11 @@ function error_specify_release() {
     exit 1
 }
 
-function error_specify_edition() {
-    show_os_info "${OS}"
-    echo -e " - Editions:\t$("editions_${OS}" | fold -s -w "$(tput cols)")"
-    echo -e "\nERROR! You must specify an edition."
-    exit 1
-}
-
 function error_not_supported_release() {
     if [[ ! "${RELEASES[*]}" =~ ${RELEASE} ]]; then
         echo -e "ERROR! ${DISPLAY_NAME} ${RELEASE} is not a supported release.\n"
         echo -n ' - Supported releases: '
         "releases_${OS}"
-        exit 1
-    fi
-}
-
-function error_not_supported_edition() {
-    if [[ ! "${EDITIONS[*]}" = *"${EDITION}"* ]]; then
-        echo -e "ERROR! ${EDITION} is not a supported $(pretty_name "${OS}") edition\n"
-        echo -n ' - Supported editions: '
-        for EDITION in "${EDITIONS[@]}"; do
-            echo -n "${EDITION} "
-        done
-        echo ""
         exit 1
     fi
 }
@@ -3487,9 +3468,20 @@ if [ -n "${2}" ]; then
         EDITIONS=("$(editions_"${OS}")")
         if [ -n "${3}" ]; then
             EDITION="${3}"
-            error_not_supported_edition
+            if [[ ! "${EDITIONS[*]}" = *"${EDITION}"* ]]; then
+                echo -e "ERROR! ${EDITION} is not a supported $(pretty_name "${OS}") edition\n"
+                echo -n ' - Supported editions: '
+                for EDITION in "${EDITIONS[@]}"; do
+                    echo -n "${EDITION} "
+                done
+                echo ""
+                exit 1
+            fi
         else
-            error_specify_edition
+            show_os_info "${OS}"
+            echo -e " - Editions:\t$("editions_${OS} | fmt -w 80")"
+            echo -e "\nERROR! You must specify an edition."
+            exit 1
         fi
         handle_missing
         VM_PATH="${OS}-${RELEASE}-${EDITION}"


### PR DESCRIPTION
# Description

This pull request replaces all use of `fold` (from ncurses) with `fmt` (from coreutils) so that ncurses is no longer a Quickemu dependency.

## Type of change

- [x] Packaging (updates the packaging)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
