### PR TITLE
fix(quickemu): correctly handle version 10.0.0 of QEMU

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1954,7 +1954,8 @@ if [ "${OS_KERNEL}" == "Darwin" ]; then
 fi
 
 QEMU_VER_LONG=$(${QEMU_IMG} --version | head -n 1 | awk '{print $3}')
-QEMU_VER_SHORT=$(echo "${QEMU_VER_LONG//./}" | cut -c1-2)
+# strip patch version and remove dots. 6.0.0 => 60 / 10.0.0 => 100
+QEMU_VER_SHORT=$(echo "${QEMU_VER_LONG%.*}" | sed 's/\.//g')
 if [ "${QEMU_VER_SHORT}" -lt 60 ]; then
     echo "ERROR! QEMU 6.0.0 or newer is required, detected ${QEMU_VER_LONG}."
     exit 1


### PR DESCRIPTION
# Description

Correctly check the QEMU version number by striping the Patch version (last digit) and removing dots.

<!-- Close any related issues. Delete if not relevant -->

- Fixes #1637

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested my code in common scenarios and confirmed there are no regressions -> not sure if necessary
- [x] I have added comments to my code, particularly in hard-to-understand sections
