### PR TITLE
fix: CachyOS downloads

### DIFF
--- a/quickget
+++ b/quickget
@@ -1645,7 +1645,7 @@ function get_bunsenlabs() {
 function get_cachyos() {
     local HASH=""
     local URL=""
-    URL="$(web_pipe "https://cachyos.org/download/" | tr '&' '\n' | grep "ISO/${EDITION}" | cut -d';' -f2)"
+    URL="$(web_pipe "https://cachyos.org/download/" | tr '&' '\n' | grep "ISO/${EDITION}" | grep -v 'iso.sha' | grep -v 'iso.sig' | cut -d';' -f2)"
     HASH=$(web_pipe "${URL}.sha256" | cut -d' ' -f1)
     echo "${URL} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -1645,9 +1645,7 @@ function get_bunsenlabs() {
 function get_cachyos() {
     local HASH=""
     local URL=""
-    local ISO=""
     URL="$(web_pipe "https://cachyos.org/download/" | tr '&' '\n' | grep "ISO/${EDITION}" | cut -d';' -f2)"
-    ISO="$(basename "${ISO}")"
     HASH=$(web_pipe "${URL}.sha256" | cut -d' ' -f1)
     echo "${URL} ${HASH}"
 }

--- a/quickget
+++ b/quickget
@@ -609,8 +609,7 @@ function releases_cachyos() {
 }
 
 function editions_cachyos() {
-    #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://mirror.cachyos.org/ISO/" | grep "title=" | grep -v testing | grep -v cli | cut -d'"' -f4 | cut -d '/' -f1 | sort)
+    echo desktop handheld
 }
 
 function releases_centos-stream() {
@@ -1643,12 +1642,12 @@ function get_bunsenlabs() {
 
 function get_cachyos() {
     local HASH=""
-    local REL=""
-    local URL="https://mirror.cachyos.org/ISO/${EDITION}/"
-    REL=$(web_pipe "${URL}" | grep -o '>[0-9]*/</a>' | grep -o '[0-9]*' | sort -ru | tail -n 1)
-    local ISO="cachyos-${EDITION}-linux-${REL}.iso"
-    HASH=$(web_pipe "${URL}/${REL}/${ISO}.sha256" | cut -d' ' -f1)
-    echo "${URL}/${REL}/${ISO} ${HASH}"
+    local URL=""
+    local ISO=""
+    URL="$(web_pipe "https://cachyos.org/download/" | tr '&' '\n' | grep "ISO/${EDITION}" | cut -d';' -f2)"
+    ISO="$(basename "${ISO}")"
+    HASH=$(web_pipe "${URL}.sha256" | cut -d' ' -f1)
+    echo "${URL} ${HASH}"
 }
 
 function get_centos-stream() {

--- a/quickget
+++ b/quickget
@@ -605,10 +605,12 @@ function releases_bunsenlabs() {
 }
 
 function releases_cachyos() {
+    # new cdn setup 10/2024
     echo latest
 }
 
 function editions_cachyos() {
+    # desktop version now installs different desktop environments
     echo desktop handheld
 }
 


### PR DESCRIPTION
Updates to new cdn

fixes  empty  elements in urls  eg. https://mirror.cachyos.org/ISO/kde///cachyos-kde-linux-.iso

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
