### PR TITLE
fix: warning about microsoft blocking your IP now specifies it may be a range block if using IPv6

### DIFF
--- a/quickget
+++ b/quickget
@@ -3287,7 +3287,7 @@ function download_windows_workstation() {
     fi
 
     if echo "$iso_download_link_json" | grep -q "Sentinel marked this request as rejected."; then
-        echo " - WARNING! Microsoft blocked the automated download request based on your IP address."
+        echo " - WARNING! Microsoft blocked the automated download request based on your IP address or IP range."
         failed=1
     fi
 


### PR DESCRIPTION
# Description

when i was trying to download windows 11 my download got blocked and it said:
*WARNING! Microsoft blocked the automated download request based on your IP address.* but when i changed my IPv6 address to another one in my prefix delegation it still didn't work suggesting they probably block a /64 at a time

so i changed the wording to say *WARNING! Microsoft blocked the automated download request based on your IP address or IP range.*

btw www.microsoft.com does have a AAAA IPv6 DNS record

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
