### PR TITLE
fix: fix `chown` syntax (`root:user` to `user:root`)

### DIFF
--- a/docs/quickemu_conf.5
+++ b/docs/quickemu_conf.5
@@ -314,7 +314,7 @@ like this:
 .EX
  \- USB:      Host pass\-through requested:
               \- Sennheiser Communications EPOS GTW 270 on bus 001 device 005 needs permission changes:
-                sudo chown \-v root:user /dev/bus/usb/001/005
+                sudo chown \-v user:root /dev/bus/usb/001/005
                 ERROR! USB permission changes are required 👆
 .EE
 .SS TPM

--- a/docs/quickemu_conf.5.md
+++ b/docs/quickemu_conf.5.md
@@ -310,7 +310,7 @@ like this:
 
      - USB:      Host pass-through requested:
                   - Sennheiser Communications EPOS GTW 270 on bus 001 device 005 needs permission changes:
-                    sudo chown -v root:user /dev/bus/usb/001/005
+                    sudo chown -v user:root /dev/bus/usb/001/005
                     ERROR! USB permission changes are required 👆
 
 ### TPM

--- a/quickemu
+++ b/quickemu
@@ -284,7 +284,7 @@ function configure_usb() {
                 echo "             o ${USB_NAME} on bus ${USB_BUS} device ${USB_DEV} is accessible."
             else
                 echo "             x ${USB_NAME} on bus ${USB_BUS} device ${USB_DEV} needs permission changes:"
-                echo "               sudo chown -v root:${USER} /dev/bus/usb/${USB_BUS}/${USB_DEV}"
+                echo "               sudo chown -v ${USER}:root /dev/bus/usb/${USB_BUS}/${USB_DEV}"
                 USB_NOT_READY=1
             fi
             USB_PASSTHROUGH="${USB_PASSTHROUGH} -device usb-host,bus=hostpass.0,vendorid=0x${VENDOR_ID},productid=0x${PRODUCT_ID}"


### PR DESCRIPTION
# Description

In USB Passthrough error, the command should be `chown $USER:root`, not `chown root:$USER`

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Packaging (updates the packaging)
- [x] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
- [x] I have made corresponding changes to the documentation (*remove if no documentation changes were required*)
