### PR TITLE
fix: dequote editions pipe

### DIFF
--- a/quickget
+++ b/quickget
@@ -3521,7 +3521,7 @@ if [ -n "${2}" ]; then
             fi
         else
             show_os_info "${OS}"
-            echo -e " - Editions:\t$("editions_${OS} | fmt -w 80")"
+            echo -e " - Editions:\t$(editions_${OS} | fmt -w 80)"
             echo -e "\nERROR! You must specify an edition."
             exit 1
         fi


### PR DESCRIPTION
# Description

Removed unneeded quotes that cause confusing `command not found` errors.


- Closes #1395

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions

