### PR TITLE
chore: use https for git submodules to use CA PKI instead of SSH TOFU

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build-docs"]
 	path = build-docs
-	url = git@github.com:philclifford/quickemu-docs.git
+	url = https://github.com/philclifford/quickemu-docs.git


### PR DESCRIPTION
# Description

For users just cloning this, ssh is incontinent because of 

```
The authenticity of host 'github.com (140.82.121.4)' can't be established.                                                                                    
ED25519 key fingerprint is SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU.                                                                                
This key is not known by any other names.                                                                                                                     
Are you sure you want to continue connecting (yes/no/[fingerprint])? no        
Host key verification failed.                                                                                                                                 
fatal: Could not read from remote repository.
```

Defaulting to HTTPS avoids this.

<!-- Close any related issues. Delete if not relevant -->

- Closes #
- Fixes #
- Resolves #

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Packaging (updates the packaging)
- [ ] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
- [x] I have made corresponding changes to the documentation (*remove if no documentation changes were required*)
