### PR TITLE
fix: handle pclinuxos inconsistent naming

### DIFF
--- a/quickget
+++ b/quickget
@@ -924,7 +924,7 @@ function editions_parrotsec() {
 
 function releases_pclinuxos() {
 # shellcheck disable=SC2005
-    echo $(web_pipe "https://ftp.fau.de/pclinuxos/pclinuxos/iso" | grep -m 1 -oP 'pclinuxos64-\K[^\-]+-\K[0-9]+\.[0-9]+' )
+    echo $(web_pipe "https://ftp.fau.de/pclinuxos/pclinuxos/iso" | grep -oP 'pclinuxos64-\K[^\-]+-\K[0-9]+\.[0-9]+' | head -n 1)
 }
 
 function editions_pclinuxos() {

--- a/quickget
+++ b/quickget
@@ -923,7 +923,7 @@ function editions_parrotsec() {
 }
 
 function releases_pclinuxos() {
-# shellcheck disable=SC2005
+# shellcheck disable=SC2046
     echo $(web_pipe "https://ftp.fau.de/pclinuxos/pclinuxos/iso" | grep -oP 'pclinuxos64-\K[^\-]+-\K[0-9]+\.[0-9]+' | head -n 1)
 }
 
@@ -2328,7 +2328,14 @@ function get_parrotsec() {
 }
 
 function get_pclinuxos() {
-    # shellcheck disable=SC2155
+    case ${EDITION} in
+        mate) RELEASE="${RELEASE//./-}";;
+        # in case an edition is added that uses the mate style and sorts higher
+        kde|kde-darkstar) RELEASE="${RELEASE//-/.}";;
+        xfce) RELEASE="${RELEASE//-/.}";;
+        *) ;;
+    esac
+# shellcheck disable=SC2155
     local HASH="$(web_pipe "${URL}/pclinuxos64-${EDITION}-${RELEASE}.md5sum" | head -c 32)"
     local ISO="pclinuxos64-${EDITION}-${RELEASE}.iso"
     local URL="https://ftp.fau.de/pclinuxos/pclinuxos/iso"

--- a/quickget
+++ b/quickget
@@ -2331,7 +2331,7 @@ function get_pclinuxos() {
     # shellcheck disable=SC2155
     local HASH="$(web_pipe "${URL}/pclinuxos64-${EDITION}-${RELEASE}.md5sum" | head -c 32)"
     local ISO="pclinuxos64-${EDITION}-${RELEASE}.iso"
-    local URL="https://ftp.nluug.nl/os/Linux/distr/pclinuxos/pclinuxos/iso"
+    local URL="https://ftp.fau.de/pclinuxos/pclinuxos/iso"
     echo "${URL}/${ISO} ${HASH}"
 }
     


### PR DESCRIPTION
# Description

- Fixes #1628

```
./quickget --check pclinuxos
PASS: pclinuxos-2024.10-kde               https://ftp.fau.de/pclinuxos/pclinuxos/iso/pclinuxos64-kde-2024.10.iso
PASS: pclinuxos-2024.10-kde-darkstar      https://ftp.fau.de/pclinuxos/pclinuxos/iso/pclinuxos64-kde-darkstar-2024.10.iso
PASS: pclinuxos-2024.10-mate              https://ftp.fau.de/pclinuxos/pclinuxos/iso/pclinuxos64-mate-2024-10.iso
PASS: pclinuxos-2024.10-xfce              https://ftp.fau.de/pclinuxos/pclinuxos/iso/pclinuxos64-xfce-2024.10.iso
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

