### PR TITLE
fix(nix): Do not use per-system overlays in Flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,11 +22,11 @@
     schemas = flake-schemas.schemas;
 
     # Define overlays for each supported system
-    overlays = forEachSupportedSystem ({pkgs, system, ...}: {
+    overlays = {
       default = final: prev: {
         quickemu = final.callPackage ./package.nix { };
       };
-    });
+    };
 
     # Define packages for each supported system
     packages = forEachSupportedSystem ({pkgs, system, ...}: rec {


### PR DESCRIPTION
# Description

The definition of the Nixpkgs overlay exported by `flake.nix` is not conforming to the Flake output schema:

https://wiki.nixos.org/wiki/Flakes#Output_schema

The correct schema for overlays is system independent.

This PR removes the `forEachDefaultSystem` call in its definition.

- Fixes #1633

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Packaging (updates the packaging)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
- [ ] I have made corresponding changes to the documentation (*remove if no documentation changes were required*)
