### PR TITLE
fix(nixos): support only latest 25.05 

### DIFF
--- a/quickget
+++ b/quickget
@@ -882,7 +882,8 @@ function releases_nixos() {
 }
 
 function editions_nixos() {
-    echo minimal plasma gnome
+    # TODO: Remove "plasma" and "gnome" editions and use only "graphical" after 24.11 support ends (expected in NixOS 25.11)
+    echo minimal plasma6 gnome
 }
 
 function releases_nwg-shell() {
@@ -2241,13 +2242,12 @@ function get_nitrux() {
 
 function get_nixos() {
     local HASH=""
-    # Adapt the plasma edition according to the NixOS release
+    # NixOS "gnome" and "plasma" ISOs are unified as "graphical" since 25.05
+    # https://github.com/NixOS/nixpkgs/pull/355893
     case "${EDITION}" in
-        plasma)
-            if [ "${RELEASE}" == "23.11" ]; then
-                EDITION+="5"
-            else
-                EDITION+="6"
+        plasma6|gnome)
+            if [[ "${RELEASE}" == "25.05" || "${RELEASE}" == "unstable" ]]; then
+                EDITION="graphical"
             fi
             ;;
     esac

--- a/quickget
+++ b/quickget
@@ -876,14 +876,13 @@ function releases_nitrux() {
 }
 
 function releases_nixos() {
-    # Lists unstable plus the two most recent releases
+    # Lists unstable plus the most recent release
     #shellcheck disable=SC2046
-    echo unstable $(web_pipe "https://nix-channels.s3.amazonaws.com/?delimiter=/" | grep -o -E 'nixos-[[:digit:]]+\.[[:digit:]]+' | cut -d- -f2 | sort -nru | head -n +2)
+    echo unstable $(web_pipe "https://nix-channels.s3.amazonaws.com/?delimiter=/" | grep -o -E 'nixos-[[:digit:]]+\.[[:digit:]]+' | cut -d- -f2 | sort -nru | head -n +1)
 }
 
 function editions_nixos() {
-    # TODO: Remove "plasma" and "gnome" editions and use only "graphical" after 24.11 support ends (expected in NixOS 25.11)
-    echo minimal plasma6 gnome
+    echo minimal graphical
 }
 
 function releases_nwg-shell() {
@@ -2242,15 +2241,6 @@ function get_nitrux() {
 
 function get_nixos() {
     local HASH=""
-    # NixOS "gnome" and "plasma" ISOs are unified as "graphical" since 25.05
-    # https://github.com/NixOS/nixpkgs/pull/355893
-    case "${EDITION}" in
-        plasma6|gnome)
-            if [[ "${RELEASE}" == "25.05" || "${RELEASE}" == "unstable" ]]; then
-                EDITION="graphical"
-            fi
-            ;;
-    esac
     local ISO="latest-nixos-${EDITION}-x86_64-linux.iso"
     local URL="https://channels.nixos.org/nixos-${RELEASE}"
     HASH=$(web_pipe "${URL}/${ISO}.sha256" | cut -d' ' -f1)


### PR DESCRIPTION
# Description

NixOS "plasma" and "gnome" ISOs were unified as "graphical" in 25.05.

This PR has two commits:

1. The first keeps 24.11 support, but VM_PATH is not updated.
2. The second drops 24.11 support, since it will reach EOL on 2025-06-30.

<!-- Close any related issues. Delete if not relevant -->

Related links

- Fixes #1672
- https://github.com/NixOS/nixpkgs/pull/355893
- https://nixos.org/blog/announcements/2025/nixos-2505/

After this change

```console
> ./quickget nixos

NixOS
 - Credentials: -
 - Website:     https://nixos.org/
 - Description: Linux distribution based on Nix package manager, tool that takes a unique approach to package management and system configuration.
 - Releases:    unstable 25.05
 - Editions:    minimal graphical

ERROR! You must specify a release.

> ./quickget nixos 25.05 graphical
Downloading NixOS 25.05 graphical
- URL: https://releases.nixos.org/nixos/25.05/nixos-25.05.803751.88331c17ba43/nixos-graphical-25.05.803751.88331c17ba43-x86_64-linux.iso
- PATH: /home/kachick/repos/github.com/quickemu-project/quickemu/nixos-25.05-graphical/latest-nixos-graphical-x86_64-linux.iso
############################################################################################################## 100.0%
Checking nixos-25.05-graphical/latest-nixos-graphical-x86_64-linux.iso with sha256sum... Good!
Making nixos-25.05-graphical.conf
 - Setting nixos-25.05-graphical.conf executable

To start your NixOS virtual machine run:
    quickemu --vm nixos-25.05-graphical.conf
```

## Type of change

<!-- Delete any that are not relevant -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
- [x] I have made corresponding changes to the documentation (*remove if no documentation changes were required*)
