### PR TITLE
fix(windows): Fix the download of the Chinese Windows ISO.

### DIFF
--- a/quickget
+++ b/quickget
@@ -3186,7 +3186,7 @@ function download_windows_workstation() {
         return $?
     }
 
-    sku_id="$(echo "${language_skuid_table_json}" | jq -r '.Skus[] | select(.LocalizedLanguage=="'"${I18N}"'").Id')"
+    sku_id="$(echo "${language_skuid_table_json}" | jq -r '.Skus[] | select(.LocalizedLanguage=="'"${I18N}"'" or .Language=="'"${I18N}"'").Id')"
     echo "$sku_id"
 
     echo " - Getting ISO download link..."


### PR DESCRIPTION
# Description

In Microsoft's new JSON API to fetch skuid & url, the response are:
```json
{
    "Skus": [
        ……,
        {
            "Id": "18474",
            "Description": "Redstone Windows Consumer x64 OEM/Retail ZH-CN DVD9",
            "ProductDisplayName": "Windows 11 24H2",
            "Language": "Chinese (Simplified)",
            "LocalizedLanguage": "Chinese Simplified",
            "LocalizedProductDisplayName": "Windows 11  Chinese (Simplified)",
            "ProductEditionName": null,
            "FriendlyFileNames": [
                "Win11_24H2_Chinese_Simplified_x64.iso"
            ]
        },
        ……,
        {
            "Id": "18480",
            "Description": "Redstone Windows Consumer x64 OEM/Retail en-us DVD9",
            "ProductDisplayName": "Windows 11 24H2",
            "Language": "English",
            "LocalizedLanguage": "English (United States)",
            "LocalizedProductDisplayName": "Windows 11  English",
            "ProductEditionName": null,
            "FriendlyFileNames": [
                "Win11_24H2_English_x64.iso"
            ]
        },
        ……
    ],
    ……
}
```

The LocalizedLanguage does not match "Chinese (Simplified)" because it is labeled as "Chinese Simplified", although the Language field is working properly.

Resolves https://github.com/quickemu-project/quickemu/issues/1528

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions

