### PR TITLE
ci: actually test running a VM

### DIFF
--- a/.github/workflows/test-build-quickemu.yml
+++ b/.github/workflows/test-build-quickemu.yml
@@ -62,4 +62,21 @@ jobs:
           tree ./result
           ./result/bin/quickemu --help
           ./result/bin/quickget --help
+          ./result/bin/quickreport
+          # Text a VM if the Nix Installer successfully enabled KVM
+          if [ $DETERMINATE_NIX_KVM -eq 1 ]; then
+            ./result/bin/quickget alpine v3.20
+            ./result/bin/quickemu --vm alpine-v3.20.conf --display none
+            sleep 5
+            if pgrep -F ./alpine-v3.20/alpine-v3.20.pid; then
+              echo "Test VM is running"
+            else
+              echo "Test VM is not running"
+              exit 1
+            fi
+            # Test a few more quickemu commands to clean up
+            ./result/bin/quickemu --vm alpine-v3.20.conf --kill
+            ./result/bin/quickemu --vm alpine-v3.20.conf --delete-disk
+            ./result/bin/quickemu --vm alpine-v3.20.conf --delete-vm
+          fi
 


### PR DESCRIPTION
# Description

Make the tests a bit more robust by actually creating and running a VM. We do this as part of the Nix build test because the Nix Installer action from Determinate Systems will attempt to enable KVM acceleration.

If KVM acceleration is available, this test will now attempt to create, run and kill and an Alpine VM.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections