### PR TITLE
fix(windows): make local account passwords never expire

### DIFF
--- a/quickget
+++ b/quickget
@@ -3030,6 +3030,11 @@ function unattended_windows() {
           <Description>Disable Hibernation</Description>
           <Order>5</Order>
         </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <CommandLine>cmd /c net accounts /maxpwage:unlimited</CommandLine>
+          <Description>Local account passwords never expire</Description>
+          <Order>6</Order>
+        </SynchronousCommand>
       </FirstLogonCommands>
     </component>
   </settings>


### PR DESCRIPTION
# Description

Set unlimited password age for local accounts on Windows.

Encountered this issue on a couple of long-lived Windows 10 22H2 VMs and tested the fix there. The fix should apply also to recent Windows 11 builds but haven't had a chance to test there yet.

Thanks to user @bogiord for providing the fix. I'm just packaging it up in a PR 😃 

- Fixes #1622 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
