### PR TITLE
fix: Secure Boot does not work for Linux guests

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -673,7 +673,7 @@ function configure_bios() {
         if [ -n "${EFI_CODE}" ] || [ ! -e "${EFI_CODE}" ]; then
             case ${secureboot} in
                 on) # shellcheck disable=SC2054,SC2140
-                    ovmfs=("${SHARE_PATH}/OVMF/OVMF_CODE_4M.secboot.fd","${SHARE_PATH}/OVMF/OVMF_VARS_4M.fd" \
+                    ovmfs=("${SHARE_PATH}/OVMF/OVMF_CODE_4M.secboot.fd","${SHARE_PATH}/OVMF/OVMF_VARS_4M.ms.fd" \
                         "${SHARE_PATH}/edk2/ovmf/OVMF_CODE.secboot.fd","${SHARE_PATH}/edk2/ovmf/OVMF_VARS.secboot.fd" \
                         "${SHARE_PATH}/OVMF/x64/OVMF_CODE.secboot.fd","${SHARE_PATH}/OVMF/x64/OVMF_VARS.fd" \
                         "${SHARE_PATH}/edk2-ovmf/OVMF_CODE.secboot.fd","${SHARE_PATH}/edk2-ovmf/OVMF_VARS.fd" \

--- a/quickemu
+++ b/quickemu
@@ -395,6 +395,16 @@ function configure_cpu() {
         fi
     fi
 
+    # SMM is also required for Linux guests when Secure Boot is enabled
+    if [ "${secureboot}" == "on" ]; then
+        if [ "${guest_os}" == "linux" ]; then
+        # SMM is not available on QEMU for macOS via Homebrew
+            if [ "${OS_KERNEL}" == "Linux" ]; then
+                SMM="on"
+            fi
+        fi
+    fi
+
     case ${guest_os} in
         batocera|freedos|haiku|solaris) MACHINE_TYPE="pc";;
         kolibrios|reactos)

--- a/quickemu
+++ b/quickemu
@@ -674,7 +674,7 @@ function configure_bios() {
             case ${secureboot} in
                 on) # shellcheck disable=SC2054,SC2140
                     ovmfs=("${SHARE_PATH}/OVMF/OVMF_CODE_4M.secboot.fd","${SHARE_PATH}/OVMF/OVMF_VARS_4M.fd" \
-                        "${SHARE_PATH}/edk2/ovmf/OVMF_CODE.secboot.fd","${SHARE_PATH}/edk2/ovmf/OVMF_VARS.fd" \
+                        "${SHARE_PATH}/edk2/ovmf/OVMF_CODE.secboot.fd","${SHARE_PATH}/edk2/ovmf/OVMF_VARS.secboot.fd" \
                         "${SHARE_PATH}/OVMF/x64/OVMF_CODE.secboot.fd","${SHARE_PATH}/OVMF/x64/OVMF_VARS.fd" \
                         "${SHARE_PATH}/edk2-ovmf/OVMF_CODE.secboot.fd","${SHARE_PATH}/edk2-ovmf/OVMF_VARS.fd" \
                         "${SHARE_PATH}/qemu/ovmf-x86_64-smm-ms-code.bin","${SHARE_PATH}/qemu/ovmf-x86_64-smm-ms-vars.bin" \


### PR DESCRIPTION
# Description

This change contains two fixes which ought to take the functionality of Secure Booting Linux guests in Quickemu from non-functional to a working state.

### SMM fix
Commit b9735800f3b2b5d66aec6e984db9d43cb6e9c4c3 should stand alone and resolve #1578. This enables SMM for Linux guests on Linux hosts when Secure Boot has been enabled.

### Microsoft Platform Key fix (partial)
Commit 8add3185e075c466a0d0692d5c87f1d5ad671362 is an example of an initial commit which will probably need wider expansion and partially resolves #413. This configures Quickemu to prefer the `*.secboot.*` version of the `OVMF_VARS` `.fd` file, which is the one which has the Microsoft Platform Keys preloaded into it.

I'm honestly less sure about this second fix as although it makes sense to me (the `*.secboot.*` file is needed to have _full_ Secure Boot working, rather than just Secure Boot stuck in Platform Setup Mode), I note that Quickemu also supports Windows 11 which makes Secure Boot mandatory, but I couldn't work out how that support was being provided.

I'll do some digging, but it's possible that the Secure Boot config for Windows 11 also hasn't been using the Microsoft Platform Keys up until now, meaning it is effectively doing nothing in Quickemu's current state.

This commit will also need expanding. Currently not every distribution ships the Microsoft PK enrolled VARS files, and the ones that do seem to put them in different places. I'm happy to go hunting around the common host distros that people might be using for Quickemu if this commit is reviewed as sensible and expand the search list for these files with pre-enrolled keys, but for now this fix only applies to Fedora as a host distro (or anything else that uses the exact same path on disk as Fedora does for these files).

- Closes #413 
- Resolves #1578

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
  - Presented as a draft for now - more testing needed once code is reviewed as generally sensible
- [x] I have added comments to my code, particularly in hard-to-understand sections
