### PR TITLE
fix(quickget): support new kde neon directory structure with editions

### DIFF
--- a/quickget
+++ b/quickget
@@ -685,6 +685,10 @@ function editions_chimeralinux() {
     echo base gnome
 }
 
+function editions_kdeneon() {
+    echo bigscreen desktop dev ko mobile
+}
+
 function releases_crunchbang++() {
     #shellcheck disable=SC2046,SC2005
     echo $(web_pipe "https://api.github.com/repos/CBPP/cbpp/releases" | grep 'download_url' | cut -d'-' -f2 | grep '^[0-9]' | sort -gru)
@@ -2223,9 +2227,9 @@ function get_kali() {
 function get_kdeneon() {
     local HASH=""
     local ISO=""
-    local URL="https://files.kde.org/neon/images/${RELEASE}/current"
-    ISO=$(web_pipe "${URL}/neon-${RELEASE}-current.sha256sum" | cut -d' ' -f3-)
-    HASH=$(web_pipe "${URL}/neon-${RELEASE}-current.sha256sum" | cut -d' ' -f1)
+    local URL="https://files.kde.org/neon/images/${EDITION}/${RELEASE}/current"
+    ISO=$(web_pipe "${URL}/neon-${RELEASE}-${EDITION}-current.sha256sum" | cut -d' ' -f3-)
+    HASH=$(web_pipe "${URL}/neon-${RELEASE}-${EDITION}-current.sha256sum" | cut -d' ' -f1)
     echo "${URL}/${ISO} ${HASH}"
 }
 

--- a/quickget
+++ b/quickget
@@ -2228,8 +2228,10 @@ function get_kdeneon() {
     local HASH=""
     local ISO=""
     local URL="https://files.kde.org/neon/images/${EDITION}/${RELEASE}/current"
-    ISO=$(web_pipe "${URL}/neon-${RELEASE}-${EDITION}-current.sha256sum" | cut -d' ' -f3-)
-    HASH=$(web_pipe "${URL}/neon-${RELEASE}-${EDITION}-current.sha256sum" | cut -d' ' -f1)
+
+    local CHKSUM_FILE_CONTENT=$(web_pipe "${URL}/neon-${RELEASE}-${EDITION}-current.sha256sum")
+    IFS=' ' read -r HASH ISO <<< "$CHKSUM_FILE_CONTENT"
+
     echo "${URL}/${ISO} ${HASH}"
 }
 


### PR DESCRIPTION
# Description

KDE Neon download link was broken since they now have a different directory structure.

I considered their new division based on devices like an edition and added support for editions by adding the `editions_kdeneon` function and updating the `get_kdeneon` function to build the correct iso and hash urls according to the new directory structure and file names.

`./quickemu --url kdeneon`

```console
kdeneon-user-bigscreen:              https://files.kde.org/neon/images/bigscreen/user/current/neon-user-bigscreen-20260621-0633.iso
kdeneon-user-desktop:                https://files.kde.org/neon/images/desktop/user/current/neon-user-desktop-20260618-0758.iso
kdeneon-user-dev:                    https://files.kde.org/neon/images/dev/user/current/PUBLIC
kdeneon-user-ko:                     https://files.kde.org/neon/images/ko/user/current/neon-user-ko-20260619-1132.iso
kdeneon-user-mobile:                 https://files.kde.org/neon/images/mobile/user/current/neon-user-mobile-20260621-0517.iso
kdeneon-testing-bigscreen:           https://files.kde.org/neon/images/bigscreen/testing/current/neon-testing-bigscreen-20260621-1913.iso
kdeneon-testing-desktop:             https://files.kde.org/neon/images/desktop/testing/current/neon-testing-desktop-20260617-1014.iso
kdeneon-testing-dev:                 https://files.kde.org/neon/images/dev/testing/current/PUBLIC
kdeneon-testing-ko:                  https://files.kde.org/neon/images/ko/testing/current/neon-testing-ko-20260619-1142.iso
kdeneon-testing-mobile:              https://files.kde.org/neon/images/mobile/testing/current/neon-testing-mobile-20260621-1549.iso
kdeneon-unstable-bigscreen:          https://files.kde.org/neon/images/bigscreen/unstable/current/neon-unstable-bigscreen-20260621-1325.iso
kdeneon-unstable-desktop:            https://files.kde.org/neon/images/desktop/unstable/current/neon-unstable-desktop-20260621-0642.iso
kdeneon-unstable-dev:                https://files.kde.org/neon/images/dev/unstable/current/neon-unstable-dev-20260622-1147.iso
kdeneon-unstable-ko:                 https://files.kde.org/neon/images/ko/unstable/current/neon-unstable-ko-20260619-0359.iso
kdeneon-unstable-mobile:             https://files.kde.org/neon/images/mobile/unstable/current/neon-unstable-mobile-20260621-1256.iso
```

`./quickget --check kdeneon`

```console
PASS: kdeneon-user-bigscreen              https://files.kde.org/neon/images/bigscreen/user/current/neon-user-bigscreen-20260621-0633.iso
PASS: kdeneon-user-desktop                https://files.kde.org/neon/images/desktop/user/current/neon-user-desktop-20260618-0758.iso
FAIL: kdeneon-user-dev                    https://files.kde.org/neon/images/dev/user/current/PUBLIC
PASS: kdeneon-user-ko                     https://files.kde.org/neon/images/ko/user/current/neon-user-ko-20260619-1132.iso
PASS: kdeneon-user-mobile                 https://files.kde.org/neon/images/mobile/user/current/neon-user-mobile-20260621-0517.iso
PASS: kdeneon-testing-bigscreen           https://files.kde.org/neon/images/bigscreen/testing/current/neon-testing-bigscreen-20260621-1913.iso
PASS: kdeneon-testing-desktop             https://files.kde.org/neon/images/desktop/testing/current/neon-testing-desktop-20260617-1014.iso
FAIL: kdeneon-testing-dev                 https://files.kde.org/neon/images/dev/testing/current/PUBLIC
PASS: kdeneon-testing-ko                  https://files.kde.org/neon/images/ko/testing/current/neon-testing-ko-20260619-1142.iso
PASS: kdeneon-testing-mobile              https://files.kde.org/neon/images/mobile/testing/current/neon-testing-mobile-20260621-1549.iso
PASS: kdeneon-unstable-bigscreen          https://files.kde.org/neon/images/bigscreen/unstable/current/neon-unstable-bigscreen-20260621-1325.iso
PASS: kdeneon-unstable-desktop            https://files.kde.org/neon/images/desktop/unstable/current/neon-unstable-desktop-20260621-0642.iso
PASS: kdeneon-unstable-dev                https://files.kde.org/neon/images/dev/unstable/current/neon-unstable-dev-20260622-1147.iso
PASS: kdeneon-unstable-ko                 https://files.kde.org/neon/images/ko/unstable/current/neon-unstable-ko-20260619-0359.iso
PASS: kdeneon-unstable-mobile             https://files.kde.org/neon/images/mobile/unstable/current/neon-unstable-mobile-20260621-1256.iso
```

What would be a clean way to fix those two failing ones (kdeneon-user-dev, kdeneon-testing-dev)?

`./quickget --check-all-arch`

```console
PASS: kdeneon-user-bigscreen              https://files.kde.org/neon/images/bigscreen/user/current/neon-user-bigscreen-20260621-0633.iso
PASS: kdeneon-user-desktop                https://files.kde.org/neon/images/desktop/user/current/neon-user-desktop-20260618-0758.iso
FAIL: kdeneon-user-dev                    https://files.kde.org/neon/images/dev/user/current/PUBLIC
PASS: kdeneon-user-ko                     https://files.kde.org/neon/images/ko/user/current/neon-user-ko-20260619-1132.iso
PASS: kdeneon-user-mobile                 https://files.kde.org/neon/images/mobile/user/current/neon-user-mobile-20260621-0517.iso
PASS: kdeneon-testing-bigscreen           https://files.kde.org/neon/images/bigscreen/testing/current/neon-testing-bigscreen-20260621-1913.iso
PASS: kdeneon-testing-desktop             https://files.kde.org/neon/images/desktop/testing/current/neon-testing-desktop-20260617-1014.iso
FAIL: kdeneon-testing-dev                 https://files.kde.org/neon/images/dev/testing/current/PUBLIC
PASS: kdeneon-testing-ko                  https://files.kde.org/neon/images/ko/testing/current/neon-testing-ko-20260619-1142.iso
PASS: kdeneon-testing-mobile              https://files.kde.org/neon/images/mobile/testing/current/neon-testing-mobile-20260621-1549.iso
PASS: kdeneon-unstable-bigscreen          https://files.kde.org/neon/images/bigscreen/unstable/current/neon-unstable-bigscreen-20260621-1325.iso
PASS: kdeneon-unstable-desktop            https://files.kde.org/neon/images/desktop/unstable/current/neon-unstable-desktop-20260621-0642.iso
PASS: kdeneon-unstable-dev                https://files.kde.org/neon/images/dev/unstable/current/neon-unstable-dev-20260622-1147.iso
PASS: kdeneon-unstable-ko                 https://files.kde.org/neon/images/ko/unstable/current/neon-unstable-ko-20260619-0359.iso
PASS: kdeneon-unstable-mobile             https://files.kde.org/neon/images/mobile/unstable/current/neon-unstable-mobile-20260621-1256.iso
SKIP: kdeneon-user-bigscreen              (not available for arm64)
SKIP: kdeneon-user-desktop                (not available for arm64)
SKIP: kdeneon-user-dev                    (not available for arm64)
SKIP: kdeneon-user-ko                     (not available for arm64)
SKIP: kdeneon-user-mobile                 (not available for arm64)
SKIP: kdeneon-testing-bigscreen           (not available for arm64)
SKIP: kdeneon-testing-desktop             (not available for arm64)
SKIP: kdeneon-testing-dev                 (not available for arm64)
SKIP: kdeneon-testing-ko                  (not available for arm64)
SKIP: kdeneon-testing-mobile              (not available for arm64)
SKIP: kdeneon-unstable-bigscreen          (not available for arm64)
SKIP: kdeneon-unstable-desktop            (not available for arm64)
SKIP: kdeneon-unstable-dev                (not available for arm64)
SKIP: kdeneon-unstable-ko                 (not available for arm64)
SKIP: kdeneon-unstable-mobile             (not available for arm64)
```
I tested getting the image and running a vm (kdeneon unstable desktop) and it boots fine.

For the changes i looked at how you handled similar stuff and I tried to make the change properly, if something is off tell me and I'll fix it!

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/quickemu-project/quickemu/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

