### PR TITLE
fix: get sparky info from mirror

### DIFF
--- a/quickget
+++ b/quickget
@@ -991,12 +991,17 @@ function editions_solus() {
 
 function releases_sparkylinux() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f3 | sort -ru)
+    echo $(web_pipe "https://sparkylinux.org/download/stable/" |  grep -E -o "sparkylinux-.*\.iso\"" | cut -d'-' -f2 | sort -ru)
 }
 
 function editions_sparkylinux() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep "ISO image" | cut -d'-' -f5 | cut -d'.' -f 1 | sort -u)
+    if [ -z "${RELEASE}" ]; then
+        echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep -E -o "sparkylinux-.*\.iso\"" | cut -d'-' -f4 | cut -d'.' -f1 | sort -u)
+    else
+        echo $(web_pipe "https://sparkylinux.org/download/stable/" | grep -E -o "sparkylinux-${RELEASE}-.*\.iso\"" | cut -d'-' -f4 | cut -d'.' -f1 | sort -u)
+    fi
+    
 }
 
 function releases_spirallinux() {


### PR DESCRIPTION
# Description

Moved the logic for Sparky to parse a mirror listing as a possibly more reliable source as suggested.

- Fixes #1405

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions

