### PR TITLE
fix: blendOS now has a single current iso

### DIFF
--- a/quickget
+++ b/quickget
@@ -583,13 +583,8 @@ function editions_biglinux() {
 }
 
 function releases_blendos() {
-    #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://mirror.ico277.xyz/blendos/gnome/" | grep "\.iso" | cut -c81- | cut -d'"' -f2 | cut -d'-' -f2)
-}
-
-function editions_blendos() {
-    #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://mirror.ico277.xyz/blendos/" | grep "\[DIR\]" | cut -c81-90 | cut -d'/' -f1 | grep -v testing | sort -u)
+    # there is now just a single latest iso
+    echo Latest
 }
 
 function releases_bodhi() {
@@ -1616,8 +1611,8 @@ function get_biglinux() {
 
 function get_blendos() {
     local HASH=""
-    local ISO="blendos-${RELEASE}-stable-${EDITION}.iso"
-    local URL="https://mirror.ico277.xyz/blendos/${EDITION}"
+    local ISO="blendOS.iso"
+    local URL="https://kc1.mirrors.199693.xyz/blend/isos/testing"
     echo "${URL}/${ISO} ${HASH}"
 }
 


### PR DESCRIPTION
# Description

BlendOS now has only a single release iso that is replaced and has a rather unfriendly version tag.  The user will need to supply "Latest" as the RELEASE

Selected a reasonable mirror as the old choice proved unreliable (generally broken in fact). Ideally a local up-to-date mirror might be parsed but for now just pick a working fast up-to-date mirror to correct the breakage.

Resolves #1437

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
