### PR TITLE
fix: increase default disk size for bazzite to 64GB minimum

### DIFF
--- a/quickget
+++ b/quickget
@@ -1391,6 +1391,8 @@ EOF
                 echo "disk_size=\"32G\"" >> "${CONF_FILE}";;
             batocera)
                 echo "disk_size=\"8G\"" >> "${CONF_FILE}";;
+            bazzite)
+                echo "disk_size=\"64G\"" >> "${CONF_FILE}";;
             dragonflybsd|haiku|openbsd|netbsd|slackware|slax|tails|tinycore)
                 echo "boot=\"legacy\"" >> "${CONF_FILE}";;
             deepin)


### PR DESCRIPTION
# Description

Increase virtual disk size to the minumum install size required.

See https://docs.bazzite.gg/General/Installation_Guide/Installing_Bazzite_for_Desktop_or_Laptop_Hardware/#minimum-system-requirements