### PR TITLE
fix: #1391 Change http to https endpoints for macos download

### DIFF
--- a/quickget
+++ b/quickget
@@ -2016,14 +2016,14 @@ function get_macos() {
 
     appleSession=$(curl -v -H "Host: osrecovery.apple.com" \
                            -H "Connection: close" \
-                           -A "InternetRecovery/1.0" http://osrecovery.apple.com/ 2>&1 | tr ';' '\n' | awk -F'session=|;' '{print $2}' | grep 1)
+                           -A "InternetRecovery/1.0" https://osrecovery.apple.com/ 2>&1 | tr ';' '\n' | awk -F'session=|;' '{print $2}' | grep 1)
     info=$(curl -s -X POST -H "Host: osrecovery.apple.com" \
                            -H "Connection: close" \
                            -A "InternetRecovery/1.0" \
                            -b "session=\"${appleSession}\"" \
                            -H "Content-Type: text/plain" \
                            -d $'cid='"$(generate_id 16)"$'\nsn='${MLB}$'\nbid='${BOARD_ID}$'\nk='"$(generate_id 64)"$'\nfg='"$(generate_id 64)"$'\nos='${OS_TYPE} \
-                           http://osrecovery.apple.com/InstallationPayload/RecoveryImage | tr ' ' '\n')
+                           https://osrecovery.apple.com/InstallationPayload/RecoveryImage | tr ' ' '\n')
     downloadLink=$(echo "$info" | grep 'oscdn' | grep 'dmg')
     downloadSession=$(echo "$info" | grep 'expires' | grep 'dmg')
     chunkListLink=$(echo "$info" | grep 'oscdn' | grep 'chunklist')


### PR DESCRIPTION
# Description
Change http to https on apple endpoints


- Fixes [#1391](https://github.com/quickemu-project/quickemu/issues/1391)


## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x ] I have performed a self-review of my code
- [x ] I have tested my code in common scenarios and confirmed there are no regressions


