### PR TITLE
fix(fedora): Check whether the link value contains an actual .iso file

### DIFF
--- a/quickget
+++ b/quickget
@@ -1823,7 +1823,7 @@ function get_fedora() {
 
 
     # shellcheck disable=SC2086
-    JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select(.variant=="'${VARIANT}'" and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'" and (.link | test(".*\\.iso$")))')
+    JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select(.variant=="'${VARIANT}'" and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'" and (.link | endswith(".iso")))')
     URL=$(echo "${JSON}" | jq -r '.link' | head -n1)
     HASH=$(echo "${JSON}" | jq -r '.sha256' | head -n1)
     echo "${URL} ${HASH}"

--- a/quickget
+++ b/quickget
@@ -1820,10 +1820,10 @@ function get_fedora() {
         RELEASE="${RELEASE/_/ }"
     fi
 
-    
+
 
     # shellcheck disable=SC2086
-    JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select(.variant=="'${VARIANT}'" and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'" and .sha256 != null)')
+    JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select(.variant=="'${VARIANT}'" and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'" and (.link | test(".*\\.iso$")))')
     URL=$(echo "${JSON}" | jq -r '.link' | head -n1)
     HASH=$(echo "${JSON}" | jq -r '.sha256' | head -n1)
     echo "${URL} ${HASH}"


### PR DESCRIPTION
Fixes #1502

# Description
Make sure to download the `.iso` for Fedora Atomic Editions instead of the `.ociarchive` by checking the `.link` field for a regex match.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have tested my code in common scenarios and confirmed there are no regressions


