### PR TITLE
fix: Use 1 as default sockets value

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -323,6 +323,10 @@ function configure_cpu() {
     HOST_CPU_SOCKETS=$(get_cpu_info 'Socket')
     HOST_CPU_VENDOR=$(get_cpu_info 'Vendor')
 
+    if [ "${HOST_CPU_SOCKETS}" = "-" ]; then
+        HOST_CPU_SOCKETS=1
+    fi
+
     CPU_MODEL="host"
     QEMU_ACCEL="tcg"
     # Configure appropriately for the host platform


### PR DESCRIPTION
# Description

lscpu populates the sockets field with '-' if the number of sockets it's determined is equal to 0 (which is accurately treated as a null value). Replace this value with 1 to fix invalid values being passed to qemu. 

<!-- Close any related issues. Delete if not relevant -->

- Fixes #1428

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
