### PR TITLE
fix: Better match parrotsec releases

### DIFF
--- a/quickget
+++ b/quickget
@@ -913,7 +913,7 @@ function releases_oraclelinux() {
 
 function releases_parrotsec() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "https://download.parrot.sh/parrot/iso/" |  grep -o -E 'href="[[:digit:]]\.[[:digit:]]+' | sort -nr | head -n 3 | cut -d\" -f 2 )
+    echo $(web_pipe "https://download.parrot.sh/parrot/iso/" | grep -o -E 'href="([[:digit:]]+\.)+[[:digit:]]+/' | sort -nr | head -n 3 | cut -d\" -f 2 | cut -d'/' -f 1)
 }
 
 function editions_parrotsec() {


### PR DESCRIPTION
# Description

Correctly match parrotsec releases including an arbitrary number of digits (i.e. '6.3.2', as opposed to '6.3'). Also handle multiple digits in between period delimiters, to account for possible v10+, and match the forward slash at the end of the reference to ensure incomplete matches aren't presented to the user. 

<!-- Close any related issues. Delete if not relevant -->

- Resolves #1501

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
