### PR TITLE
Update quickget releases_rockylinux() grep

### DIFF
--- a/quickget
+++ b/quickget
@@ -991,7 +991,7 @@ function releases_rebornos() {
 
 function releases_rockylinux() {
     #shellcheck disable=SC2046,SC2005
-    echo $(web_pipe "http://dl.rockylinux.org/vault/rocky/" | grep "^<a href" | grep -v full | grep -v RC | grep -v ISO | cut -d'"' -f2 | tr -d / | sort -ru)
+    echo $(web_pipe "http://dl.rockylinux.org/vault/rocky/" | grep "<a href=\"[0-9]\." | grep -v full | grep -v RC | grep -v ISO | cut -d'"' -f4 | tr -d / | sort -ru)
 }
 
 function editions_rockylinux() {


### PR DESCRIPTION
# Description

Rocky linux version page (https://dl.rockylinux.org/vault/rocky/) has changed, and no releases were listed as a result. This updates the grep to extract the correct version from the new page.

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Packaging (updates the packaging)
- [ ] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
