### PR TITLE
fix(ubuntu): just get the latest iso as the previous has been removed

### DIFF
--- a/quickget
+++ b/quickget
@@ -2639,11 +2639,11 @@ function get_ubuntu-server() {
     esac
 
     if web_check "${URL}/SHA256SUMS"; then
-        DATA=$(web_pipe "${URL}/SHA256SUMS" | grep "${NAME}" | grep amd64 | grep iso)
+        DATA=$(web_pipe "${URL}/SHA256SUMS" | grep "${NAME}" | grep amd64 | grep iso | tail -n 1 )
         ISO=$(cut -d'*' -f2 <<<"${DATA}")
         HASH=$(cut -d' ' -f1 <<<"${DATA}")
     else
-        DATA=$(web_pipe "${URL}/MD5SUMS" | grep "${NAME}" | grep amd64 | grep iso)
+        DATA=$(web_pipe "${URL}/MD5SUMS" | grep "${NAME}" | grep amd64 | grep iso | tail -n 1 )
         ISO=$(cut -d' ' -f3 <<<"${DATA}")
         HASH=$(cut -d' ' -f1 <<<"${DATA}")
     fi
@@ -2683,11 +2683,11 @@ function get_ubuntu() {
         URL="https://cdimage.ubuntu.com/${OS}/releases/${RELEASE}/release"
     fi
     if web_check "${URL}/SHA256SUMS"; then
-        DATA=$(web_pipe "${URL}/SHA256SUMS" | grep 'desktop\|dvd\|install' | grep amd64 | grep iso | grep -v "+mac")
+        DATA=$(web_pipe "${URL}/SHA256SUMS" | grep 'desktop\|dvd\|install' | grep amd64 | grep iso | grep -v "+mac" | tail -n 1 )
         ISO=$(cut -d'*' -f2 <<<"${DATA}" | sed '1q;d')
         HASH=$(cut -d' ' -f1 <<<"${DATA}" | sed '1q;d')
     else
-        DATA=$(web_pipe "${URL}/MD5SUMS" | grep 'desktop\|dvd\|install' | grep amd64 | grep iso | grep -v "+mac")
+        DATA=$(web_pipe "${URL}/MD5SUMS" | grep 'desktop\|dvd\|install' | grep amd64 | grep iso | grep -v "+mac" | tail -n 1 )
         ISO=$(cut -d'*' -f2 <<<"${DATA}")
         HASH=$(cut -d' ' -f1 <<<"${DATA}")
     fi


### PR DESCRIPTION
# Description

They have left references to the  24.04.2 iso in the SHA256SUMS file but removed the iso. We need to filter out the latest until they tidy up.


- Resolves #1714

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions

```
 ./quickget --check ubuntu 
PASS: ubuntu-14.04                        https://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso
PASS: ubuntu-16.04                        https://releases.ubuntu.com/16.04/ubuntu-16.04.7-desktop-amd64.iso
PASS: ubuntu-18.04                        https://releases.ubuntu.com/18.04/ubuntu-18.04.6-desktop-amd64.iso
PASS: ubuntu-20.04                        https://releases.ubuntu.com/20.04/ubuntu-20.04.6-desktop-amd64.iso
PASS: ubuntu-22.04                        https://releases.ubuntu.com/22.04/ubuntu-22.04.5-desktop-amd64.iso
PASS: ubuntu-24.04                        https://releases.ubuntu.com/24.04/ubuntu-24.04.3-desktop-amd64.iso
PASS: ubuntu-25.04                        https://releases.ubuntu.com/25.04/ubuntu-25.04-desktop-amd64.iso
```