### PR TITLE
fix: Use ALSA on systems without a PulseAudio daemon

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -878,12 +878,18 @@ function configure_storage() {
 }
 
 function configure_display() {
+    # Determine which audio driver use between Pulseaudio or ALSA
+    local AUDIO_DRIVER="pa"
+    if ! command -v pacmd >/dev/null 2>&1 ; then
+      AUDIO_DRIVER="alsa"
+    fi
+
     # Setup the appropriate audio device based on the display output
     # https://www.kraxel.org/blog/2020/01/qemu-sound-audiodev/
     case ${display} in
         cocoa) AUDIO_DEV="coreaudio,id=audio0";;
         none|spice|spice-app) AUDIO_DEV="spice,id=audio0";;
-        *) AUDIO_DEV="pa,id=audio0";;
+        *) AUDIO_DEV="${AUDIO_DRIVER},id=audio0";;
     esac
 
     # Determine a sane resolution for Linux guests.

--- a/quickemu
+++ b/quickemu
@@ -881,7 +881,7 @@ function configure_display() {
     # Determine which audio driver use between Pulseaudio or ALSA
     local AUDIO_DRIVER="pa"
     if ! command -v pacmd >/dev/null 2>&1 ; then
-      AUDIO_DRIVER="alsa"
+        AUDIO_DRIVER="alsa"
     fi
 
     # Setup the appropriate audio device based on the display output


### PR DESCRIPTION
Quickemu actualy don't even start if pulseaudio is not installed.

    qemu-system-x86_64: could not stat pidfile /run/user/1000/pulse/pid: No such file or directory

ALSA should be working on QEMU :), a simple solution is to test if `pacmd` is
currently installed.
