### PR TITLE
fix: Accept edition as fedora variant

### DIFF
--- a/quickget
+++ b/quickget
@@ -1873,6 +1873,8 @@ function get_fedora() {
 
 
     # shellcheck disable=SC2086
+    # Fedora may promote variants from Spins to Editions, in which case we want to accept either "Spins" or the specific edition name to preserve backwards compatibility
+    # For example, Fedora 42 KDE is now an edition, while previous releases are spins
     JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select((.variant=="'"${VARIANT}"'" or .variant=="'"${EDITION}"'") and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'" and (.link | endswith(".iso")))')
     URL=$(echo "${JSON}" | jq -r '.link' | head -n1)
     HASH=$(echo "${JSON}" | jq -r '.sha256' | head -n1)

--- a/quickget
+++ b/quickget
@@ -1873,7 +1873,7 @@ function get_fedora() {
 
 
     # shellcheck disable=SC2086
-    JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select(.variant=="'${VARIANT}'" and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'" and (.link | endswith(".iso")))')
+    JSON=$(web_pipe "https://getfedora.org/releases.json" | jq '.[] | select((.variant=="'"${VARIANT}"'" or .variant=="'"${EDITION}"'") and .subvariant=="'"${EDITION}"'" and .arch=="x86_64" and .version=="'"${RELEASE}"'" and (.link | endswith(".iso")))')
     URL=$(echo "${JSON}" | jq -r '.link' | head -n1)
     HASH=$(echo "${JSON}" | jq -r '.sha256' | head -n1)
     echo "${URL} ${HASH}"
@@ -2343,7 +2343,7 @@ function get_pclinuxos() {
     local URL="https://ftp.fau.de/pclinuxos/pclinuxos/iso"
     echo "${URL}/${ISO} ${HASH}"
 }
-    
+
 function get_peppermint() {
     local HASH=""
     local ISO=""


### PR DESCRIPTION
# Description

Fedora 42 promoted KDE from a spin to a full edition. This breaks the previous jq expression for Fedora 42 KDE. Modify the expression to accept either "Spins" or the specific edition to preserve backwards compatibility while being able to match the new pattern.

<!-- Close any related issues. Delete if not relevant -->

- Closes #1669 

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
