### PR TITLE
fix: specify helper to qemu

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1328,7 +1328,7 @@ function vm_boot() {
         fi
 
         # shellcheck disable=SC2054,SC2206
-        args+=(-nic bridge,br=${network},model=virtio-net-pci${MAC})
+        args+=(-nic bridge,br=${network},helper=$(type -p qemu-bridge-helper),model=virtio-net-pci${MAC})
     else
         echo " - Network:  User (${NET_DEVICE})"
         # shellcheck disable=SC2054,SC2206


### PR DESCRIPTION
# Description
Without this change I could not launch a vm with a network configured. `network="br0"`
```
failed to create tun device: Operation not permitted
qemu-system-x86_64: -nic bridge,br=br0,model=virtio-net-pci: bridge helper failed
```
Tested on nixos. Maybe there is a better way to get it to work, feel free to let me know and close this PR in that case :)  


## Type of change
Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
