### PR TITLE
Update Debian & Archlinux for "sensible" 2026 defaults

### DIFF
--- a/quickget
+++ b/quickget
@@ -1673,6 +1673,7 @@ EOF
                     echo "tpm=\"on\"" >> "${CONF_FILE}"
                 fi
                 echo "secureboot=\"on\"" >> "${CONF_FILE}"
+                ;;
             deepin)
                 echo "disk_size=\"64G\"" >> "${CONF_FILE}"
                 echo "ram=\"4G\"" >> "${CONF_FILE}"

--- a/quickget
+++ b/quickget
@@ -1652,6 +1652,10 @@ EOF
         case ${OS} in
             alma|centos-stream|endless|garuda|gentoo|kali|nixos|oraclelinux|popos|rockylinux)
                 echo "disk_size=\"32G\"" >> "${CONF_FILE}";;
+            archlinux)
+                echo "secureboot=\"on\"" >> "${CONF_FILE}"
+                echo "tpm=\"on\"" >> "${CONF_FILE}"
+                echo "disk_size=\"32G\"" >> "${CONF_FILE}";;
             openindiana)
                 echo "boot=\"legacy\"" >> "${CONF_FILE}"
                 echo "disk_size=\"32G\"" >> "${CONF_FILE}";;
@@ -1661,6 +1665,14 @@ EOF
                 echo "disk_size=\"64G\"" >> "${CONF_FILE}";;
             dragonflybsd|haiku|openbsd|netbsd|slackware|slax|tinycore)
                 echo "boot=\"legacy\"" >> "${CONF_FILE}";;
+            debian)
+                if [[ "${RELEASE}" == *"12"* ]]; then
+                    echo "tpm=\"on\"" >> "${CONF_FILE}"
+                fi
+                if [[ "${RELEASE}" == *"13"* ]]; then
+                    echo "tpm=\"on\"" >> "${CONF_FILE}"
+                fi
+                echo "secureboot=\"on\"" >> "${CONF_FILE}"
             deepin)
                 echo "disk_size=\"64G\"" >> "${CONF_FILE}"
                 echo "ram=\"4G\"" >> "${CONF_FILE}"


### PR DESCRIPTION
Both Debian 12 and 13 can boot with both TPM and Secureboot enabled, as can Archlinux 2026.01 and beyond__(last tested with 2026.06.01)__, update the configurations to enable these.

# Description

When booting with a host with secureboot or TPM, Ubuntu Server and Debian and Archlinux will occasionally boot directly to PXE and break. Rather than manually editing configurations before first boot, I fixed __quickget__ to automatically apply these defaults instead.

There should probably be a current check for all OSes, I will be checking Ubuntu Desktop's and Tails in the next few weeks, as I have time.

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Packaging (updates the packaging)
- [ ] Documentation (updates the documentation)

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections __(none are required)__