### PR TITLE
fix(quickemu): select the first complete firmware pair

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1000,16 +1000,16 @@ function configure_bios() {
                         );;
                 esac
             fi
-            # Attempt each EFI_CODE file one by one, selecting the corresponding code and vars
-            # when an existing file is found.
+            # Select the first complete firmware pair, preserving the order of preference above.
             _IFS=$IFS
             IFS=","
             for f in "${ovmfs[@]}"; do
                 # shellcheck disable=SC2086
                 set -- ${f};
-                if [ -e "${1}" ]; then
+                if [ -e "${1}" ] && [ -e "${2}" ]; then
                     EFI_CODE="${1}"
                     EFI_EXTRA_VARS="${2}"
+                    break
                 fi
             done
             IFS=$_IFS


### PR DESCRIPTION
# Description

The firmware search currently checks only the CODE file and keeps scanning, so a later incomplete or lower-priority candidate can overwrite a valid preferred pair.

Require both CODE and VARS to exist, then stop at the first complete pair. This preserves the declared order, including the Microsoft-key Nix pair added by #1879.

Related: #543 previously proposed the same complete-pair validation and first-match behavior.

## Testing

- `bash -n quickemu`
- `shellcheck quickemu`
- `nix build path:.#quickemu`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/quickemu-project/quickemu/pull/1938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

