### PR TITLE
fix: windows 11 25H2 installation

### DIFF
--- a/quickget
+++ b/quickget
@@ -2942,21 +2942,18 @@ function unattended_windows() {
           <Path>E:\qxldod\w10\amd64</Path>
         </PathAndCredentials>
         <PathAndCredentials wcm:action="add" wcm:keyValue="7">
-          <Path>E:\amd64\w10</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="8">
           <Path>E:\viogpudo\w10\amd64</Path>
         </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="9">
+        <PathAndCredentials wcm:action="add" wcm:keyValue="8">
           <Path>E:\viorng\w10\amd64</Path>
         </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="10">
+        <PathAndCredentials wcm:action="add" wcm:keyValue="9">
           <Path>E:\NetKVM\w10\amd64</Path>
         </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="11">
+        <PathAndCredentials wcm:action="add" wcm:keyValue="10">
           <Path>E:\viofs\w10\amd64</Path>
         </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="12">
+        <PathAndCredentials wcm:action="add" wcm:keyValue="11">
           <Path>E:\Balloon\w10\amd64</Path>
         </PathAndCredentials>
       </DriverPaths>

--- a/quickget
+++ b/quickget
@@ -2942,18 +2942,15 @@ function unattended_windows() {
           <Path>E:\qxldod\w10\amd64</Path>
         </PathAndCredentials>
         <PathAndCredentials wcm:action="add" wcm:keyValue="7">
-          <Path>E:\viogpudo\w10\amd64</Path>
-        </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="8">
           <Path>E:\viorng\w10\amd64</Path>
         </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="9">
+        <PathAndCredentials wcm:action="add" wcm:keyValue="8">
           <Path>E:\NetKVM\w10\amd64</Path>
         </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="10">
+        <PathAndCredentials wcm:action="add" wcm:keyValue="9">
           <Path>E:\viofs\w10\amd64</Path>
         </PathAndCredentials>
-        <PathAndCredentials wcm:action="add" wcm:keyValue="11">
+        <PathAndCredentials wcm:action="add" wcm:keyValue="10">
           <Path>E:\Balloon\w10\amd64</Path>
         </PathAndCredentials>
       </DriverPaths>
@@ -3026,6 +3023,11 @@ function unattended_windows() {
           <CommandLine>Cmd /c POWERCFG -H OFF</CommandLine>
           <Description>Disable Hibernation</Description>
           <Order>5</Order>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add">
+          <CommandLine>pnputil /add-driver E:\viogpudo\w10\amd64\viogpudo.inf /install</CommandLine>
+          <Description>Install viogpudo driver</Description>
+          <Order>6</Order>
         </SynchronousCommand>
       </FirstLogonCommands>
     </component>


### PR DESCRIPTION
# Description

This PR fixes some issues installing recent Windows 11 builds. Tested on both Windows 10 22H2 and Windows 11 25H2.

Thanks again to @bogiord who did the real detective work. I'm just packaging up their fixes in this PR.

- Fixes #1475 
- Fixes #1620

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
