### PR TITLE
feat(quickemu): provide IP for listening SSH port

### DIFF
--- a/docs/quickemu.1
+++ b/docs/quickemu.1
@@ -76,7 +76,7 @@ Set VM screen width; requires \(aq\-\-height\(aq
 Set VM screen height; requires \(aq\-\-width\(aq
 .TP
 \f[B]\-\-ssh\-access\f[R]
-Enable remote spice access support.
+Enable remote ssh access support.
 \(aqlocal\(aq (default), \(aqremote\(aq, \(aqclientipaddress\(aq
 .TP
 \f[B]\-\-ssh\-port <port>\f[R]

--- a/docs/quickemu.1
+++ b/docs/quickemu.1
@@ -75,6 +75,10 @@ Set VM screen width; requires \(aq\-\-height\(aq
 \f[B]\-\-height <height>\f[R]
 Set VM screen height; requires \(aq\-\-width\(aq
 .TP
+\f[B]\-\-ssh\-access\f[R]
+Enable remote spice access support.
+\(aqlocal\(aq (default), \(aqremote\(aq, \(aqclientipaddress\(aq
+.TP
 \f[B]\-\-ssh\-port <port>\f[R]
 Set SSH port manually
 .TP

--- a/docs/quickemu.1.md
+++ b/docs/quickemu.1.md
@@ -84,6 +84,10 @@ You can also pass optional parameters
 **--height \<height\>**
 :   Set VM screen height; requires '--width'
 
+**--ssh-access**
+:   Enable remote ssh access support. 'local' (default), 'remote',
+    'clientipaddress'
+
 **--ssh-port \<port\>**
 :   Set SSH port manually
 

--- a/quickemu
+++ b/quickemu
@@ -1430,10 +1430,21 @@ function configure_ports() {
         ssh_port=$(get_port 22220 9)
     fi
 
+    if [ -z "${SSH_ACCESS}" ] || [ "${SSH_ACCESS}" == "local" ]; then
+        SSH_ADDR="127.0.0.1"
+        ssh_host="localhost"
+    elif [ "${SSH_ACCESS}" == "remote" ]; then
+        SSH_ADDR=""
+        ssh_host="localhost"
+    else
+        SSH_ADDR="${SSH_ACCESS}"
+        ssh_host="${SSH_ACCESS}"
+    fi
+
     if [ -n "${ssh_port}" ]; then
         echo "ssh,${ssh_port}" >> "${VMDIR}/${VMNAME}.ports"
-        NET="${NET},hostfwd=tcp::${ssh_port}-:22"
-        echo " - ssh:      On host:  ssh user@localhost -p ${ssh_port}"
+        NET="${NET},hostfwd=tcp:${SSH_ADDR}:${ssh_port}-:22"
+        echo " - ssh:      On host:  ssh user@${ssh_host} -p ${ssh_port}"
     else
         echo " - ssh:      All ssh ports have been exhausted."
     fi
@@ -2310,6 +2321,7 @@ function usage() {
     echo "  --viewer <viewer>                 : Choose an alternative viewer. @Options: 'spicy' (default), 'remote-viewer', 'none'"
     echo "  --width <width>                   : Set VM screen width; requires '--height'"
     echo "  --height <height>                 : Set VM screen height; requires '--width'"
+    echo "  --ssh-access                      : Enable remote ssh access support. 'local' (default), 'remote', 'clientipaddress'"
     echo "  --ssh-port <port>                 : Set SSH port manually"
     echo "  --spice-port <port>               : Set SPICE port manually"
     echo "  --public-dir <path>               : Expose share directory. @Options: '' (default: xdg-user-dir PUBLICSHARE), '<directory>', 'none'"
@@ -2584,6 +2596,7 @@ SNAPSHOT_ACTION=""
 SNAPSHOT_TAG=""
 SOCKET_MONITOR=""
 SOCKET_SERIAL=""
+SSH_ACCESS=""
 STATUS_QUO=""
 USB_PASSTHROUGH=""
 VM=""
@@ -2715,6 +2728,10 @@ else
             -height|--height)
                 SHORTCUT_OPTIONS+="--height ${2} "
                 height="${2}"
+                shift 2;;
+            -ssh-access|--ssh-access)
+                SHORTCUT_OPTIONS+="--ssh-access ${2} "
+                SSH_ACCESS="${2}"
                 shift 2;;
             -ssh-port|--ssh-port)
                 SHORTCUT_OPTIONS+="--ssh-port ${2} "


### PR DESCRIPTION
# Description

The changes provided introduce a new optional argument `--ssh-access` similar to `--access` only for SSH instead of SPICE. It takes the same values.

Instead of binding the SSH listening port to 0.0.0.0 by default listening on all network interfaces, which potentially allows anyone on the local network to access it, I propose defaulting it to localhost, similar to the `--access` behavior.

This change may break existing setups that rely on accessing the SSH port from another machine on the same LAN. However, I believe defaulting to localhost provides a clearer and safer default for most users, while those who need remote access can still explicitly provide the `remote` option or a specific IP.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my code

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/quickemu-project/quickemu/pull/1934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

