### PR TITLE
fix(macos) Add support for gnu hash algo

### DIFF
--- a/quickget
+++ b/quickget
@@ -5,6 +5,9 @@
 # shellcheck disable=SC2317
 export LC_ALL=C
 
+# Detect host OS for checksum tool compatibility
+HOST_OS=$(uname -s)
+
 function cleanup() {
     if [ -n "$(jobs -p)" ]; then
         kill "$(jobs -p)" 2>/dev/null
@@ -1192,6 +1195,17 @@ function check_hash() {
         *) echo "WARNING! Can't guess hash algorithm, not checking ${iso} hash."
             return;;
     esac
+
+    # Use GNU coreutils on macOS/Darwin (prefixed with 'g')
+    if [ "${HOST_OS}" = "Darwin" ]; then
+        case ${hash_algo} in
+            md5sum) hash_algo=gmd5sum;;
+            sha1sum) hash_algo=gsha1sum;;
+            sha256sum) hash_algo=gsha256sum;;
+            sha512sum) hash_algo=gsha512sum;;
+        esac
+    fi
+
     echo -n "Checking ${iso} with ${hash_algo}... "
     if ! echo "${hash} ${iso}" | ${hash_algo} --check --status; then
         echo "ERROR!"


### PR DESCRIPTION
# Description

Adds support for running on a macOS host that uses Darwin sha*sum tools rather than GNU ones. The fix detects when running on macOS and selects the *g* versions of the tools, which can be installed via `brew install sha3sum`, providing `/opt/homebrew/bin/gsha256sum` and its counterparts. 

I have pre-emptively updated the [installation docs](https://github.com/quickemu-project/quickemu/wiki/01-Installation).

<!-- Close any related issues. Delete if not relevant -->

- Fixes #1529

## Type of change

<!-- Delete any that are not relevant -->

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have tested my code in common scenarios and confirmed there are no regressions
- [X] I have added comments to my code, particularly in hard-to-understand sections
- [X] I have made corresponding changes to the documentation (*remove if no documentation changes were required*)
