### PR TITLE
fix: Use the pcnet ethernet device for FreeDOS

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -742,7 +742,7 @@ function configure_bios() {
 
 function configure_os_quirks() {
 
-    if [ "${guest_os}" == "batocera" ] || [ "${guest_os}" == "freedos" ] || [ "${guest_os}" == "haiku" ] || [ "${guest_os}" == "kolibrios" ]; then
+    if [ "${guest_os}" == "batocera" ] || [ "${guest_os}" == "haiku" ] || [ "${guest_os}" == "kolibrios" ]; then
         NET_DEVICE="rtl8139"
     fi
 
@@ -753,7 +753,8 @@ function configure_os_quirks() {
     case ${guest_os} in
         windows-server) NET_DEVICE="e1000";;
         *bsd|linux*|windows) NET_DEVICE="virtio-net";;
-        freedos) sound_card="sb16";;
+        freedos) sound_card="sb16"
+                 NET_DEVICE="pcnet";;
         *solaris) usb_controller="xhci"
                   sound_card="ac97";;
         reactos) NET_DEVICE="e1000"


### PR DESCRIPTION
# Description

FreeDOS does ship the Crynwr packet driver package, which does contain an RTL8139 driver. However, you have to install the package after installing FreeDOS, even if you performed a full install. It also seems to lock up for me when attempting to load it.

The PCNet packet driver on the other hand, is installed with a full FreeDOS install, is open source, and does work, at least for me.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections