### PR TITLE
fix(macos): Correct version user receives from quickget; add sequoia

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -414,7 +414,7 @@ function configure_cpu() {
             # A CPU with fma is required for Metal support
             # A CPU with invtsc is required for macOS to boot
             case ${macos_release} in
-                ventura|sonoma)
+                ventura|sonoma|sequoia)
                     # A CPU with AVX2 support is required for >= macOS Ventura
                     if check_cpu_flag sse4_2 && check_cpu_flag avx2; then
                         if [ "${HOST_CPU_VENDOR}" != "GenuineIntel" ] && [ -z "${HYPERVISOR}" ]; then
@@ -766,7 +766,7 @@ function configure_os_quirks() {
             #   * VirtIO Memory Balloning is supported since Big Sur (https://pmhahn.github.io/virtio-balloon/)
             #   * VirtIO RNG is supported since Big Sur, but exposed to all guests by default.
             case ${macos_release} in
-                big-sur|monterey|ventura|sonoma)
+                big-sur|monterey|ventura|sonoma|sequoia)
                     BALLOON="-device virtio-balloon"
                     MAC_DISK_DEV="virtio-blk-pci"
                     NET_DEVICE="virtio-net"

--- a/quickget
+++ b/quickget
@@ -2063,7 +2063,7 @@ function get_macos() {
         ventura|13)
             BOARD_ID="Mac-BE088AF8C5EB4FA2";;
         sonoma|14)
-            BOARD_ID="Mac-53FDB3D8DB8CA971";;
+            BOARD_ID="Mac-827FAC58A8FDFA22";;
         *) echo "ERROR! Unknown release: ${RELEASE}"
            releases_macos
            exit 1;;

--- a/quickget
+++ b/quickget
@@ -822,7 +822,7 @@ function releases_maboxlinux() {
 }
 
 function releases_macos() {
-    echo mojave catalina big-sur monterey ventura sonoma
+    echo mojave catalina big-sur monterey ventura sonoma sequoia
 }
 
 function releases_mageia() {
@@ -2064,6 +2064,8 @@ function get_macos() {
             BOARD_ID="Mac-BE088AF8C5EB4FA2";;
         sonoma|14)
             BOARD_ID="Mac-827FAC58A8FDFA22";;
+        sequoia|15)
+            BOARD_ID="Mac-53FDB3D8DB8CA971";;
         *) echo "ERROR! Unknown release: ${RELEASE}"
            releases_macos
            exit 1;;


### PR DESCRIPTION
# Description

Use the "Mac-827FAC58A8FDFA22" board ID (MacBookAir8,1) to download the Sonoma BaseSystem.dmg file.

> According to https://github.com/kholia/OSX-KVM/commit/ad213b6c80cbe9fdcd661832bb2ade8ec2b47a76#diff-1685371f8911f8e43b5420735f31cd5ec4dc7aedd7978a010abe4913af16c16aR541

Resolves #1501


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions

