### PR TITLE
fix: TrueNAS Scale download

### DIFF
--- a/quickget
+++ b/quickget
@@ -1061,7 +1061,7 @@ function releases_truenas-core() {
 }
 
 function releases_truenas-scale() {
-    echo 23
+    echo 24
 }
 
 function releases_tuxedo-os() {

--- a/quickget
+++ b/quickget
@@ -698,7 +698,7 @@ function releases_endeavouros() {
 }
 
 function releases_endless() {
-    echo 5.1.1
+    echo 6.0.4
 }
 
 function editions_endless() {
@@ -1798,11 +1798,11 @@ function get_endless() {
     # Endless edition names are "base" for the small minimal one or the Language for the large full release
     # The isos are stamped as they are finished so ....
     case ${EDITION} in
-        base)  FILE_TS="240103-025438";;
-        en)    FILE_TS="240103-025437";;
-        es)    FILE_TS="240103-025438";;
-        fr)    FILE_TS="240103-025438";;
-        pt_BR) FILE_TS="240103-030103";;
+        base)  FILE_TS="241023-183516";;
+        en)    FILE_TS="241023-200926";;
+        es)    FILE_TS="241023-184649";;
+        fr)    FILE_TS="241023-191212";;
+        pt_BR) FILE_TS="241023-191427";;
     esac
     URL="https://images-dl.endlessm.com/release/${RELEASE}/eos-amd64-amd64/${EDITION}"
     ISO="eos-eos${RELEASE:0:3}-amd64-amd64.${FILE_TS}.${EDITION}.iso"


### PR DESCRIPTION
# Description

Release 23 has been replaced by 24 on https://www.truenas.com/download-truenas-scale/, which causes downloads to fail.

Also update Endless OS while we are at it.

Please include a summary of the changes along with any relevant motivation and context.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
