### PR TITLE
fix: Allow non-v24 arcolinux releases

### DIFF
--- a/quickget
+++ b/quickget
@@ -545,9 +545,7 @@ function releases_archlinux() {
 
 function releases_arcolinux() {
     #shellcheck disable=SC2046,SC2005
-    # breaking change in v24.05
-    # v24.05.1 is the first release with the new naming scheme and too complex to parse old and new so just show the new
-    echo $(web_pipe "https://mirror.accum.se/mirror/arcolinux.info/iso/" | grep -o -E -e "v24.0[5-9].[[:digit:]]{2}"  -e "v24.1[0-2].[[:digit:]]{2}" | sort -ru | head -n 5)
+    echo $(web_pipe "https://mirror.accum.se/mirror/arcolinux.info/iso/" | grep -o -E -e "v[[:digit:]]{2}.[[:digit:]]{2}.[[:digit:]]{2}" | sort -ru | head -n 5)
 }
 
 function editions_arcolinux() {


### PR DESCRIPTION
# Description

Quickget was modified to only allow arcolinux versions with the major release being 24 and minor being 06 or above, due to a change in editions taking place at that point. This is no longer necessary, as the latest 5 releases are well past this change. Version 25 has been released and isn't matched by the current regex.

<!-- Close any related issues. Delete if not relevant -->

- Resolves #1574

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
