### PR TITLE
remove popos 21.10

### DIFF
--- a/quickget
+++ b/quickget
@@ -900,7 +900,7 @@ function editions_peppermint() {
 }
 
 function releases_popos() {
-    echo 22.04 21.10 20.04
+    echo 22.04 20.04
 }
 
 function editions_popos() {


### PR DESCRIPTION
this is an unsupported release now

# Description

Remove Pop!_OS 21.10 release

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
- [ ] I have made corresponding changes to the documentation (*remove if no documentation changes were required*)
