### PR TITLE
fix: make shellcheck happy by removing pointless echo

### DIFF
--- a/quickget
+++ b/quickget
@@ -3330,7 +3330,7 @@ function create_vm() {
 # fallback to checking if quickemu is in the current directory.
 function resolve_quickemu() {
     if command -v quickemu >/dev/null 2>&1; then
-        echo "$(command -v quickemu)"
+        command -v quickemu
     elif [ -f "./quickemu" ]; then
         echo "$(pwd)/quickemu"
     else


### PR DESCRIPTION
# Description

Little update to make `shellcheck` happier by removing a pointless echo.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
