### PR TITLE
fix(windows): Use new Microsoft JSON API to fix URL generation

### DIFF
--- a/quickget
+++ b/quickget
@@ -1769,7 +1769,7 @@ function get_elementary() {
     case ${RELEASE} in
         7.0) STAMP="20230129rc";;
         7.1) STAMP="20230926rc";;
-        8.0) STAMP="20241122rc";;        
+        8.0) STAMP="20241122rc";;
     esac
     local ISO="elementaryos-${RELEASE}-stable.${STAMP}.iso"
     local URL="https://ams3.dl.elementary.io/download"
@@ -3130,9 +3130,9 @@ function download_windows_workstation() {
     local session_id=""
     local iso_download_page_html=""
     local product_edition_id=""
-    local language_skuid_table_html=""
+    local language_skuid_table_json=""
     local sku_id=""
-    local iso_download_link_html=""
+    local iso_download_link_json=""
     local iso_download_link=""
 
     echo "Downloading Windows ${RELEASE} (${I18N})"
@@ -3177,41 +3177,33 @@ function download_windows_workstation() {
         return $?
     }
 
-    # Extract everything after the last slash
-    local url_segment_parameter="${url##*/}"
+    local profile="606624d44113"
 
     echo -n " - Getting language SKU ID: "
     # Get language -> skuID association table
-    # SKU ID: This specifies the language of the ISO. We always use "English (United States)", however, the SKU for this changes with each Windows release
-    # We must make this request so our next one will be allowed
-    # --data "" is required otherwise no "Content-Length" header will be sent causing HTTP response "411 Length Required"
-    language_skuid_table_html="$(curl --silent --request POST --user-agent "$user_agent" --data "" --header "Accept:" --max-filesize 10K --fail --proto =https --tlsv1.2 --http1.1 -- "https://www.microsoft.com/en-US/api/controls/contentinclude/html?pageId=a8f8f489-4c7f-463a-9ca6-5cff94d8d041&host=www.microsoft.com&segments=software-download,$url_segment_parameter&query=&action=getskuinformationbyproductedition&sessionId=$session_id&productEditionId=$product_edition_id&sdVersion=2")" || {
+    language_skuid_table_json="$(curl -s --fail --max-filesize 100K --proto =https --tlsv1.2 --http1.1 "https://www.microsoft.com/software-download-connector/api/getskuinformationbyproductedition?profile=${profile}&ProductEditionId=${product_edition_id}&SKU=undefined&friendlyFileName=undefined&Locale=en-US&sessionID=${session_id}")" || {
         handle_curl_error $?
         return $?
     }
 
-    # Limit untrusted size for input validation
-    language_skuid_table_html="$(echo "$language_skuid_table_html" | head -c 10240)"
-
-    # tr: Filter for only alphanumerics or "-" to prevent HTTP parameter injection
-    sku_id="$(echo "$language_skuid_table_html" | grep "${I18N}" | sed 's/&quot;//g' | cut -d ',' -f 1  | cut -d ':' -f 2 | tr -cd '[:alnum:]-' | head -c 16)"
+    sku_id="$(echo "${language_skuid_table_json}" | jq -r '.Skus[] | select(.LocalizedLanguage=="'"${I18N}"'").Id')"
     echo "$sku_id"
 
     echo " - Getting ISO download link..."
     # Get ISO download link
     # If any request is going to be blocked by Microsoft it's always this last one (the previous requests always seem to succeed)
     # --referer: Required by Microsoft servers to allow request
-    iso_download_link_html="$(curl --silent --request POST --user-agent "$user_agent" --data "" --referer "$url" --header "Accept:" --max-filesize 100K --fail --proto =https --tlsv1.2 --http1.1 -- "https://www.microsoft.com/en-US/api/controls/contentinclude/html?pageId=6e2a1789-ef16-4f27-a296-74ef7ef5d96b&host=www.microsoft.com&segments=software-download,$url_segment_parameter&query=&action=GetProductDownloadLinksBySku&sessionId=$session_id&skuId=$sku_id&language=English&sdVersion=2")"
+    iso_download_link_json="$(curl -s --fail --referer "$url" "https://www.microsoft.com/software-download-connector/api/GetProductDownloadLinksBySku?profile=${profile}&productEditionId=undefined&SKU=${sku_id}&friendlyFileName=undefined&Locale=en-US&sessionID=${session_id}")"
 
     local failed=0
 
-    if ! [ "$iso_download_link_html" ]; then
+    if ! [ "$iso_download_link_json" ]; then
         # This should only happen if there's been some change to how this API works
         echo " - Microsoft servers gave us an empty response to our request for an automated download."
         failed=1
     fi
 
-    if echo "$iso_download_link_html" | grep -q "We are unable to complete your request at this time."; then
+    if echo "$iso_download_link_json" | grep -q "Sentinel marked this request as rejected."; then
         echo " - WARNING! Microsoft blocked the automated download request based on your IP address."
         failed=1
     fi
@@ -3225,9 +3217,7 @@ function download_windows_workstation() {
     fi
 
     # Filter for 64-bit ISO download URL
-    # sed: HTML decode "&" character
-    # tr: Filter for only alphanumerics or punctuation
-    iso_download_link="$(echo "$iso_download_link_html" | grep -o "https://software.download.prss.microsoft.com.*IsoX64" | cut -d '"' -f 1 | sed 's/&amp;/\&/g' | tr -cd '[:alnum:][:punct:]')"
+    iso_download_link="$(echo "${iso_download_link_json}" | jq -r '.ProductDownloadOptions[].Uri' | grep x64)"
 
     if ! [ "$iso_download_link" ]; then
         # This should only happen if there's been some change to the download endpoint web address


### PR DESCRIPTION
# Description

Update download_windows_workstation function to use Microsoft's new JSON API to fetch skuid & url. The previous method no longer is functional.

<!-- Close any related issues. Delete if not relevant -->

- Resolves #1528

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections