### PR TITLE
fix: use double brackets for if clause with and & or concatenation

### DIFF
--- a/quickget
+++ b/quickget
@@ -1457,8 +1457,8 @@ EOF
             echo "disk_size=\"64G\"" >> "${CONF_FILE}"
         fi
 
-        # Enable TPM for Windows 11
-        if [ "${OS}" == "windows" ] && [ "${RELEASE}" == "11" ] || [ "${OS}" == "windows-server" ] && [ "${RELEASE}" == "2022" ]; then
+        # Enable TPM for Windows 11 and Windows Server 2022
+        if [[ "${OS}" == "windows" && "${RELEASE}" == "11" || "${OS}" == "windows-server" && "${RELEASE}" == "2022" ]]; then
             echo "tpm=\"on\"" >> "${CONF_FILE}"
             echo "secureboot=\"off\"" >> "${CONF_FILE}"
         fi


### PR DESCRIPTION
Previous if clause does not work with Bash version 5.2.15(1)-release (x86_64-pc-linux-gnu)
for OS="windows" and RELEASE="11"
(leads to missing `tpm="on"` line in .conf resulting file)

Fixes #1387

## Type of change

[x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
