### PR TITLE
fix: Implement fallback for 'update-initramfs' in ignore_msrs_always function

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -35,7 +35,7 @@ function ignore_msrs_always() {
 		            ;;
 	            3)
 		            echo "ERROR! User does not have update-initramfs or mkinitcpio installed, please find out respective utility to update/regenrate intiramfs."
-		            echo "Run respective command for 'sudo update-initramfs -k all -u'(debian) or 'sudo mkinitcpio -p linux'(arch)"
+		            echo "Run respective command for 'sudo update-initramfs -k all -u'(debian) or 'sudo mkinitcpio -P'(arch)"
                 exit 1
                 ;;
             esac

--- a/quickemu
+++ b/quickemu
@@ -13,23 +13,14 @@ function ignore_msrs_always() {
         if ! grep -lq 'ignore_msrs=Y' /etc/modprobe.d/kvm-quickemu.conf >/dev/null 2>&1; then
             echo "options kvm ignore_msrs=Y" | sudo tee /etc/modprobe.d/kvm-quickemu.conf
 
-            # Code to verify if user has update-initramfs(debian exclusive? absent on arch ?) or mkinitcpio(present on arch) utility present
- 
-            flag=0;
-            man update-initramfs &>2
-            a="$(echo $?)"
-            # echo $a
-            if [[  $a -eq 0 ]]; then
-	            flag=1;
+            # Rebuild initramfs so the new kvm option takes effect
+            flag=0
+            if command -v update-initramfs &>/dev/null; then
+                flag=1
+            elif command -v mkinitcpio &>/dev/null; then
+                flag=2
             else
-	            man mkinitcpio &>2
-	            a="$(echo $?)"
-	            # echo $a
-	            if [[ "$a" -eq 0 ]]; then
-		            flag=2;
-	            else
-		            flag=3;
-	            fi
+                flag=3
             fi
 
             # echo $flag;

--- a/quickemu
+++ b/quickemu
@@ -12,7 +12,44 @@ function ignore_msrs_always() {
         # Skip if ignore_msrs is already enabled, assumes initramfs has been rebuilt
         if ! grep -lq 'ignore_msrs=Y' /etc/modprobe.d/kvm-quickemu.conf >/dev/null 2>&1; then
             echo "options kvm ignore_msrs=Y" | sudo tee /etc/modprobe.d/kvm-quickemu.conf
-            sudo update-initramfs -k all -u
+
+            # Code to verify if user has update-initramfs(debian exclusive? absent on arch ?) or mkinitcpio(present on arch) utility present
+ 
+            flag=0;
+            man update-initramfs &>2
+            a="$(echo $?)"
+            # echo $a
+            if [[  $a -eq 0 ]]; then
+	            flag=1;
+            else
+	            man mkinitcpio &>2
+	            a="$(echo $?)"
+	            # echo $a
+	            if [[ "$a" -eq 0 ]]; then
+		            flag=2;
+	            else
+		            flag=3;
+	            fi
+            fi
+
+            # echo $flag;
+
+            case "$flag" in
+	            1)
+		            sudo update-initramfs -k all -u
+		            ;;
+	            2)
+		            sudo mkinitcpio -p linux
+                echo "Ran mkinitcpio -p linux"
+		            ;;
+	            3)
+		            echo "ERROR! User does not have update-initramfs or mkinitcpio installed, please find out respective utility to update/regenrate intiramfs."
+		            echo "Run respective command for 'sudo update-initramfs -k all -u'(debian) or 'sudo mkinitcpio -p linux'(arch)"
+                exit 1
+                ;;
+            esac
+
+
         fi
     else
         echo "ERROR! /etc/modprobe.d was not found, I don't know how to configure this system."

--- a/quickemu
+++ b/quickemu
@@ -30,8 +30,8 @@ function ignore_msrs_always() {
 		            sudo update-initramfs -k all -u
 		            ;;
 	            2)
-		            sudo mkinitcpio -p linux
-                echo "Ran mkinitcpio -p linux"
+		            sudo mkinitcpio -P
+                echo "Ran mkinitcpio -P"
 		            ;;
 	            3)
 		            echo "ERROR! User does not have update-initramfs or mkinitcpio installed, please find out respective utility to update/regenrate intiramfs."

--- a/quickemu
+++ b/quickemu
@@ -31,11 +31,10 @@ function ignore_msrs_always() {
 		            ;;
 	            2)
 		            sudo mkinitcpio -P
-                echo "Ran mkinitcpio -P"
-		            ;;
+                ;;
 	            3)
 		            echo "ERROR! User does not have update-initramfs or mkinitcpio installed, please find out respective utility to update/regenrate intiramfs."
-		            echo "Run respective command for 'sudo update-initramfs -k all -u'(debian) or 'sudo mkinitcpio -P'(arch)"
+		            echo "Run respective command for rebuilding initramfs: 'sudo update-initramfs -k all -u'(debian) or 'sudo mkinitcpio -P'(arch)"
                 exit 1
                 ;;
             esac


### PR DESCRIPTION

# Description

Implements fallback in the absence of 'update-initramfs' utility(the command fails on arch). The counterpart on arch would be 'mkinitcpio'  (possibly mkinitcpio -p linux ).





## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/quickemu-project/quickemu/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

