### PR TITLE
feat: Improve quickget custom configurations, including unattended windows support

### DIFF
--- a/quickget
+++ b/quickget
@@ -3333,18 +3333,16 @@ function create_config() {
         *windows-server*|*eval_oemret_x*|*eval_x*) CUSTOM_OS="windows-server";;
         *windows*|win*)
             CUSTOM_OS="windows"
-            while [ $# -gt 2 ]; do
-                case "${3}" in
-                    -unattended|--unattended)
-                        echo "Downloading VirtIO drivers..."
-                        web_get "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso" "${VM_PATH}"
-                        FIXED_ISO=${VM_PATH}/virtio-win.iso
-
-                        rm -f "${VM_PATH}/unattended.iso"
-                        unattended_windows "${VM_PATH}"
-                        shift
-                esac
-            done
+            # Older windows 10 ISOs use the year followed by the month rather than the year & half). Match any text for language.
+            if [ "${3}" != "--disable-unattended" ] && ( [ "${3}" == "--unattended" ] || grep -E -q 'Win(10|11)_([0-9]{2}H(1|2)|[0-9]{4})_[^.]*?(x64|x32)(v[0-9])?.iso' <<< "${INPUT}" ); then
+                echo "Creating unattended Windows installation files. To disable, pass --disable-unattended"
+                echo
+                echo "Downloading VirtIO drivers..."
+                web_get "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso" "${VM_PATH}"
+                FIXED_ISO=${VM_PATH}/virtio-win.iso
+                rm -f "${VM_PATH}/unattended.iso"
+                unattended_windows "${VM_PATH}"
+            fi
             ;;
 
         *) CUSTOM_OS="linux";;
@@ -3397,7 +3395,7 @@ Arguments:
   --help                                   : Show this help message
 ------------------------------------ Flags -------------------------------------
 --create-config:
-  --unattended                             : Unattended windows installation
+  --disable-unattended                     : Force quickget not to set up an unattended installation
 -------------------------- For testing & development ---------------------------
   --url           [os] [release] [edition] : Show image URL(s)
   --check         [os] [release] [edition] : Check image URL(s)

--- a/quickget
+++ b/quickget
@@ -308,51 +308,6 @@ function csv_data() {
     wait
 }
 
-function create_config() {
-    local VM_PATH="${1}"
-    local INPUT="${2}"
-    OS="custom"
-    if ! mkdir "${VM_PATH}" 2>/dev/null; then
-        echo "ERROR! Could not create directory: ${VM_PATH}. Please verify that it does not already exist"
-        exit 1
-    fi
-    if [[ "${INPUT}" == "http://"* ]] || [[ "${INPUT}" == "https://"* ]]; then
-        INPUT="$(web_redirect "${INPUT}")"
-        if [[ "${INPUT}" == *".iso" ]] || [[ "${INPUT}" == *".img" ]]; then
-            web_get "${INPUT}" "${VM_PATH}"
-            INPUT="${VM_PATH}/${INPUT##*/}"
-        else
-            echo "ERROR! Only ISO,IMG and QCOW2 file types are supported for --create-config"
-            exit 1
-        fi
-    fi
-    if [[ "${INPUT}" == *".iso" ]]; then
-        echo "Moving image to VM dir" && mv "${INPUT}" "${VM_PATH}"
-        CUSTOM_IMAGE_TYPE="iso"
-    elif [[ "${INPUT}" == *".img" ]]; then
-        echo "Moving image to VM dir" && mv "${INPUT}" "${VM_PATH}"
-        CUSTOM_IMAGE_TYPE="img"
-    elif [[ "${INPUT}" == *".qcow2" ]]; then
-        echo "Moving image to VM dir" && mv "${INPUT}" "${VM_PATH}/disk.qcow2"
-        CUSTOM_IMAGE_TYPE="qcow2"
-    else
-        echo "ERROR! Only ISO,IMG and QCOW2 file types are supported for --create-config"
-        exit 1
-    fi
-    echo "Creating custom VM config for ${INPUT##*/}."
-    case "${INPUT,,}" in
-        *windows-server*) CUSTOM_OS="windows-server";;
-        *windows*) CUSTOM_OS="windows";;
-        *freebsd*) CUSTOM_OS="freebsd";;
-        *kolibrios*) CUSTOM_OS="kolibrios";;
-        *reactos*) CUSTOM_OS="reactos";;
-        *) CUSTOM_OS="linux";;
-    esac
-    echo "Selecting OS: ${CUSTOM_OS}. If this is incorrect, please modify the config file to include the correct OS."
-    echo
-    make_vm_config "${INPUT}"
-}
-
 function list_supported() {
     list_csv | cut -d ',' -f2,3,4 | tr ',' ' '
     exit 0
@@ -3324,6 +3279,56 @@ function create_vm() {
             fi;;
     esac
     make_vm_config "${ISO}"
+}
+
+function create_config() {
+    local VM_PATH="${1}"
+    local INPUT="${2}"
+    local FIXED_ISO=""
+
+    OS="custom"
+    if ! mkdir "${VM_PATH}" 2>/dev/null; then
+        echo "ERROR! Could not create directory: ${VM_PATH}. Please verify that it does not already exist"
+        exit 1
+    fi
+    if [[ "${INPUT}" == "http://"* ]] || [[ "${INPUT}" == "https://"* ]]; then
+        INPUT="$(web_redirect "${INPUT}")"
+        if [[ "${INPUT}" == *".iso" ]] || [[ "${INPUT}" == *".img" ]]; then
+            web_get "${INPUT}" "${VM_PATH}"
+            INPUT="${VM_PATH}/${INPUT##*/}"
+        else
+            echo "ERROR! Only ISO,IMG and QCOW2 file types are supported for --create-config"
+            exit 1
+        fi
+    fi
+    if [[ "${INPUT}" == *".iso" ]]; then
+        echo "Moving image to VM dir" && mv "${INPUT}" "${VM_PATH}"
+        CUSTOM_IMAGE_TYPE="iso"
+    elif [[ "${INPUT}" == *".img" ]]; then
+        echo "Moving image to VM dir" && mv "${INPUT}" "${VM_PATH}"
+        CUSTOM_IMAGE_TYPE="img"
+    elif [[ "${INPUT}" == *".qcow2" ]]; then
+        echo "Moving image to VM dir" && mv "${INPUT}" "${VM_PATH}/disk.qcow2"
+        CUSTOM_IMAGE_TYPE="qcow2"
+    else
+        echo "ERROR! Only ISO,IMG and QCOW2 file types are supported for --create-config"
+        exit 1
+    fi
+    echo "Creating custom VM config for ${INPUT##*/}."
+    case "${INPUT,,}" in
+        *windows-server*) CUSTOM_OS="windows-server";;
+        *windows*)
+            CUSTOM_OS="windows"
+            ;;
+
+        *freebsd*) CUSTOM_OS="freebsd";;
+        *kolibrios*) CUSTOM_OS="kolibrios";;
+        *reactos*) CUSTOM_OS="reactos";;
+        *) CUSTOM_OS="linux";;
+    esac
+    echo "Selecting OS: ${CUSTOM_OS}. If this is incorrect, please modify the config file to include the correct OS."
+    echo
+        make_vm_config "${INPUT}"
 }
 
 # Use command -v command to check if quickemu is in the system's PATH and

--- a/quickget
+++ b/quickget
@@ -3300,13 +3300,17 @@ function create_config() {
         INPUT="$(web_redirect "${INPUT}")"
         if [[ "${INPUT}" == *".iso" ]] || [[ "${INPUT}" == *".img" ]]; then
             web_get "${INPUT}" "${VM_PATH}"
-            INPUT="${VM_PATH}/${INPUT##*/}"
+            INPUT="${INPUT##*/}"
         else
             echo "ERROR! Only ISO,IMG and QCOW2 file types are supported for --create-config"
             exit 1
         fi
     fi
-    if [[ "${INPUT}" == *".iso" ]]; then
+
+    if [ ! -f "${INPUT}" ]; then
+        echo "ERROR! The input must be a valid URL or path to an ISO, IMG, or QCOW2 file."
+        exit 1
+    elif [[ "${INPUT}" == *".iso" ]]; then
         echo "Moving image to VM dir" && mv "${INPUT}" "${VM_PATH}"
         CUSTOM_IMAGE_TYPE="iso"
     elif [[ "${INPUT}" == *".img" ]]; then
@@ -3319,10 +3323,15 @@ function create_config() {
         echo "ERROR! Only ISO,IMG and QCOW2 file types are supported for --create-config"
         exit 1
     fi
+    INPUT="$(basename "${INPUT}")"
+
     echo "Creating custom VM config for ${INPUT##*/}."
     case "${INPUT,,}" in
-        *windows-server*) CUSTOM_OS="windows-server";;
-        *windows*)
+        *freebsd*) CUSTOM_OS="freebsd";;
+        *kolibrios*) CUSTOM_OS="kolibrios";;
+        *reactos*) CUSTOM_OS="reactos";;
+        *windows-server*|*eval_oemret_x*|*eval_x*) CUSTOM_OS="windows-server";;
+        *windows*|win*)
             CUSTOM_OS="windows"
             while [ $# -gt 2 ]; do
                 case "${3}" in
@@ -3338,18 +3347,10 @@ function create_config() {
             done
             ;;
 
-        *freebsd*) CUSTOM_OS="freebsd";;
-        *kolibrios*) CUSTOM_OS="kolibrios";;
-        *reactos*) CUSTOM_OS="reactos";;
         *) CUSTOM_OS="linux";;
     esac
-    echo "Selecting OS: ${CUSTOM_OS}. If this is incorrect, please modify the config file to include the correct OS."
-    echo
-    if [ -n "${FIXED_ISO}" ]; then
-        make_vm_config "${INPUT}" "${FIXED_ISO}"
-    else
-        make_vm_config "${INPUT}"
-    fi
+    echo -e "Selecting OS: ${CUSTOM_OS}. If this is incorrect, please modify the config file to include the correct OS.\n"
+    make_vm_config "${INPUT}" "${FIXED_ISO}"
 }
 
 # Use command -v command to check if quickemu is in the system's PATH and

--- a/quickget
+++ b/quickget
@@ -3339,7 +3339,7 @@ function create_config() {
                 echo
                 echo "Downloading VirtIO drivers..."
                 web_get "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso" "${VM_PATH}"
-                FIXED_ISO=${VM_PATH}/virtio-win.iso
+                FIXED_ISO="virtio-win.iso"
                 rm -f "${VM_PATH}/unattended.iso"
                 unattended_windows "${VM_PATH}"
             fi

--- a/quickget
+++ b/quickget
@@ -3324,6 +3324,18 @@ function create_config() {
         *windows-server*) CUSTOM_OS="windows-server";;
         *windows*)
             CUSTOM_OS="windows"
+            while [ $# -gt 2 ]; do
+                case "${3}" in
+                    -unattended|--unattended)
+                        echo "Downloading VirtIO drivers..."
+                        web_get "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso" "${VM_PATH}"
+                        FIXED_ISO=${VM_PATH}/virtio-win.iso
+
+                        rm -f "${VM_PATH}/unattended.iso"
+                        unattended_windows "${VM_PATH}"
+                        shift
+                esac
+            done
             ;;
 
         *freebsd*) CUSTOM_OS="freebsd";;
@@ -3333,7 +3345,11 @@ function create_config() {
     esac
     echo "Selecting OS: ${CUSTOM_OS}. If this is incorrect, please modify the config file to include the correct OS."
     echo
+    if [ -n "${FIXED_ISO}" ]; then
+        make_vm_config "${INPUT}" "${FIXED_ISO}"
+    else
         make_vm_config "${INPUT}"
+    fi
 }
 
 # Use command -v command to check if quickemu is in the system's PATH and
@@ -3373,11 +3389,14 @@ Advanced usage:
 
 Arguments:
   --download      <os> <release> [edition] : Download image; no VM configuration
-  --create-config <os> [path/url]          : Create VM config for a OS image
+  --create-config <os> [path/url] [flags]  : Create VM config for a OS image
   --open-homepage <os>                     : Open homepage for the OS
   --show          [os]                     : Show OS information
   --version                                : Show version
   --help                                   : Show this help message
+------------------------------------ Flags -------------------------------------
+--create-config:
+  --unattended                             : Unattended windows installation
 -------------------------- For testing & development ---------------------------
   --url           [os] [release] [edition] : Show image URL(s)
   --check         [os] [release] [edition] : Check image URL(s)

--- a/quickget
+++ b/quickget
@@ -2612,7 +2612,9 @@ function get_zorin() {
 }
 
 function unattended_windows() {
-    cat << 'EOF' > "${1}"
+    mkdir -p "${1}/unattended" 2>/dev/null
+
+    cat << 'EOF' > "${1}/unattended/autounattend.xml"
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend"
   xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
@@ -2894,6 +2896,15 @@ function unattended_windows() {
   </settings>
 </unattend>
 EOF
+
+
+echo "Downloading Spice drivers..."
+web_get https://www.spice-space.org/download/windows/spice-webdavd/spice-webdavd-x64-latest.msi "${VM_PATH}/unattended"
+web_get https://www.spice-space.org/download/windows/vdagent/vdagent-win-0.10.0/spice-vdagent-x64-0.10.0.msi "${VM_PATH}/unattended"
+web_get https://www.spice-space.org/download/windows/usbdk/UsbDk_1.0.22_x64.msi "${VM_PATH}/unattended"
+
+echo "Making unattended.iso"
+mkisofs -quiet -l -o "${VM_PATH}/unattended.iso" "${VM_PATH}/unattended/"
 }
 
 function handle_curl_error() {
@@ -3203,13 +3214,7 @@ function get_windows() {
     rm -f "${VM_PATH}/unattended.iso"
     case ${RELEASE} in
         10|11)
-            mkdir -p "${VM_PATH}/unattended" 2>/dev/null
-            web_get https://www.spice-space.org/download/windows/spice-webdavd/spice-webdavd-x64-latest.msi "${VM_PATH}/unattended"
-            web_get https://www.spice-space.org/download/windows/vdagent/vdagent-win-0.10.0/spice-vdagent-x64-0.10.0.msi "${VM_PATH}/unattended"
-            web_get https://www.spice-space.org/download/windows/usbdk/UsbDk_1.0.22_x64.msi "${VM_PATH}/unattended"
-            echo "Making unattended.iso"
-            unattended_windows "${VM_PATH}/unattended/autounattend.xml"
-            mkisofs -quiet -l -o "${VM_PATH}/unattended.iso" "${VM_PATH}/unattended/"
+            unattended_windows "${VM_PATH}"
             ;;
     esac
 


### PR DESCRIPTION
- **refactor: move create_config function to the bottom**
- **refactor: move unattended win installation code inside function**
- **feat: add --unattended flag to --create-config to create unattend.iso (windows hosts)**

# Description

Ability to pass in `--unattended` to `--create-config` to create unattended.iso and download VirtIO drivers for Windows guests.

- Closes #1369

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
- [x] I have made corresponding changes to the documentation (*remove if no documentation changes were required*)

