### PR TITLE
fix: move creation of script before functions that may update it

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1187,6 +1187,8 @@ function vm_boot() {
     # Set the hostname of the VM
     NET="user,hostname=${VMNAME}"
 
+    echo "#!/usr/bin/env bash" > "${VMDIR}/${VMNAME}.sh"
+
     configure_cpu
     configure_ram
     configure_bios
@@ -1198,8 +1200,6 @@ function vm_boot() {
     configure_file_sharing
     configure_usb
     configure_tpm
-
-    echo "#!/usr/bin/env bash" > "${VMDIR}/${VMNAME}.sh"
 
     # Changing process name is not supported on macOS
     if [ "${OS_KERNEL}" == "Linux" ]; then


### PR DESCRIPTION
# Description

Move the initialisation of the script to above the functions so that changes they might make (e.g. `configure_tpm`) are retained. 

- Fixes #1573


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested my code in common scenarios and confirmed there are no regressions

