### PR TITLE
feat: allow skipping downloads using SIGINT

### DIFF
--- a/quickget
+++ b/quickget
@@ -1201,6 +1201,9 @@ function web_pipe() {
 
 # Download a file from the web
 function web_get() {
+
+    trap 'echo && echo "Skipping download" && echo; trap '"'exit'"' SIGINT' SIGINT
+
     local CHECK=""
     local HEADERS=()
     local URL="${1}"
@@ -1253,6 +1256,8 @@ function web_get() {
         echo "ERROR! Failed to download ${URL} with curl."
         rm -f "${DIR}/${FILE}"
     fi
+
+    trap 'exit' SIGINT
 }
 
 # checks if a URL needs to be redirected and returns the final URL


### PR DESCRIPTION

# Description

Downloads get skipped using SIGINT instead of terminating script

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
