### PR TITLE
fix: version detection fails with qemu v10

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1954,9 +1954,8 @@ if [ "${OS_KERNEL}" == "Darwin" ]; then
 fi
 
 QEMU_VER_LONG=$(${QEMU_IMG} --version | head -n 1 | awk '{print $3}')
-# strip patch version and remove dots. 6.0.0 => 60 / 10.0.0 => 100
-QEMU_VER_SHORT=$(echo "${QEMU_VER_LONG%.*}" | sed 's/\.//g')
-if [ "${QEMU_VER_SHORT}" -lt 60 ]; then
+QEMU_VER_MAJOR=$(echo "${QEMU_VER_LONG}" | cut -d. -f1)
+if [ "${QEMU_VER_MAJOR}" -lt 6 ]; then
     echo "ERROR! QEMU 6.0.0 or newer is required, detected ${QEMU_VER_LONG}."
     exit 1
 fi


### PR DESCRIPTION


# Description

The version check (>= 6.0.0) relied on the major version being just two digits. This change extracts the major version as a number and makes sure it's >= 6.

Please include a summary of the changes along with any relevant motivation and context.

<!-- Close any related issues. Delete if not relevant -->
 
- Fixes #1668 

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
