### PR TITLE
fix: download Fedora Silverblue iso instead of ociarchive file

### DIFF
--- a/quickget
+++ b/quickget
@@ -1841,7 +1841,7 @@ function get_fedora() {
         *) VARIANT="Spins";;
     esac
     #shellcheck disable=SC2086
-    JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select(.variant=="'${VARIANT}'" and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'")')
+    JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select(.variant=="'${VARIANT}'" and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'" and .sha256 != null)')
     URL=$(echo "${JSON}" | jq -r '.link' | head -n1)
     HASH=$(echo "${JSON}" | jq -r '.sha256' | head -n1)
     echo "${URL} ${HASH}"


### PR DESCRIPTION
# Description

Make sure to download the `iso` for Fedora Silverblue instead of the `ociarchive`

Fixes #1257

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Packaging (updates the packaging)
- [ ] Documentation (updates the documentation)

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have tested my code in common scenarios and confirmed there are no regressions
- [X] I have added comments to my code, particularly in hard-to-understand sections
- [X] I have made corresponding changes to the documentation (*remove if no documentation changes were required*)


Result with this change:

```
$ ./quickget fedora 40 Silverblue
Downloading Fedora 40 Silverblue
- URL: https://fedora.mirrorservice.org/fedora/linux/releases/40/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-40-1.14.iso
```

Before the change

```
$ quickget fedora 40 Silverblue
Downloading Fedora 40 Silverblue
- URL: https://mirrors.xtom.ee/fedora/releases/40/Silverblue/x86_64/images/Fedora-Silverblue-40.1.14.ociarchive
```