### PR TITLE
fix(quickemu): defer guest QEMU lookup

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -2599,14 +2599,10 @@ readonly LAUNCHER=$(basename "${0}")
 readonly DISK_MIN_SIZE=$((197632 * 8))
 readonly VERSION="4.9.9"
 
-# Default architecture is x86_64, can be overridden by config file (arch="aarch64")
-arch="${arch:-x86_64}"
-ARCH_VM="${arch}"
 ARCH_HOST=$(uname -m)
-QEMU=$(command -v "qemu-system-${ARCH_VM}")
 QEMU_IMG=$(command -v qemu-img)
-if [ ! -x "${QEMU}" ] || [ ! -x "${QEMU_IMG}" ]; then
-    echo "ERROR! QEMU not found. Please make sure 'qemu-system-${ARCH_VM}' and 'qemu-img' are installed."
+if [ ! -x "${QEMU_IMG}" ]; then
+    echo "ERROR! qemu-img not found. Please make sure qemu-img is installed."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- defer selecting the guest QEMU binary until the VM configuration selects its architecture
- retain the early `qemu-img` check required for version detection

## Verification

- `bash -n quickemu`
- isolated mock: an `arch="aarch64"` config reaches `--kill` with only `qemu-system-aarch64` and `qemu-img`; an x86 config still fails after config loading when its binary is missing


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/quickemu-project/quickemu/pull/1935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

