### PR TITLE
Fix: set RTC to localtime only for Windows/ReactOS/DOS and UTC for all others

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1198,7 +1198,7 @@ function vm_boot() {
         args+=(-rtc base=localtime,clock=host,driftfix=slew)
     else
         # shellcheck disable=SC2054
-        args+=(-rtc base=utc,clock=host,driftfix=slew)
+        args+=(-rtc base=utc,clock=host)
     fi
 
     # shellcheck disable=SC2206

--- a/quickemu
+++ b/quickemu
@@ -1191,8 +1191,15 @@ function vm_boot() {
     args+=(-machine ${MACHINE_TYPE},smm=${SMM},vmport=off,accel=${QEMU_ACCEL} ${GUEST_TWEAKS}
         ${CPU} ${SMP}
         -m ${RAM_VM} ${BALLOON}
-        -rtc base=localtime,clock=host,driftfix=slew
         -pidfile "${VMDIR}/${VMNAME}.pid")
+
+    if [ "${guest_os}" == "windows" ] || [ "${guest_os}" == "windows-server" ] || [ "${guest_os}" == "reactos" ] || [ "${guest_os}" == "freedos" ]; then
+        # shellcheck disable=SC2054
+        args+=(-rtc base=localtime,clock=host,driftfix=slew)
+    else
+        # shellcheck disable=SC2054
+        args+=(-rtc base=utc,clock=host,driftfix=slew)
+    fi
 
     # shellcheck disable=SC2206
     args+=(${VIDEO} -display ${DISPLAY_RENDER})


### PR DESCRIPTION
# Description

Windows/ReactOS/DOS conventionally set the system RTC to local time, but Linux/UNIX/macOS use UTC. Guest systems that expect UTC and have the time zone set to local time will have the wrong system clock time at startup until they set the clock with NTP. This is especially an issue for disk images imported from or shared with another VM configuration that uses UTC for non-Windows guests.

Further, according to the QEMU man page:

> Enable driftfix (i386 targets only) if you experience time drift problems, specifically with Windows' ACPI HAL. This option will try to figure out how many timer interrupts were not processed by the Windows guest and will re-inject them.

This option thus seems unnecessary for other systems and may cause performance or timekeeping issues, so enable only for Windows/ReactOS/DOS.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have tested my code in common scenarios and confirmed there are no regressions
