### PR TITLE
fix: add host address to spice command in output

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1522,7 +1522,7 @@ function configure_ports() {
             SPICE+=",port=${spice_port},addr=${SPICE_ADDR}"
             echo "spice,${spice_port}" >> "${VMDIR}/${VMNAME}.ports"
             echo "${spice_port}" > "${VMDIR}/${VMNAME}.spice"
-            echo -n " - SPICE:    On host:  spicy --title \"${VMNAME}\" --host ${SPICE_ADDR} --port ${spice_port}"
+            echo -n " - SPICE:    On host:  spicy --title \"${VMNAME}\"${SPICE_ADDR:+ --host ${SPICE_ADDR}} --port ${spice_port}"
             if [ "${guest_os}" != "macos" ] && [ -n "${PUBLIC}" ]; then
                 echo -n " --spice-shared-dir ${PUBLIC}"
             fi

--- a/quickemu
+++ b/quickemu
@@ -1522,7 +1522,7 @@ function configure_ports() {
             SPICE+=",port=${spice_port},addr=${SPICE_ADDR}"
             echo "spice,${spice_port}" >> "${VMDIR}/${VMNAME}.ports"
             echo "${spice_port}" > "${VMDIR}/${VMNAME}.spice"
-            echo -n " - SPICE:    On host:  spicy --title \"${VMNAME}\" --port ${spice_port}"
+            echo -n " - SPICE:    On host:  spicy --title \"${VMNAME}\" --host ${SPICE_ADDR} --port ${spice_port}"
             if [ "${guest_os}" != "macos" ] && [ -n "${PUBLIC}" ]; then
                 echo -n " --spice-shared-dir ${PUBLIC}"
             fi


### PR DESCRIPTION
# Description

If one spins up a new VM while providing a specific IP address (e.g. 127.0.0.5) for the `--access` flag in conjunction with `--display none`, the SPICE command output in the terminal fails to connect from the host to the VM. It is missing the `--host` argument plus the correct IP address stored in the variable `SPICE_ADDR`. Providing this directly in the output solves this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/quickemu-project/quickemu/pull/1933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

