### PR TITLE
refactor: remove redundant code from resolve_quickemu()

### DIFF
--- a/quickget
+++ b/quickget
@@ -3363,7 +3363,7 @@ function create_config() {
 # fallback to checking if quickemu is in the current directory.
 function resolve_quickemu() {   
     command -v quickemu || \
-    if [ -f "./quickemu" ]; then
+    if [ -x "./quickemu" ]; then
         echo "$(pwd)/quickemu"
     else
         echo "quickemu not found" >&2

--- a/quickget
+++ b/quickget
@@ -3361,10 +3361,9 @@ function create_config() {
 
 # Use command -v command to check if quickemu is in the system's PATH and
 # fallback to checking if quickemu is in the current directory.
-function resolve_quickemu() {
-    if command -v quickemu >/dev/null 2>&1; then
-        command -v quickemu
-    elif [ -f "./quickemu" ]; then
+function resolve_quickemu() {   
+    command -v quickemu || \
+    if [ -f "./quickemu" ]; then
         echo "$(pwd)/quickemu"
     else
         echo "quickemu not found" >&2


### PR DESCRIPTION
# Description

resolve_quickemu has inelegant test logic with redundant duplicate usage of `command`. This refactors resolve_quickemu slightly to remove the redundancy. It also changes the local fallback test to look for an executable file rather than just a file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
